### PR TITLE
Clean up FAQs sections and add new Get Started FAQs

### DIFF
--- a/arbitrum-docs/for-users/troubleshooting-users.md
+++ b/arbitrum-docs/for-users/troubleshooting-users.md
@@ -1,8 +1,8 @@
 # Troubleshooting: Using Arbitrum
 
-import FaqPartial, {toc as FAQTOC} from '../partials/\_troubleshooting-users-partial.md';
+import FaqPartial, {toc as FAQTOC} from '../partials/\_troubleshooting-bridging-partial.md';
 
-<div data-faq-origin-slug='user-faq'>
+<div data-faq-origin-slug='bridging-faq'>
     <FaqPartial />
 </div>
 

--- a/arbitrum-docs/learn-more/faq.md
+++ b/arbitrum-docs/learn-more/faq.md
@@ -1,0 +1,11 @@
+---
+title: "Frequently asked questions: Get started"
+---
+
+import FaqPartial, {toc as FAQTOC} from '../partials/\_troubleshooting-users-partial.md';
+
+<div data-faq-origin-slug='get-started-faq'>
+    <FaqPartial />
+</div>
+
+export const toc = FAQTOC

--- a/arbitrum-docs/partials/_troubleshooting-bridging-partial.md
+++ b/arbitrum-docs/partials/_troubleshooting-bridging-partial.md
@@ -1,0 +1,46 @@
+### How do I move assets between One and Nova? {#how-do-i-move-assets-between-one-and-nova}
+<p>Both Arbitrum One and Arbitrum Nova run as layers on top of Ethereum. Thus, you can always move assets between the two chains in two steps by going "through" Ethereum. In other words: withdraw your assets on Arbitrum One to Ethereum and then deposit them onto Nova, or conversely, withdraw your assets from Nova on to Ethreum and then deposit them on to Arbitrum One. These steps can all be done at <a href="https://bridge.arbitrum.io/">https://bridge.arbitrum.io/</a>.</p>
+
+<p>Some <a href="https://portal.arbitrum.one/#bridges">third party bridges</a> support transferring between Arbitrum One and Nova directly; (remember that third party bridges are created by third parties; DYOR!)</p>
+
+<p></p>
+
+
+
+### What fees do I have to pay when bridging funds from L1 to L2? {#what-fees-do-i-have-to-pay-when-bridging-funds-from-l1-to-l2}
+<p>When bridging over tokens from L1 to L2, you will have to sign one or two transactions with their corresponding fees:</p>
+
+<ol><li>If your bridging a token for the first time, you'll sign one <strong>approval transaction</strong>.</li>
+<li>In all cases, you'll sign a <strong>deposit transaction</strong> that will send your tokens to the Bridge.</li>
+</ol>
+<p></p>
+
+<p>Keep in mind that the approval transaction needs to be executed once per token and wallet. This means that if you bridge again the same token from the same wallet, you won't have to pay that transaction. However, if you bridge the same token from a different wallet, you will have to pay that transaction again.</p>
+
+<p></p>
+
+<p>In any case, the bridge and your wallet will guide you through the process, showing the transaction(s) that you need to sign in order to have your tokens bridged to Arbitrum.</p>
+
+<p></p>
+
+
+
+### When I initiate withdrawal from Arbitrum, how long does it take before I receive my funds? {#when-i-initiate-withdrawal-from-arbitrum-how-long-does-it-take-before-i-receive-my-funds}
+<p><a href="https://developer.arbitrum.io/faqs/what-if-dispute#okay-okay-but-if-were-just-talking-about-an-l2-to-l1-message-and-assuming-theres-no-disputes-how-long-between-the-time-the-message-is-initiated-and-when-i-can-execute-it-on-l1-is-it-exactly-one-week"></a></p>
+
+<p>It will typically be <em>roughly</em> one week.</p>
+
+<p>There's some variability in the exact wall-clock time of the dispute window, plus there's some expected additional "padding" time on both ends (no more than about an hour, typically).</p>
+
+<p>The variability of the dispute window comes from the slight variance of block times. Arbitrum One's dispute window is 45818 blocks; this converts to ~1 week assuming 13.2 seconds per block, which was the average block time when Ethereum used Proof of Work (with the switch to Proof of Stake, average block times are about 12 seconds).</p>
+
+<p>The "padding on both ends" involves three events that have to occur between a client receiving their transaction receipt from a Sequencer and their L2-to-L1 message being executable. After getting their receipt,</p>
+
+<ol><li>The Sequencer posts their transaction in a batch (usually within a few minutes, though the Sequencer will wait a bit longer if the L1 is congested). Then,</li>
+<li>A validator includes their transaction in an RBlock (usually within the hour). Then, after the ~week long dispute window passes, the RBlock is confirmable, and</li>
+<li>Somebody (anybody) confirms the RBlock on L1 (usually within ~15 minutes).</li>
+</ol>
+<p>Additionally, in the rare and unlikely event of a dispute, this delay period will be extended for the dispute to resolve.</p>
+
+
+

--- a/arbitrum-docs/partials/_troubleshooting-building-partial.md
+++ b/arbitrum-docs/partials/_troubleshooting-building-partial.md
@@ -1,5 +1,13 @@
-### Why am I getting error "429 Too Many Requests" when using one of Offchain Labs' Public RPCs? {#why-am-i-getting-error-429-too-many-requests-when-using-one-of-offchain-labs-public-rpcs}
-<p>Offchain Labs offers public RPCs for free, but limits requests to prevent DOSing. Hitting the rate limit could come from your request frequency and/or the resources required to process the requests. If you hitting our rate limit, we recommend <a href="https://developer.arbitrum.io/node-running/running-a-node">running your own node</a> or <a href="https://developer.arbitrum.io/node-running/node-providers">using a third party node provider</a>.</p>
+### How does gas work on Arbitrum? {#how-does-gas-work-on-arbitrum}
+<p>Fees on Arbitrum chains are collected on L2 in the chains' native currency (ETH on both Arbitrum One and Nova).</p>
+
+<p>A transaction fee is comprised of both an L1 and an L2 component:</p>
+
+<p>The L1 component is meant to compensate the Sequencer for the cost of posting transactions on L1 (but no more). (See <a href="https://developer.arbitrum.io/arbos/l1-pricing">L1 Pricing</a>.)</p>
+
+<p>The L2 component covers the cost of operating the L2 chain; it uses Geth for gas calculation and thus behaves nearly identically to L1 Ethereum. One difference is that unlike on Ethereum, Arbitrum chains enforce a gas price floor; currently 0.1 gwei on Arbitrum One and 0.01 gwei on Nova (See [Gas](/arbos/gas.mdx)).</p>
+
+<p>L2 Gas price adjusts responsively to chain congestion, ala EIP 1559.</p>
 
 <p></p>
 
@@ -41,13 +49,10 @@ To let's find out which is custom error this signature represents, we can use th
 
 
 
-### Do I need to pay a tip / Priority fee for my Arbitrum transactions? {#do-i-need-to-pay-a-tip--priority-fee-for-my-arbitrum-transactions}
-<p>Since transactions are processed in the order that the Sequencer receives them, no priority fee is necessary for Arbitrum transactions; if a transaction does include a priority fee, it will be refunded to the transaction's origin address at the end of execution.</p>
-
-
-
 ### How is the L1 portion of an Arbitrum transaction's gas fee computed?  {#how-is-the-l1-portion-of-an-arbitrum-transactions-gas-fee-computed-}
-<p>The L1 fee that a transaction is required to pay is determined by compressing its data with brotli and multiplying the size of the result (in bytes) by ArbOS's current calldata price; the latter value can be queried via the <code>getPricesInWei</code>method of the <code>ArbGasInfo</code>precompile.</p>
+<p>The L1 fee that a transaction is required to pay is determined by compressing its data with brotli and multiplying the size of the result (in bytes) by ArbOS's current calldata price; the latter value can be queried via the <code>getPricesInWei</code>method of the <code>ArbGasInfo</code>precompile. You can find more information about gas calculations in <a href="https://medium.com/offchainlabs/understanding-arbitrum-2-dimensional-fees-fd1d582596c9">Understanding Arbitrum: 2-Dimensional Fees</a> and <a href="https://developer.arbitrum.io/devs-how-tos/how-to-estimate-gas">How to estimate gas in Arbitrum</a>.</p>
+
+<p></p>
 
 
 
@@ -75,26 +80,68 @@ To let's find out which is custom error this signature represents, we can use th
 
 <p><a href="https://github.com/NomicFoundation/hardhat/releases/tag/hardhat%402.12.2">Hardhat v2.12.2</a> added supports for forking networks like Arbitrum with custom transaction types, so if you're using hardhat, upgrade to 2.12.2!</p>
 
+<p></p>
 
-### References
-<ul><li><a href="https://github.com/NomicFoundation/hardhat/issues/2995">https://github.com/NomicFoundation/hardhat/issues/2995</a></li></ul>
+<p><strong>References</strong></p>
+
+<ul><li><a href="https://github.com/NomicFoundation/hardhat/issues/2995">https://github.com/NomicFoundation/hardhat/issues/2995</a></li>
+</ul>
+<p></p>
 
 
 
-### Why does it look like two identical transaction consume a different amount of gas? {#why-does-it-look-like-two-identical-transaction-consume-a-different-amount-of-gas}
+### Why does it look like two identical transactions consume a different amount of gas? {#why-does-it-look-like-two-identical-transactions-consume-a-different-amount-of-gas}
 <p></p>
 
 <p>Calling an Arbitrum node's <code>eth_estimateGas</code> RPC returns a value sufficient to cover both the L1 and L2 components of the fee for the current gas price; this is the value that, e.g., will appear in users' wallets in the "gas limit" field.</p>
 
 <p>Thus, if the L1 calldata price changes over time, it will appear (in e.g., a wallet) that a transaction's gas limit is changing. In fact, the L2 gas limit isn't changing, merely the total gas required to cover the transaction's L1 + L2 fees.</p>
 
-<p>See <a href="https://medium.com/offchainlabs/understanding-arbitrum-2-dimensional-fees-fd1d582596c9">2-D fees</a> for more.</p>
+<p>See <a href="https://medium.com/offchainlabs/understanding-arbitrum-2-dimensional-fees-fd1d582596c9">2-D fees</a> and <a href="https://developer.arbitrum.io/devs-how-tos/how-to-estimate-gas">How to estimate gas in Arbitrum</a> for more.</p>
+
+<p></p>
+
+<p><strong>References</strong></p>
+
+<p><a href="https://medium.com/offchainlabs/understanding-arbitrum-2-dimensional-fees-fd1d582596c9">https://medium.com/offchainlabs/understanding-arbitrum-2-dimensional-fees-fd1d582596c9</a></p>
 
 <p></p>
 
 
-### References
-<p><a href="https://medium.com/offchainlabs/understanding-arbitrum-2-dimensional-fees-fd1d582596c9">https://medium.com/offchainlabs/understanding-arbitrum-2-dimensional-fees-fd1d582596c9</a></p>
+
+### Why am I getting error "429 Too Many Requests" when using one of Offchain Labs' Public RPCs? {#why-am-i-getting-error-429-too-many-requests-when-using-one-of-offchain-labs-public-rpcs}
+<p>Offchain Labs offers public RPCs for free, but limits requests to prevent DOSing. Hitting the rate limit could come from your request frequency and/or the resources required to process the requests. If you hitting our rate limit, we recommend <a href="https://developer.arbitrum.io/node-running/running-a-node">running your own node</a> or <a href="https://developer.arbitrum.io/node-running/node-providers">using a third party node provider</a>.</p>
+
+<p></p>
+
+
+
+### How do block.timestamp and block.number work on Arbitrum? {#how-do-blocktimestamp-and-blocknumber-work-on-arbitrum}
+<p>Solidity calls to <code>block.number</code> and <code>block.timestamp</code> on Arbitrum will return the block number/ timestamp of the under lying L1 on a slight delay; i.e., updated every few minutes. Note that L2 block numbers (i.e., as seen in block explorers / returned by RPCs) are different, and are typically updated roughly every second.</p>
+
+<p>For more info, see <a href="https://developer.arbitrum.io/time">block numbers and time</a>.</p>
+
+<p></p>
+
+
+
+### Do I need to download any special npm libraries in order to use web3.js or ethers-js on Arbitrum?  {#do-i-need-to-download-any-special-npm-libraries-in-order-to-use-web3js-or-ethersjs-on-arbitrum-}
+<p>Nope; web3.js and ethers.js will work out of the box just like they do on L1 Ethereum.<br />
+<br />
+Once upon a time, Arbitrum developers were required to download supplemental packages with names like "arb-provider-ethers" and "arb-ethers-web3-bridge", but these packages are deprecated and no longer required! Any guide that directs devs to use them should be considered out-dated.</p>
+
+<p></p>
+
+<p></p>
+
+
+
+### How can I list my token on the Arbitrum Bridge? {#how-can-i-list-my-token-on-the-arbitrum-bridge}
+<p>The L2 token list used in the Arbitrum bridge is generated from the L1 tokens that are part of the token list of Uniswap, Gemini or Coinmarketcap. This is valid for L1-native tokens that have been bridged over to L2, and for L2-native tokens that have been bridged over to L1 as long as they are part of any of those lists.</p>
+
+<p>Currently, there isn't any L2-only token list.</p>
+
+<p></p>
 
 <p></p>
 

--- a/arbitrum-docs/partials/_troubleshooting-nodes-partial.md
+++ b/arbitrum-docs/partials/_troubleshooting-nodes-partial.md
@@ -1,7 +1,5 @@
-### Why do I need an L1 node to run an Arbitrum node? {#why-do-i-need-an-l1-node-to-run-an-arbitrum-node}
-<p>On the node syncing stage, Arbitrum nodes read transactions from batches that were previously posted on L1 and have been executed. They then connect to the Sequencer feed to receive new incoming batched transactions that have not yet been posted on L1.</p>
-
-<p>When fully synced, the Arbitrum node uses the State Transition Function (STF) to consume transactions coming from the Sequencer feed and creates a new state. It also waits for the L1 batch to be posted. If the L1 batch that is finalized on L1 is different from what the Sequencer published, the node will change the state based on the L1 batched transactions.</p>
+### How do I run a node? {#how-do-i-run-a-node}
+<p>See instructions <a href="https://developer.arbitrum.io/node-running/running-a-node">here</a>! </p>
 
 <p></p>
 
@@ -23,8 +21,10 @@
 
 
 
-### How do I run a node? {#how-do-i-run-a-node}
-<p>See instructions <a href="https://developer.arbitrum.io/node-running/running-a-node">here</a>! </p>
+### Why do I need an L1 node to run an Arbitrum node? {#why-do-i-need-an-l1-node-to-run-an-arbitrum-node}
+<p>On the node syncing stage, Arbitrum nodes read transactions from batches that were previously posted on L1 and have been executed. They then connect to the Sequencer feed to receive new incoming batched transactions that have not yet been posted on L1.</p>
+
+<p>When fully synced, the Arbitrum node uses the State Transition Function (STF) to consume transactions coming from the Sequencer feed and creates a new state. It also waits for the L1 batch to be posted. If the L1 batch that is finalized on L1 is different from what the Sequencer published, the node will change the state based on the L1 batched transactions.</p>
 
 <p></p>
 

--- a/arbitrum-docs/partials/_troubleshooting-users-partial.md
+++ b/arbitrum-docs/partials/_troubleshooting-users-partial.md
@@ -1,5 +1,54 @@
+### Why do I need ETH to use the Arbitrum network? {#why-do-i-need-eth-to-use-the-arbitrum-network}
+<p>When moving funds from Mainnet (L1) to Arbitrum (L2), you'll need ETH in your Arbitrum wallet. Even if you want only to use another, non-ETH, token, you will still need a small amount of ETH in your wallet on the Arbitrum network. This is because all Arbitrum transactions are powered by ETH. ETH is the currency used for gas fees.</p>
+
+<p></p>
+
+<p></p>
+
+
+
 ### Do I need to pay a tip / Priority fee for my Arbitrum transactions? {#do-i-need-to-pay-a-tip--priority-fee-for-my-arbitrum-transactions}
 <p>Since transactions are processed in the order that the Sequencer receives them, no priority fee is necessary for Arbitrum transactions; if a transaction does include a priority fee, it will be refunded to the transaction's origin address at the end of execution.</p>
+
+
+
+### How can I see the balance of my Eth / Tokens on Arbitrum in my wallet? {#how-can-i-see-the-balance-of-my-eth--tokens-on-arbitrum-in-my-wallet}
+<p>Most wallets are "connected" to one given network at a time. To view your Ether / Token balances, ensure that you are connected to the appropriate Arbitrum chain. In MetaMask, you can switch networks via the "networks" dropdown. In this dropdown, select your desired network (either Arbitrum One or Arbitrum Nova for our mainnet networks). If your desired network hasn't been added to your wallet yet, you can add it at <a href="https://bridge.arbitrum.io/">https://bridge.arbitrum.io/</a>.</p>
+
+<p></p>
+
+
+
+### What happens if I send my funds to an exchange that does not support Arbitrum? {#what-happens-if-i-send-my-funds-to-an-exchange-that-does-not-support-arbitrum}
+<p>If you send the funds and the receiving wallet/exchange does not support the Arbitrum network you are sending funds through, there is unfortunately nothing that we can do to recover your funds. You would need to contact the wallet/exchage support and see if they can do anything to help you retrieve the funds.</p>
+
+<p></p>
+
+
+
+### Does Arbitrum have a mempool? {#does-arbitrum-have-a-mempool}
+<p>The Arbitrum Sequencer orders transactions on a first come, first served basis; the Sequencer inserts transactions into a queue based on the order they are received and executes them accordingly. This queue thus exists in lieu of a mempool. The Sequencer's queue has no space limit; transactions on the queue will eventually timeout and be discarded if not executed in time. Under normal conditions, the queue is empty, since transactions are executed near-instantaneously.</p>
+
+<p></p>
+
+
+
+### What's the difference between Arbitrum Rollup and Arbitrum AnyTrust? {#whats-the-difference-between-arbitrum-rollup-and-arbitrum-anytrust}
+<p>Arbitrum Rollup is an Optimistic Rollup protocol; it is trustless and permissionless. Part of how these properties are achieved is by requiring all chain data to be posted on layer 1. This means the availability of this data follows directly from the security properties of Ethereum itself, and, in turn, that any party can participate in validating the chain and ensuring its safety.</p>
+
+<p>By contrast, Arbitrum AnyTrust introduces a trust assumption in exchange for lower fees; data availability is managed by a Data Availability Committee (DAC), a fixed, permissioned set of entities. We introduce some threshold, K, with the assumption that at least K members of the committee are honest. For simplicity, we'll hereby assume a committee of size 20 and a K value of 2:</p>
+
+<p>If 19 out of the 20 committee members <em>and</em> the Sequencer are malicious and colluding together, they can break the chain's safety (and, e.g., steal users' funds); this is the new trust assumption.</p>
+
+<p>If anywhere between 2 and 18 of the committee members are well behaved, the AnyTrust chain operates in "Rollup mode"; i.e., data gets posted on L1.</p>
+
+<p>In what should be the common and happy case, however, in which at least 19 of the 20 committee members are well behaved, the system operates without posting the L2 chain's data on L1, and thus, users pay significantly lower fees. This is the core upside of AnyTrust chains over rollups.</p>
+
+<p>Variants of the AnyTrust model in which the new trust assumption is minimized are under consideration; stay tuned.</p>
+
+<p>For more, see <a href="https://developer.arbitrum.io/inside-anytrust">Inside AnyTrust</a>.</p>
+
+<p></p>
 
 
 
@@ -16,12 +65,49 @@
 
 
 
-### How do I move assets between One and Nova? {#how-do-i-move-assets-between-one-and-nova}
-<p>Both Arbitrum One and Arbitrum Nova run as layers on top of Ethereum. Thus, you can always move assets between the two chains in two steps by going "through" Ethereum. In other words: withdraw your assets on Arbitrum One to Ethereum and then deposit them onto Nova, or conversely, withdraw your assets from Nova on to Ethreum and then deposit them on to Arbitrum One. These steps can all be done at <a href="https://bridge.arbitrum.io/">https://bridge.arbitrum.io/</a>.</p>
+### If there is a dispute, can my L2 transaction get reorged / throw out / "yeeted"? {#if-there-is-a-dispute-can-my-l2-transaction-get-reorged--throw-out--yeeted}
+<p>Nope; once an Arbitrum transaction is included on L1, there is no way it can be reorged (unless the L1 itself reorgs, of course). A "dispute" involves Validators disagreeing over execution, i.e., the outputted state of a chain. The inputs, however, can't be disputed; they are determined by the Inbox on L1. (See <a href="https://developer.arbitrum.io/tx-lifecycle">Transaction Lifecycle</a>)</p>
 
-<p>Some <a href="https://portal.arbitrum.one/#bridges">third party bridges</a> support transferring between Arbitrum One and Nova directly; (remember that third party bridges are created by third parties; DYOR!)</p>
+
+### ...okay but if there's a dispute, will my transaction get delayed?<a href="https://developer.arbitrum.io/faqs/protocol-faqs#q-dispute-delay"></a>
+<p>The only thing that a dispute can add delay to is the confirmation of L2-to-L1 messages. All other transactions continue to be processed, even while a dispute is still undergoing. (Additionally: in practice, most L2-to-L1 messages represent withdrawals of fungible assets; these can be trustlessly completed <em>even during a dispute</em> via trustless fast "liquidity exit" applications. See <a href="https://developer.arbitrum.io/arbos/l2-to-l1-messaging">L2-to-L1 Messages</a>).</p>
+
+
+## 
+
+
+### Are "Sequencers" the same thing as "Validators"? Can a centralized Sequencer do bad things like steal all my money? {#are-sequencers-the-same-thing-as-validators-can-a-centralized-sequencer-do-bad-things-like-steal-all-my-money}
+<p>No and no!</p>
+
+<p>An Arbitrum Chain's Sequencer(s) and Validators and completely distinct entities, with their own distinct roles.</p>
+
+<p>The <a href="https://developer.arbitrum.io/sequencer">Sequencer</a> is the entity granted specific privileges over ordering transactions; once the Sequencer commits to an ordering (by posting a batch on Ethereum), it has no say over what happens next (i.e., execution). A malicious/faulty Sequencer can do things like reorder transactions or <em>temporarily</em> delay a transaction's inclusion — things which could be, to be sure, annoying and bad — but can do nothing to compromise the chain's safety.</p>
+
+<p>The <em>Validators</em> are the ones responsible for the safety of the chain; i.e., making staked claims about the chain state, disputing each other, etc.</p>
+
+<p>Currently, on Arbitrum One, the Sequencer is a centralized entity maintained by Offchain Labs. Eventually, the single Sequencer will be replaced by a distributed committee of Sequencers who come to consensus on transaction ordering. This upgrade will be an improvement; we don't want you to have to trust us not to reorder your transactions. However, it also isn't <em>strictly</em> necessary for Arbitrum One to achieve its most fundamental properties.</p>
+
+<p>In other words: <em><strong>An Arbitrum Rollup chain with a centralized Sequencer could theoretically still be trustless!</strong></em></p>
+
+<p>Which is to say — the more important thing than decentralizing the Sequencer, i.e., the thing you ought to care more about — is decentralizing the <em>Validators</em>.</p>
+
+<p>Arbitrum One's Validator set is currently whitelisted; overtime, the whitelist will grow and then be removed entirely. For more info see <a href="https://developer.arbitrum.io/mainnet-beta">"Mainnet Beta"</a>.</p>
+
+
+
+### Why was "one week" chosen for Arbitrum One's dispute window? {#why-was-one-week-chosen-for-arbitrum-ones-dispute-window}
+<p>Generally, some dispute period is necessary for Arbitrum Rollup so that validators have time to dispute an invalid assertion.<br />
+<br />
+A week is expected to be more than enough time for validators to carry out an interactive dispute, assuming they don't encounter difficulty in getting their transactions included on L1. One week was chosen following the general consensus among the Ethereum research community — as well as other layer 2 projects — to provide enough time for the community to socially coordinate in the case of a coordinated Ethereum-staker censorship attack.</p>
 
 <p></p>
+
+
+
+### What's the state of Arbitrum One's decentralization? {#whats-the-state-of-arbitrum-ones-decentralization}
+<p>Arbitrum One runs on a <a href="https://github.com/OffchainLabs/nitro">full, feature complete implementation</a> of the Arbitrum Rollup protocol; given that this is still fairly new technology, however, we currently maintain administrative "training wheels." The centralized components of the system will be progressively phased out over time.</p>
+
+<p>For status updates, see <a href="https://developer.arbitrum.io/mainnet-beta">"Mainnet Beta"</a>, or check out the work of our friends at <a href="https://l2beat.com/scaling/risk/">L2BEAT</a>.</p>
 
 
 

--- a/notion-docs/scripts/update.ts
+++ b/notion-docs/scripts/update.ts
@@ -55,7 +55,7 @@ async function generateFiles() {
   const validDefs = _definitions.filter(isValid)
 
 
-  const userFAQ = await lookupFAQs(notion, {
+  const getStartedFAQ = await lookupFAQs(notion, {
     filter: {
       and: [
         {
@@ -72,6 +72,12 @@ async function generateFiles() {
         },
       ],
     },
+    sorts: [
+      {
+        property: 'FAQ order index',
+        direction: 'ascending'
+      }
+    ]
   })
 
   const nodeFAQ = await lookupFAQs(notion, {
@@ -91,6 +97,12 @@ async function generateFiles() {
         },
       ],
     },
+    sorts: [
+      {
+        property: 'FAQ order index',
+        direction: 'ascending'
+      }
+    ]
   })
 
   const buildFAQ = await lookupFAQs(notion, {
@@ -110,6 +122,37 @@ async function generateFiles() {
         },
       ],
     },
+    sorts: [
+      {
+        property: 'FAQ order index',
+        direction: 'ascending'
+      }
+    ]
+  })
+
+  const bridgeFAQ = await lookupFAQs(notion, {
+    filter: {
+      and: [
+        {
+          property: 'Target document slugs',
+          multi_select: {
+            contains: 'troubleshooting-bridging',
+          },
+        },
+        {
+          property: 'Publishable?',
+          select: {
+            equals: 'Publishable',
+          },
+        },
+      ],
+    },
+    sorts: [
+      {
+        property: 'FAQ order index',
+        direction: 'ascending'
+      }
+    ]
   })
 
   const addItems = (items: KnowledgeItem[], page: string) => {
@@ -141,7 +184,7 @@ async function generateFiles() {
 
   fs.writeFileSync(
     '../arbitrum-docs/partials/_troubleshooting-users-partial.md',
-    renderSimpleFAQs(userFAQ.filter(isValid), linkableTerms)
+    renderSimpleFAQs(getStartedFAQ.filter(isValid), linkableTerms)
   )
   fs.writeFileSync(
     '../arbitrum-docs/partials/_troubleshooting-nodes-partial.md',
@@ -150,6 +193,10 @@ async function generateFiles() {
   fs.writeFileSync(
     '../arbitrum-docs/partials/_troubleshooting-building-partial.md',
     renderSimpleFAQs(buildFAQ.filter(isValid), linkableTerms)
+  )
+  fs.writeFileSync(
+    '../arbitrum-docs/partials/_troubleshooting-bridging-partial.md',
+    renderSimpleFAQs(bridgeFAQ.filter(isValid), linkableTerms)
   )
 }
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -409,45 +409,9 @@ const sidebars = {
       ]
     },
     {
-      type: "category",
-      label: "FAQs",
-      items: [
-        {
-          type: "doc",
-          id: "faqs/faqs-index",
-          label: "FAQ index"
-        },
-        {
-          type: "doc",
-          id: "faqs/gas-faqs",
-          label: "Gas"
-        },
-        {
-          type: "doc",
-          id: "faqs/nodes-faqs",
-          label: "Nodes"
-        },
-        {
-          type: "doc",
-          id: "faqs/x-chain-faqs",
-          label: "Cross-chain messaging"
-        },
-        {
-          type: "doc",
-          id: "faqs/protocol-faqs",
-          label: "Protocol"
-        },
-        {
-          type: "doc",
-          id: "faqs/tooling-faqs",
-          label: "Tooling"
-        },
-        {
-          type: "doc",
-          id: "faqs/misc-faqs",
-          label: "Misc"
-        }
-      ]
+      type: "doc",
+      id: "learn-more/faq",
+      label: "Frequently asked questions: Get started"
     },
     {
       type: "doc",


### PR DESCRIPTION
- All FAQs from the Get Started FAQ section(moved to Learn More) have been moved to the appropriate topic.
- New Get Started FAQs have been created from the contents of that page (related to basic usage) and the Arbitrum Support page
- Ordering FAQs is now available through the FAQ order index property in the FAQ CMS
- Styles have been adjusted for consistency among all FAQ pages

Notes (please let me know if this aligns with the current strategy):
- I've created a `learn-more` folder to place the contents of that section there. For now, only the faq page. 
- The FAQ page is called `Frequently asked questions: Get started` and it's identified like that within the code too (e.g. data-faq-origin-slug="get-started-faq")
