### PR TITLE
Replace Arbgas w gas

### DIFF
--- a/arbitrum-docs/intro/glossary.mdx
+++ b/arbitrum-docs/intro/glossary.mdx
@@ -64,7 +64,7 @@
 
 - **Retryable Ticket**: An L1 to L2 cross chain message initiated by an L1 transaction sent to an Arbitrum chain for execution (e.g., a token deposit).
 
-- **Retryable Autoredeem**: The "automatic" execution of a retryable ticket on Arbitrum (using provided ArbGas).
+- **Retryable Autoredeem**: The "automatic" execution of a retryable ticket on Arbitrum (using provided gas).
 
 ## Token Bridging
 


### PR DESCRIPTION
Since we no longer have a notion of arbgas, it'd be less confusing for users/devs if we replace it with gas.