### PR TITLE
Add support for variables

### DIFF
--- a/arbitrum-docs/node-running/running-a-classic-node.mdx
+++ b/arbitrum-docs/node-running/running-a-classic-node.mdx
@@ -22,7 +22,7 @@ on pre-Nitro blocks.
 
 ### Required Artifacts
 
-- Latest Docker Image: offchainlabs/arb-node:v1.4.5-e97c1a4
+- Latest Docker Image: <code>@latestClassicNodeImage@</code>
 - Latest classic snapshot for Arbitrum One: https://snapshot.arbitrum.io/mainnet/db.tar
 
 ### Required parameters
@@ -42,7 +42,7 @@ on pre-Nitro blocks.
 - When running docker image, an external volume should be mounted to persist the database across restarts. The mount point should be `/home/user/.arbitrum/mainnet`.
   - Here is an example of how to run arb-node for mainnet (only good for archive requests on pre-Nitro blocks, so probably want to enable archive as well):
   ```shell
-  docker run --rm -it  -v /some/local/dir/arbitrum-mainnet/:/home/user/.arbitrum/mainnet -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 offchainlabs/arb-node:v1.4.5-e97c1a4 --l1.url=https://l1-node:8545 --node.chain-id=42161 --l2.disable-upstream
+  docker run --rm -it  -v /some/local/dir/arbitrum-mainnet/:/home/user/.arbitrum/mainnet -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 @latestClassicNodeImage@ --l1.url=https://l1-node:8545 --node.chain-id=42161 --l2.disable-upstream
   ```
 
 ### Note on permissions

--- a/arbitrum-docs/node-running/running-a-feed-relay.mdx
+++ b/arbitrum-docs/node-running/running-a-feed-relay.mdx
@@ -4,11 +4,11 @@ When running more than one node, you want to run a single feed relay per datacen
 
 - Here is an example of how to run the feed relay for Arbitrum One:
   ```shell
-  docker run --rm -it  -p 0.0.0.0:9642:9642 --entrypoint relay offchainlabs/nitro-node:v2.0.14-2baa834 --node.feed.output.addr=0.0.0.0 --node.feed.input.url=wss://arb1.arbitrum.io/feed --l2.chain-id=42161
+  docker run --rm -it  -p 0.0.0.0:9642:9642 --entrypoint relay @latestNitroNodeImage@ --node.feed.output.addr=0.0.0.0 --node.feed.input.url=wss://arb1.arbitrum.io/feed --l2.chain-id=42161
   ```
 - Here is an example of how to run nitro-node for Arbitrum One with custom relay:
   ```shell
-  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 offchainlabs/nitro-node:v2.0.14-2baa834 --l1.url=https://l1-mainnet-node:8545 --l2.chain-id=42161 --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=* --node.feed.input.url=ws://local-relay-address:9642
+  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 @latestNitroNodeImage@ --l1.url=https://l1-mainnet-node:8545 --l2.chain-id=42161 --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=* --node.feed.input.url=ws://local-relay-address:9642
   ```
 
 

--- a/arbitrum-docs/node-running/running-a-node.md
+++ b/arbitrum-docs/node-running/running-a-node.md
@@ -21,7 +21,7 @@ content-type: quickstart
 
 ### Required Artifacts
 
-- Latest Docker Image: `offchainlabs/nitro-node:v2.0.14-2baa834`
+- Latest Docker Image: <code>@latestNitroNodeImage@</code>
 
 - Arbitrum One Nitro Genesis Database Snapshot
 
@@ -58,7 +58,7 @@ content-type: quickstart
   - Note that is important that `/some/local/dir/arbitrum` already exists, otherwise the directory might be created with `root` as owner, and the docker container won't be able to write to it
 
   ```shell
-  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 offchainlabs/nitro-node:v2.0.14-2baa834 --l1.url https://l1-node:8545 --l2.chain-id=<L2ChainId> --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=*
+  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 @latestNitroNodeImage@ --l1.url https://l1-node:8545 --l2.chain-id=<L2ChainId> --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=*
   ```
 
   - Note that if you are running L1 node on localhost, you may need to add `--network host` right after `docker run` to use docker host-based networking

--- a/arbitrum-docs/node-running/running-a-validator.mdx
+++ b/arbitrum-docs/node-running/running-a-validator.mdx
@@ -25,7 +25,7 @@ Here we describe different types of validators and provide instructions on how t
 - Running a validator in `Watchtower` mode is the same as running a Nitro node with `--node.staker.enable --node.staker.strategy=Watchtower`
 - Here is an example of how to run a watchtower validator for Arbitrum One:
   ```shell
-  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum offchainlabs/nitro-node:v2.0.14-2baa834 --l1.url=https://l1-mainnet-node:8545 --l2.chain-id=42161 --node.staker.enable --node.staker.strategy=Watchtower
+  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum @latestNitroNodeImage@ --l1.url=https://l1-mainnet-node:8545 --l2.chain-id=42161 --node.staker.enable --node.staker.strategy=Watchtower
   ```
 - If a deviation is detected, a validator in Watchtower mode will log an error containing the string `found incorrect assertion in watchtower mode`
 - To verify validator is working, this log line shows the wallet is setup correctly:
@@ -43,7 +43,7 @@ Here we describe different types of validators and provide instructions on how t
 - All other validators require a funded wallet to immediately post stake, as well as additional funds that will be spent at regular intervals
 - Here is an example of how to tell Nitro to create validator wallet for Arbitrum One and exit:
   ```shell
-  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum offchainlabs/nitro-node:v2.0.14-2baa834 --l1.url=https://l1-mainnet-node:8545 --l2.chain-id=42161 --node.staker.enable --l1.wallet.only-create-key --l1.wallet.password="SOME SECURE PASSWORD"
+  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum @latestNitroNodeImage@ --l1.url=https://l1-mainnet-node:8545 --l2.chain-id=42161 --node.staker.enable --l1.wallet.only-create-key --l1.wallet.password="SOME SECURE PASSWORD"
   ```
 - Wallet file will be created under the mounted directory inside the `arb1/wallet/` directory for Arb1, or `nova/wallet/` directory for Nova. Be sure to backup the wallet, it will be the only way to withdraw stake when desired
 
@@ -54,7 +54,7 @@ Here we describe different types of validators and provide instructions on how t
 - If a defensive validator detects a deviation, it will log `bringing defensive validator online because of incorrect assertion`, and wait for funds to be added to wallet so stake can be posted and a dispute created
 - Here is an example of how to run a whitelisted defensive validator for Arbitrum One:
   ```shell
-  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum offchainlabs/nitro-node:v2.0.14-2baa834 --l1.url=https://l1-mainnet-node:8545 --l2.chain-id=42161 --node.staker.enable --node.staker.strategy=Defensive --l1.wallet.password="SOME SECURE PASSWORD"
+  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum @latestNitroNodeImage@ --l1.url=https://l1-mainnet-node:8545 --l2.chain-id=42161 --node.staker.enable --node.staker.strategy=Defensive --l1.wallet.password="SOME SECURE PASSWORD"
   ```
 - To verify validator is working, this log line shows the wallet is setup correctly:
   ```shell

--- a/arbitrum-docs/node-running/running-an-archive-node.mdx
+++ b/arbitrum-docs/node-running/running-an-archive-node.mdx
@@ -35,8 +35,8 @@ The minimum storage requirements will change over time as the Nitro chain grows 
 2. **CPU:** 4+ core CPU
 3. **Storage:** Minimum 2TB SSD (make sure it is extendable)
 4. **Docker images:** We'll specify these in the below commands; you don't need to manually download them.
-   - Latest Docker image for **Arbitrum One**: `offchainlabs/nitro-node:v2.0.14-2baa834`
-   - Latest Docker image for **Arbitrum Classic**: `offchainlabs/arb-node:v1.4.5-e97c1a4`
+   - Latest Docker image for **Arbitrum One**: <code>@latestNitroNodeImage@</code>
+   - Latest Docker image for **Arbitrum Classic**: <code>@latestClassicNodeImage@</code>
 5. **Database snapshots:**
    - Arbitrum One Nitro genesis database snapshot
      - Use the parameter `--init.url="https://snapshot.arbitrum.io/mainnet/nitro.tar"` on first startup to initialize the Nitro database
@@ -79,15 +79,15 @@ To run both Arbitrum One and Arbitrum Classic in archive mode, follow one of the
 
 - **Arbitrum One archive node**: <!-- todo: when should I choose the first one over the second one? what do they do differently? -->
   ```shell
-  docker run --rm -it -v /some/local/dir/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 offchainlabs/nitro-node:v2.0.14-2baa834 --l1.url https://l1-node:8545 --l2.chain-id= --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=* --node.caching.archive
+  docker run --rm -it -v /some/local/dir/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 @latestNitroNodeImage@ --l1.url https://l1-node:8545 --l2.chain-id= --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=* --node.caching.archive
   ```
 - **Arbitrum One archive node**:
   ```shell
-  docker run --rm -it -v /some/local/dir/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 offchainlabs/nitro-node:v2.0.11-8e786ec --l1.url https://l1-node:8545 --l2.chain-id=42161 --node.rpc.classic-redirect=<classic node RPC> --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=* --node.caching.archive
+  docker run --rm -it -v /some/local/dir/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 @latestNitroNodeImage@ --l1.url https://l1-node:8545 --l2.chain-id=42161 --node.rpc.classic-redirect=<classic node RPC> --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=* --node.caching.archive
   ```
 - **Arbitrum Classic archive node**:
   ```shell
-  docker run --rm -it -v /some/local/dir/arbitrum-mainnet/:/home/user/.arbitrum/mainnet -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 offchainlabs/arb-node:v1.4.5-e97c1a4 --l1.url=https://l1-node:8545/ --node.chain-id=42161 --l2.disable-upstream --node.cache.allow-slow-lookup --core.checkpoint-gas-frequency=156250000
+  docker run --rm -it -v /some/local/dir/arbitrum-mainnet/:/home/user/.arbitrum/mainnet -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 @latestClassicNodeImage@ --l1.url=https://l1-node:8545/ --node.chain-id=42161 --l2.disable-upstream --node.cache.allow-slow-lookup --core.checkpoint-gas-frequency=156250000
   ```
 
 Note that the above commands both map to port `8547` on their hosts. If you want to run both on the same host, you should edit those mapping to different ports, and specify your Classic node RPC url as `<classic node RPC>` in your Nitro start command. To verify the connection health of your node(s), see [Docker network between containers - Docker Networking Example](https://www.middlewareinventory.com/blog/docker-network-example/).

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -3,6 +3,7 @@
 
 const lightCodeTheme = require("prism-react-renderer/themes/github");
 const darkCodeTheme = require("prism-react-renderer/themes/dracula");
+const variableInjector = require('./src/remark/variable-injector');
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -49,6 +50,14 @@ const config = {
             );
           },
           showLastUpdateTime: true,
+          remarkPlugins: [
+            [
+              variableInjector,
+              {
+                replacements: require("./static/globalVars.js")
+              }
+            ]
+          ]
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css')

--- a/website/src/remark/variable-injector.js
+++ b/website/src/remark/variable-injector.js
@@ -1,0 +1,57 @@
+// Based on https://github.com/facebook/docusaurus/issues/395
+// For future reference, we can virtually use any pattern to match agains variables,
+// but there's a limitation for handling text enclosed between single backticks (`) or triple backticks (```)
+// Docusaurus formats the code enclosed in backticks to apply certain styles to some characters
+// (to highlight instructions, operators, ...)
+// When using those characters as part of the pattern, they will not match and the variable will not be
+// injected.
+// These characters are: [, {, (, |
+// Here are some valid patterns
+//    ^FOO => /\^([a-zA-Z0-9_-]+)/g
+//    ::FOO => /\:\:([a-zA-Z0-9_-]+)/g
+//    @ FOO @ => /\@\s*([a-zA-Z0-9_-]+)\s*\@/g
+//    :: FOO :: => /\:\:\s*([a-zA-Z0-9_-]+)\s*\:\:/g
+
+const visit = require('unist-util-visit');
+
+const plugin = (options) => {
+  const transformer = async (ast) => {
+    visit(ast, ['text', 'code', 'link'], (node) => {
+      // Replace all occurrences of [[ varName ]] with the value of varName
+      let value;
+      switch(node.type) {
+        case "link":
+          value = node.url;
+          break;
+        
+        case "text":
+        case "code":
+          value = node.value;
+          break;
+      }
+
+      value = value.replace(/\@\s*([a-zA-Z0-9_-]+)\s*\@/g, (match, varName) => {
+        return options.replacements[varName] || match;
+      });
+
+      switch (node.type) {
+        case "link":
+          node.url = value;
+          break;
+
+        case "text":
+        case "code":
+          node.value = value;
+          break;
+      }
+
+      /*
+      node.value = node.value.replace(/\{\{\s*([a-zA-Z0-9_-]+)\s*\}\}/g, (match, varName) => {
+        return options.replacements[varName] || match;
+      }); */
+    });
+  };
+  return transformer;
+};
+
+module.exports = plugin;

--- a/website/static/globalVars.js
+++ b/website/static/globalVars.js
@@ -1,0 +1,6 @@
+const globalVars = {
+    latestNitroNodeImage: 'offchainlabs/nitro-node:v2.0.14-2baa834',
+    latestClassicNodeImage: 'offchainlabs/arb-node:v1.4.5-e97c1a4',
+}
+
+module.exports = globalVars;


### PR DESCRIPTION
Attempt to add support for variables within the docs. This PR presents the basic structure and a use case: node images

Current behavior is:
- Any text, code or URL (in link tags) enclosed in @ characters can be replaced by the correspondent variable (e.g. @latestNitroVersion@)
- Variables are kept in `website/static/globalVars.js`

There are some limitations for this support:
- We can use other pattern, but if we want to support injecting variables in backticks enclosed texts, we can't use the following characters: [, {, (, |, &, = (probably some more). These characters are handled differently by docusaurus when converting those texts to "code" tags, to support syntax highlighting.
- Variables inside single backticks are not detected, but those can be replaced by < code> HTML tags (the behavior is the same)