### PR TITLE
Updating Local Dev Node information

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,24 @@ Arbitrum Docs, built with docusaurus; docs are live at https://developer.arbitru
 
 [Arbitrum SDK](https://github.com/OffchainLabs/arbitrum-sdk) auto-genned docs are included as submodule.
 
-## Local Build
-
-```shell
-cd ./website
-```
-
 ### Initial set up
 
+```shell
+git clone git@github.com:OffchainLabs/arbitrum-docs.git
+
+cd arbitrum-docs/
+
+git submodule update --init --recursive
+
+cd website/
+```
+
+Install node dependencies
 ```
 yarn
 ```
 
+You will only need to generate docs once:
 ```
 yarn generate_sdk_docs
 ```
@@ -29,7 +35,7 @@ yarn start_nitro_docs
 ```
 
 
-Generate sdk docs and live build:
+(Re)generate sdk docs and live build:
 ```
 yarn start
 ```

--- a/arbitrum-docs/node-running/local-dev-node.mdx
+++ b/arbitrum-docs/node-running/local-dev-node.mdx
@@ -24,9 +24,13 @@
 
   (Note that running with the --init flag will clear all chain data and redeploy!)
 
-  The L1 Geth devnet will be running at http://localhost:8545 and the L2 Nitro devent at http://localhost:7545.
+  The L1 Geth devnet will be running at http://localhost:8545 and the L2 Nitro devnet at http://localhost:8547.
 
-  Address `0x683642c22feDE752415D4793832Ab75EFdF6223c` with private key `0xe887f7d17d07cc7b8004053fb8826f6657084e88904bb61590e498ca04704cf2` will be prefunded with test Ether.
+  The following accounts will be prefunded with Ether:
+
+    * *L2 Nitro devnet*: `0x683642c22feDE752415D4793832Ab75EFdF6223c` with private key `0xe887f7d17d07cc7b8004053fb8826f6657084e88904bb61590e498ca04704cf2`
+
+    * *both networks*: `0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E` with private key `0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659`
 
 ### Get Core Contracts
 
@@ -39,5 +43,47 @@ docker exec nitro-sequencer-1  cat /config/deployment.json
 For the outbox address, run (replace "PUT_THE_ROLLUP_ADDRESS_HERE" with rollup address):
 
 ```bash
-`curl '[http://localhost:8545/](http://localhost:8545/)' -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":0,"method":"eth_call","params":[{"to":"PUT_THE_ROLLUP_ADDRESS_HERE","data":"0xce11e6ab"},"latest"]}'`
+`curl 'http://localhost:8545/' -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":0,"method":"eth_call","params":[{"to":"PUT_THE_ROLLUP_ADDRESS_HERE","data":"0xce11e6ab"},"latest"]}'`
+```
+
+---
+
+Some default addresses can be found here:
+
+```
+"l2Network": {
+    "chainID": 412346,
+    "confirmPeriodBlocks": 20,
+    "ethBridge": {
+      "bridge": "0x2b360a9881f21c3d7aa0ea6ca0de2a3341d4ef3c",
+      "inbox": "0xff4a24b22f94979e9ba5f3eb35838aa814bad6f1",
+      "outbox": "0x49940929c7cA9b50Ff57a01d3a92817A414E6B9B",
+      "rollup": "0x65a59d67da8e710ef9a01eca37f83f84aedec416",
+      "sequencerInbox": "0xe7362d0787b51d8c72d504803e5b1d6dcda89540"
+    },
+    "explorerUrl": "",
+    "isArbitrum": true,
+    "isCustom": true,
+    "name": "ArbLocal",
+    "partnerChainID": 1337,
+    "retryableLifetimeSeconds": 604800,
+    "nitroGenesisBlock": 0,
+    "depositTimeout": 900000,
+    "tokenBridge": {
+      "l1CustomGateway": "0x3DF948c956e14175f43670407d5796b95Bb219D8",
+      "l1ERC20Gateway": "0x4A2bA922052bA54e29c5417bC979Daaf7D5Fe4f4",
+      "l1GatewayRouter": "0x525c2aBA45F66987217323E8a05EA400C65D06DC",
+      "l1MultiCall": "0xDB2D15a3EB70C347E0D2C2c7861cAFb946baAb48",
+      "l1ProxyAdmin": "0xe1080224B632A93951A7CFA33EeEa9Fd81558b5e",
+      "l1Weth": "0x408Da76E87511429485C32E4Ad647DD14823Fdc4",
+      "l1WethGateway": "0xF5FfD11A55AFD39377411Ab9856474D2a7Cb697e",
+      "l2CustomGateway": "0x525c2aBA45F66987217323E8a05EA400C65D06DC",
+      "l2ERC20Gateway": "0xe1080224B632A93951A7CFA33EeEa9Fd81558b5e",
+      "l2GatewayRouter": "0x1294b86822ff4976BfE136cB06CF43eC7FCF2574",
+      "l2Multicall": "0xDB2D15a3EB70C347E0D2C2c7861cAFb946baAb48",
+      "l2ProxyAdmin": "0xda52b25ddB0e3B9CC393b0690Ac62245Ac772527",
+      "l2Weth": "0x408Da76E87511429485C32E4Ad647DD14823Fdc4",
+      "l2WethGateway": "0x4A2bA922052bA54e29c5417bC979Daaf7D5Fe4f4"
+    }
+}
 ```


### PR DESCRIPTION
* Added some additional instructions for setting up this docs repo
* L2 nitro devnet runs on port 8547, not 7545
* Added information around the additional test wallet. The previous test wallet was only funded on L2 (and not L1)
    * sourced it from the [nitro script](https://github.com/OffchainLabs/nitro/blob/master/test-node.bash#L42)
* Provided some default addresses (sourced from [discord](https://discord.com/channels/585084330037084172/859511259183448084/1063583531089023116))

---

Not sure how often the test wallet private key changes and/or the default addresses, let me know if these shouldn't be hardcoded into the docs