### PR TITLE
Update running-a-classic-node.mdx

### DIFF
--- a/arbitrum-docs/node-running/running-a-classic-node.mdx
+++ b/arbitrum-docs/node-running/running-a-classic-node.mdx
@@ -23,6 +23,7 @@ on pre-Nitro blocks.
 ### Required Artifacts
 
 - Latest Docker Image: offchainlabs/arb-node:v1.4.5-e97c1a4
+- Latest classic snapshot for Arbitrum One: https://snapshot.arbitrum.io/mainnet/db.tar
 
 ### Required parameters
 


### PR DESCRIPTION
Seems lots of ppl asked if we have snapshot for classic node, and classic node sync speed is too slow, so we may need add this at our docs directly.