### PR TITLE
Fixing build dapp nav

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -95,7 +95,7 @@ const config = {
           },
           {
             type: "doc",
-            docId: "migration/dapp_migration",
+            docId: "getting-started-devs",
             position: "left",
             label: "Build DApps",
           },


### PR DESCRIPTION
Fixing link in nav for "Build Dapp" to start on first page of that section