### PR TITLE
Fix broken URL in optional parameter

### DIFF
--- a/arbitrum-docs/node-running/running-a-node.mdx
+++ b/arbitrum-docs/node-running/running-a-node.mdx
@@ -72,7 +72,7 @@ Note: If you’re interested in accessing an Arbitrum chain, but you don’t wan
 
 ### Optional parameters
 
-- `--init.url="https://snapshot.arbitrum.io/mainnet/nitro.tar"`
+- `--init.url=https://snapshot.arbitrum.io/mainnet/nitro.tar`
   - URL to download genesis database from. Only needed when starting Arbitrum One without database
 - `--node.rpc.classic-redirect=<classic node RPC>`
   - If set, will redirect archive requests for pre-nitro blocks to the designated RPC, which should be an Arbitrum Classic node with archive database. Only valid for Arbitrum One.


### PR DESCRIPTION
## Description

While I was trying to run an archive node, I had to use the `init.url` parameter using the given value on the documentation.
But the presence of the double-quotes prevent the node to start because the URL could not be parsed.
This PR removes those double-quotes.