### PR TITLE
fix: Node data growth rate

### DIFF
--- a/arbitrum-docs/node-running/running-a-node.mdx
+++ b/arbitrum-docs/node-running/running-a-node.mdx
@@ -8,7 +8,7 @@ Note: If you’re interested in accessing an Arbitrum chain, but you don’t wan
   - RAM: 4-8 GB
   - CPU: 2-4 core CPU (For AWS: t3 xLarge)
   - Storage: Minimum 1.2TB SSD (make sure it is extendable)
-  - Estimated Growth Rate: 14GB per day
+  - Estimated Growth Rate: around 3 GB per day
 
 ❗️Note: The minimum storage requirements will change over time as the Nitro chain grows. It is recommended to use more than the minimum requirements to run a robust full node.
 


### PR DESCRIPTION
According to Ed, this number should be 3 GB rather than 14 GB.