### PR TITLE
Cleanup some titles and anchors + Fix ArbOwner links

### DIFF
--- a/arbitrum-docs/arbos/precompiles.mdx
+++ b/arbitrum-docs/arbos/precompiles.mdx
@@ -1,4 +1,6 @@
-# Overview
+---
+title: "ArbOS precompiles"
+---
 
 ArbOS provides L2-specific precompiles with methods smart contracts can call the same way they can solidity functions. This reference exhaustively documents the specific calls ArbOS makes available. For more details on the infrastructure that makes this possible, please refer to the [ArbOS documentation](arbos.mdx). For an abbreviated reference on the precompiles we expect users to most often use, please see the [common precompiles documentation](common-precompiles.mdx).
 
@@ -28,13 +30,13 @@ From the perspective of user applications, precompiles live as contracts at the 
 [arbinfo_link]: https://github.com/OffchainLabs/nitro/blob/master/precompiles/ArbInfo.go
 [arbgasinfo_link]: https://github.com/OffchainLabs/nitro/blob/master/precompiles/ArbGasInfo.go
 [arbostest_link]: https://github.com/OffchainLabs/nitro/blob/master/precompiles/ArbosTest.go
-[arbowner_link]: https://github.com/OffchainLabs/nitro/blob/master/precompiles/ArbOwner.go
+[arbowner_link]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go
 [arbownerpublic_link]: https://github.com/OffchainLabs/nitro/blob/master/precompiles/ArbOwnerPublic.go
 [arbretryabletx_link]: https://github.com/OffchainLabs/nitro/blob/master/precompiles/ArbRetryableTx.go
 [arbstatistics_link]: https://github.com/OffchainLabs/nitro/blob/master/precompiles/ArbStatistics.go
 [arbsys_link]: https://github.com/OffchainLabs/nitro/blob/master/precompiles/ArbSys.go
 
-# ArbAddressTable
+## ArbAddressTable
 
 [ArbAddressTable][arbaddresstable_link] provides the ability to create short-hands for commonly used accounts.
 
@@ -63,7 +65,7 @@ From the perspective of user applications, precompiles live as contracts at the 
 [ats5]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbAddressTable.sol#L68
 [ats6]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbAddressTable.sol#L73
 
-# ArbAggregator
+## ArbAggregator
 
 [ArbAggregator][arbaggregator_link] provides aggregators and their users methods for configuring how they participate in L1 aggregation. Arbitrum One's default aggregator is the Sequencer, which a user will prefer unless `SetPreferredAggregator` is invoked to change it.
 
@@ -107,7 +109,7 @@ Compression ratios are measured in basis points. Methods that are checkmarked ar
 [ads0]: https://github.com/OffchainLabs/nitro/blob/ba3a86afb2e7057bdc3cce54b28be4c1c0579180/solgen/src/precompiles/ArbAggregator.sol#L67
 [ads1]: https://github.com/OffchainLabs/nitro/blob/ba3a86afb2e7057bdc3cce54b28be4c1c0579180/solgen/src/precompiles/ArbAggregator.sol#L75
 
-# ArbBLS
+## ArbBLS
 
 [ArbBLS][arbbls_link] provides a registry of BLS public keys for accounts.
 
@@ -137,7 +139,7 @@ Compression ratios are measured in basis points. Methods that are checkmarked ar
 [bds0]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbBLS.sol#L25
 [bds1]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbBLS.sol#L33
 
-# ArbDebug
+## ArbDebug
 
 [ArbDebug][arbdebug_link] provides mechanisms useful for testing. The methods of `ArbDebug` are only available for chains with the `AllowDebugPrecompiles` chain parameter set. Otherwise, calls to this precompile will revert.
 
@@ -164,7 +166,7 @@ Compression ratios are measured in basis points. Methods that are checkmarked ar
 [des1]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbDebug.sol#L34
 [des2]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbDebug.sol#L41
 
-# ArbFunctionTable
+## ArbFunctionTable
 
 [ArbFunctionTable][arbfunctiontable_link] provides aggregators the ability to manage function tables, to enable one form of transaction compression. The Nitro aggregator implementation does not use these, so these methods have been stubbed and their effects disabled. They are kept for backwards compatibility.
 
@@ -181,7 +183,7 @@ Compression ratios are measured in basis points. Methods that are checkmarked ar
 [fts1]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbFunctionTable.sol#L32
 [fts2]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbFunctionTable.sol#L29
 
-# ArbGasInfo
+## ArbGasInfo
 
 [ArbGasInfo][arbgasinfo_link] provides insight into the cost of using the chain. These methods have been adjusted to account for Nitro's heavy use of calldata compression. Of note to end-users, we no longer make a distinction between non-zero and zero-valued calldata bytes.
 
@@ -240,7 +242,7 @@ Compression ratios are measured in basis points. Methods that are checkmarked ar
 [gis16]: https://github.com/OffchainLabs/nitro/blob/6b6de9068662883518cff13c67b885161763f52c/contracts/src/precompiles/ArbGasInfo.sol#L126
 [gis17]: https://github.com/OffchainLabs/nitro/blob/6b6de9068662883518cff13c67b885161763f52c/contracts/src/precompiles/ArbGasInfo.sol#L129
 
-# ArbInfo
+## ArbInfo
 
 [ArbInfo][arbinfo_link] provides the ability to lookup basic info about accounts and contracts.
 
@@ -254,7 +256,7 @@ Compression ratios are measured in basis points. Methods that are checkmarked ar
 [is0]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbInfo.sol#L25
 [is1]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbInfo.sol#L28
 
-# ArbosTest
+## ArbosTest
 
 [ArbosTest][arbostest_link] Ppovides a method of burning arbitrary amounts of gas, which exists for historical reasons. In Classic, `ArbosTest` had additional methods only the zero address could call. These have been removed since users don't use them and calls to missing methods revert.
 
@@ -265,7 +267,7 @@ Compression ratios are measured in basis points. Methods that are checkmarked ar
 [t0]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/precompiles/ArbosTest.go#L17
 [ts0]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbosTest.sol#L27
 
-# ArbOwner
+## ArbOwner
 
 [ArbOwner][arbowner_link] provides owners with tools for managing the rollup. Calls by non-owners will always revert.
 
@@ -275,66 +277,65 @@ Most of Arbitrum Classic's owner methods have been removed since they no longer 
 - ArbOS upgrades happen with the rest of the system rather than being independent
 - Exemptions to address aliasing are no longer offered. Exemptions were intended to support backward compatibility for contracts deployed before aliasing was introduced, but no exemptions were ever requested.
 
-| Methods                                                                    |                                                                                                  |
-| :------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------- |
-| [![](../assets/e.png)][os0] [`addChainOwner`][o0]`(account)`               | Add account as a chain owner                                                                     |
-| [![](../assets/e.png)][os1] [`removeChainOwner`][o1]`(account)`            | Remove account from the list of chain owners                                                     |
-| [![](../assets/e.png)][os2] [`isChainOwner`][o2]`(account)`                | See if account is a chain owner                                                                  |
-| [![](../assets/e.png)][os3] [`getAllChainOwners`][o3]`()`                  | Retrieves the list of chain owners                                                               |
-| [![](../assets/e.png)][os4] [`setL1BaseFeeEstimate`][o4]`(price)`          | Set the L1 basefee estimate directly, bypassing the autoregression                               |
-| [![](../assets/e.png)][os5] [`setL1BaseFeeEstimateInertia`][o5]`(inertia)` | Set how slowly ArbOS updates its estimate of the L1 basefee                                      |
-| [![](../assets/e.png)][os6] [`setL2GasPrice`][o6]`(price)`                 | Set the L2 gas price directly, bypassing the pool calculus                                       |
-| [![](../assets/e.png)][os7] [`setMinimumGasPrice`][o7]`(price)`            | Set the minimum gas price needed for a transaction to succeed                                    |
-| [![](../assets/e.png)][os8] [`setSpeedLimit`][o8]`(limit)`                 | Set the computational speed limit for the chain                                                  |
-| [![](../assets/e.png)][os9] [`setGasPoolSeconds`][o9]`(seconds)`           | Set the number of seconds worth of the speed limit the gas pool contains                         |
-| [![](../assets/e.png)][os10] [`setGasPoolTarget`][o10]`(target)`           | Set the target fullness in bips the pricing model will try to keep the pool at                   |
-| [![](../assets/e.png)][os11] [`setGasPoolWeight`][o11]`(weight)`           | Set the extent in bips to which the pricing model favors filling the pool over increasing speeds |
-| [![](../assets/e.png)][os12] [`setRateEstimateInertia`][o12]`(inertia)`    | Set how slowly ArbOS updates its estimate the amount of gas being burnt per second               |
-| [![](../assets/e.png)][os13] [`setMaxTxGasLimit`][o13]`(limit)`            | Set the maximum size a tx (and block) can be                                                     |
-| [![](../assets/e.png)][os14] [`getNetworkFeeAccount`][o14]`()`             | Get the network fee collector                                                                    |
-| [![](../assets/e.png)][os15] [`setNetworkFeeAccount`][o15]`(account)`      | Set the network fee collector                                                                    |
+| Methods                                                       |                                                                                           |
+| :------------------------------------------------------------ | :---------------------------------------------------------------------------------------- |
+| [`addChainOwner`][o0]`(newOwner)`                             | Adds account as a chain owner                                                             |
+| [`removeChainOwner`][o1]`(addr)`                              | Removes account from the list of chain owners                                             |
+| [`isChainOwner`][o2]`(addr)`                                  | Sees if account is a chain owner                                                          |
+| [`getAllChainOwners`][o3]`()`                                 | Retrieves the list of chain owners                                                        |
+| [`setL1BaseFeeEstimateInertia`][o4]`(inertia)`                | Sets how slowly ArbOS updates its estimate of the L1 basefee                              |
+| [`setL2BaseFee`][o5]`(priceInWei)`                            | Sets the L2 gas price directly, bypassing the pool calculus                               |
+| [`setMinimumL2BaseFee`][o6]`(priceInWei)`                     | Sets the minimum base fee needed for a transaction to succeed                             |
+| [`setSpeedLimit`][o7]`(limit)`                                | Sets the computational speed limit for the chain                                          |
+| [`setMaxTxGasLimit`][o8]`(limit)`                             | Sets the maximum size a tx (and block) can be                                             |
+| [`setL2GasPricingInertia`][o9]`(sec)`                         | Sets the L2 gas pricing inertia                                                           |
+| [`setL2GasBacklogTolerance`][o10]`(sec)`                      | Sets the the L2 gas backlog tolerance                                                     |
+| [`getNetworkFeeAccount`][o11]`()`                             | Gets the network fee collector                                                            |
+| [`getInfraFeeAccount`][o12]`()`                               | Gets the infrastructure fee collector                                                     |
+| [`setNetworkFeeAccount`][o13]`(newNetworkFeeAccount)`         | Sets the network fee collector to the new network fee account                             |
+| [`setInfraFeeAccount`][o14]`(newNetworkFeeAccount)`           | Sets the infra fee collector to the new network fee account                               |
+| [`scheduleArbOSUpgrade`][o15]`(newVersion, timestamp)`        | Schedules and ArbOS upgrade to the requested version at the requested timestamp           |
+| [`setL1PricingEquilibrationUnits`][o16]`(equilibrationUnits)` | Sets the L1 price equilibration units                                                     |
+| [`setL1PricingInertia`][o17]`(inertia)`                       | Sets how slowly ArbOS updates its estimate of the L1 price                                |
+| [`setL1PricingRewardRecipient`][o18]`(recipient)`             | Sets the recipient of the l1 pricing rewards                                              |
+| [`setL1PricingRewardRate`][o19]`(weiPerUnit)`                 | Sets the L1 pricing rewards rate                                                          |
+| [`setL1PricePerUnit`][o20]`(pricePerUnit)`                    | Sets the L1 price per unit                                                                |
+| [`setPerBatchGasCharge`][o21]`(cost)`                         | Sets the cost per batch to charge                                                         |
+| [`setAmortizedCostCapBips`][o22]`(cap)`                       | Sets the amortized cost cap bips                                                          |
+| [`releaseL1PricerSurplusFunds`][o23]`(maxWeiToRelease)`       | Releases the L1Pricer surplus funds                                                       |
 
-[o0]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/precompiles/ArbOwner.go#L24
-[o1]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/precompiles/ArbOwner.go#L29
-[o2]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/precompiles/ArbOwner.go#L38
-[o3]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/precompiles/ArbOwner.go#L43
-[o4]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/precompiles/ArbOwner.go#L48
-[o5]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/precompiles/ArbOwner.go#L53
-[o6]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/precompiles/ArbOwner.go#L58
-[o7]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/precompiles/ArbOwner.go#L63
-[o8]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/precompiles/ArbOwner.go#L68
-[o9]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/precompiles/ArbOwner.go#L73
-[o10]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/precompiles/ArbOwner.go#L78
-[o11]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/precompiles/ArbOwner.go#L83
-[o12]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/precompiles/ArbOwner.go#L88
-[o13]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/precompiles/ArbOwner.go#L93
-[o14]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/precompiles/ArbOwner.go#L98
-[o15]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/precompiles/ArbOwner.go#L103
-[os0]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbOwner.sol#L30
-[os1]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbOwner.sol#L33
-[os2]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbOwner.sol#L36
-[os3]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbOwner.sol#L39
-[os4]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbOwner.sol#L42
-[os5]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbOwner.sol#L45
-[os6]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbOwner.sol#L48
-[os7]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbOwner.sol#L51
-[os8]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbOwner.sol#L54
-[os9]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbOwner.sol#L57
-[os10]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbOwner.sol#L60
-[os11]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbOwner.sol#L63
-[os12]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbOwner.sol#L66
-[os13]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbOwner.sol#L69
-[os14]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbOwner.sol#L72
-[os15]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbOwner.sol#L75
+[o0]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L30
+[o1]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L35
+[o2]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L44
+[o3]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L49
+[o4]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L54
+[o5]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L59
+[o6]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L64
+[o7]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L69
+[o8]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L74
+[o9]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L79
+[o10]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L84
+[o11]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L89
+[o12]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L94
+[o13]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L99
+[o14]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L104
+[o15]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L109
+[o16]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L113
+[o17]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L117
+[o18]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L121
+[o19]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L125
+[o20]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L129
+[o21]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L133
+[o22]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L137
+[o23]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/ArbOwner.go#L141
 
-| Events                                                 |                                                           |
-| :----------------------------------------------------- | :-------------------------------------------------------- |
-| [![](../assets/e.png)][oes0] [`OwnerActs`][oe0] &nbsp; | Emitted when a successful call is made to this precompile |
+| Events             |                                                           |
+| :----------------- | :-------------------------------------------------------- |
+| [`OwnerActs`][oe0] | Emitted when a successful call is made to this precompile |
 
-[oe0]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/precompiles/wrapper.go#L105
-[oes0]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbOwner.sol#L78
+[oe0]: https://github.com/OffchainLabs/nitro/blob/v2.0.13/precompiles/wrapper.go#L106
 
-# ArbOwnerPublic
+## ArbOwnerPublic
 
 [ArbOwnerPublic][arbownerpublic_link] provides non-owners with info about the current chain owners.
 
@@ -351,7 +352,7 @@ Most of Arbitrum Classic's owner methods have been removed since they no longer 
 [ops1]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbOwnerPublic.sol#L28
 [ops2]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbOwnerPublic.sol#L31
 
-# ArbRetryableTx
+## ArbRetryableTx
 
 [ArbRetryableTx][arbretryabletx_link] provides methods for managing retryables. The model has been adjusted for Nitro, most notably in terms of how retry transactions are scheduled. For more information on retryables, please see [the retryable documentation](arbos#Retryables).
 
@@ -394,7 +395,7 @@ Most of Arbitrum Classic's owner methods have been removed since they no longer 
 [rtes3]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbRetryableTx.sol#L81
 [old_event_link]: https://github.com/OffchainLabs/arb-os/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/arb_os/arbretryable.mini#L90
 
-# ArbStatistics
+## ArbStatistics
 
 [ArbStatistics][arbstatistics_link] provides statistics about the chain as of just before the Nitro upgrade. In Arbitrum Classic, this was how a user would get info such as the total number of accounts, but there are better ways to get that info in Nitro.
 
@@ -405,7 +406,7 @@ Most of Arbitrum Classic's owner methods have been removed since they no longer 
 [st0]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/precompiles/ArbStatistics.go#L19
 [sts0]: https://github.com/OffchainLabs/nitro/blob/3f504c57fba8ddf0759b7a55b4108e0bf5a078b3/solgen/src/precompiles/ArbStatistics.sol#L32
 
-# ArbSys
+## ArbSys
 
 [ArbSys][arbsys_link] provides system-level functionality for interacting with L1 and understanding the call stack.
 

--- a/arbitrum-docs/for-devs/troubleshooting-building.md
+++ b/arbitrum-docs/for-devs/troubleshooting-building.md
@@ -1,4 +1,6 @@
-# Troubleshooting: BUIDling on Arbitrum
+---
+title: "Troubleshooting: Building Arbitrum dApps"
+---
 
 import FaqPartial, {toc as FAQTOC} from '../partials/\_troubleshooting-building-partial.md';
 

--- a/arbitrum-docs/for-users/troubleshooting-users.md
+++ b/arbitrum-docs/for-users/troubleshooting-users.md
@@ -1,4 +1,6 @@
-# Troubleshooting: Using Arbitrum
+---
+title: "Troubleshooting: Bridge funds using the Arbitrum Bridge"
+---
 
 import FaqPartial, {toc as FAQTOC} from '../partials/\_troubleshooting-bridging-partial.md';
 

--- a/arbitrum-docs/getting-started-users.mdx
+++ b/arbitrum-docs/getting-started-users.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Quickstart: Bridge Funds Using the Arbitrum Bridge"
+title: "Quickstart: Bridge funds using the Arbitrum Bridge"
 description: "Learn how to use Arbitrum's Bridge to transfer ETH/ tokens between Ethereum's L1 and Arbitrum's L2 chains."
 author: mahsamoosavi
 ---

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -174,7 +174,7 @@ const sidebars = {
     },
     {
       type: "doc",
-      label: "Troubleshooting",
+      label: "Troubleshooting: Building dApps",
       id: "for-devs/troubleshooting-building"
     },
     /*
@@ -224,7 +224,7 @@ const sidebars = {
     },
     {
       type: "doc",
-      label: "Troubleshooting",
+      label: "Troubleshooting: Bridge tokens",
       id: "for-users/troubleshooting-users"
     },
   ],


### PR DESCRIPTION
- Align Troubleshooting pages' titles and menu entries: [Preview 1](https://nitro-docs-git-titles-and-anchors-cleanup-offchain-labs.vercel.app/for-devs/troubleshooting-building), [Preview 2](https://nitro-docs-git-titles-and-anchors-cleanup-offchain-labs.vercel.app/for-users/troubleshooting-users)
- Align case on the title of Quickstart for bridging: [Preview](https://nitro-docs-git-titles-and-anchors-cleanup-offchain-labs.vercel.app/getting-started-users)
- Fix precompiles titles anchors: [Preview](https://nitro-docs-git-titles-and-anchors-cleanup-offchain-labs.vercel.app/arbos/precompiles)
- Review ArbOwner links: [Preview](https://nitro-docs-git-titles-and-anchors-cleanup-offchain-labs.vercel.app/arbos/precompiles#arbowner)