### PR TITLE
Add NodeJS installation to build instructions + details to docker

### DIFF
--- a/arbitrum-docs/node-running/build-nitro-locally.md
+++ b/arbitrum-docs/node-running/build-nitro-locally.md
@@ -20,7 +20,6 @@ This how-to is based on [debian-11.6.0-arm64](https://cdimage.debian.org/debian-
   ln -s /usr/bin/wasm-ld-13 /usr/local/bin/wasm-ld
   ```
 
-
 ### 2. Configure Nitro
 
   ```bash
@@ -29,8 +28,16 @@ This how-to is based on [debian-11.6.0-arm64](https://cdimage.debian.org/debian-
   git submodule update --init --recursive --force
   ```
 
+### 3. Configure Node [16.19](https://github.com/nvm-sh/nvm)
 
-### 3. Configure Rust [1.66.1](https://www.rust-lang.org/tools/install)
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+source "$HOME/.bashrc"
+nvm install 16.19
+nvm use 16.19
+```
+
+### 4. Configure Rust [1.66.1](https://www.rust-lang.org/tools/install)
 
   ```bash
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
@@ -42,7 +49,7 @@ This how-to is based on [debian-11.6.0-arm64](https://cdimage.debian.org/debian-
   cargo install cbindgen
   ```
 
-### 4. Configure [Docker](https://docs.docker.com/engine/install/debian/)
+### 5. Configure [Docker](https://docs.docker.com/engine/install/debian/)
 
   ```bash
   apt-get remove docker docker-engine docker.io containerd runc
@@ -50,25 +57,27 @@ This how-to is based on [debian-11.6.0-arm64](https://cdimage.debian.org/debian-
   apt-get install ca-certificates curl gnupg
   mkdir -m 0755 -p /etc/apt/keyrings
   curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  chmod a+r /etc/apt/keyrings/docker.gpg
   echo \
     "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
     "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
     tee /etc/apt/sources.list.d/docker.list > /dev/null
   apt-get update
   apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  service docker start
   ```
 
-### 5. Configure Go [1.19.5](https://github.com/moovweb/gvm)
+### 6. Configure Go [1.19.5](https://github.com/moovweb/gvm)
 
   ```bash
   bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)
-  source /root/.gvm/scripts/gvm
+  source "$HOME/.gvm/scripts/gvm"
   apt-get install bison
   gvm install go1.19.5
   gvm use 1.19.5 --default
   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.2
   ```
-### 6. Start build
+### 7. Start build
 
   ```bash
   make


### PR DESCRIPTION
Added:

- Section for installation of NVM (Node Version Manager) and NodeJS v16.19 (latest compatible version with nitro)
- Two details in docker installation
- Added use of `$HOME` instead of `/root` in gvm section

Tested on Debian distro (default Debian WSL image)

[Preview is here](https://nitro-docs-git-add-notes-to-build-node-page-offchain-labs.vercel.app/node-running/build-nitro-locally)