### PR TITLE
Move link to latest nitro snapshot

### DIFF
--- a/arbitrum-docs/node-running/running-a-node.mdx
+++ b/arbitrum-docs/node-running/running-a-node.mdx
@@ -18,9 +18,9 @@ Note: If you’re interested in accessing an Arbitrum chain, but you don’t wan
 
 - Arbitrum One Nitro Genesis Database Snapshot
 
-  - Use the parameter `--init.url="https://snapshot.arbitrum.io/mainnet/nitro.tar"` on first startup to initialize Nitro database
-  - If running more than one node, easiest to manually download image from https://snapshot.arbitrum.io/mainnet/nitro.tar and host it locally for your nodes
-  - Or use `--init.url="file:///path/to/snapshot/in/container/nitro.tar"` to use a local snapshot archive
+  - Use the parameter `--init.url="https://snapshot.arbitrum.io/mainnet/nitro-recent.tar"` on first startup to initialize Nitro database
+  - If running more than one node, easiest to manually download image from https://snapshot.arbitrum.io/mainnet/nitro-recent.tar and host it locally for your nodes
+  - Or use `--init.url="file:///path/to/snapshot/in/container/nitro-recent.tar"` to use a local snapshot archive
   - sha256 checksum: `a609773c6103435b8a04d32c63f42bb5fa0dc8fc38a2acee4d2ab2d05880205c`
   - size: 33.5573504 GB
 
@@ -72,7 +72,7 @@ Note: If you’re interested in accessing an Arbitrum chain, but you don’t wan
 
 ### Optional parameters
 
-- `--init.url="https://snapshot.arbitrum.io/mainnet/nitro.tar"`
+- `--init.url="https://snapshot.arbitrum.io/mainnet/nitro-recent.tar"`
   - URL to download genesis database from. Only needed when starting Arbitrum One without database
 - `--node.rpc.classic-redirect=<classic node RPC>`
   - If set, will redirect archive requests for pre-nitro blocks to the designated RPC, which should be an Arbitrum Classic node with archive database. Only valid for Arbitrum One.


### PR DESCRIPTION
Old snapshot link (https://snapshot.arbitrum.io/mainnet/nitro.tar) is very outdated. I think this snapshot is more recent.