### PR TITLE
Improve testnets FAQs

### DIFF
--- a/arbitrum-docs/partials/_troubleshooting-building-partial.md
+++ b/arbitrum-docs/partials/_troubleshooting-building-partial.md
@@ -150,16 +150,16 @@ Once upon a time, Arbitrum developers were required to download supplemental pac
 ### What is a testnet or a devnet? {#what-is-a-testnet-or-a-devnet}
 <p>Testnets (or devnets) primarily serve developers who want to test out the applications they're building without having to use any real mainnet funds.</p>
 
-<p>Arbitrum testnets have the same full feature-set as the mainnet networks. They are also "true" L2s that run on top of public testnet Layer 1s, using their underlying networks for security and settlement.</p>
+<p>Arbitrum's Nitro Goerli Rollup testnet has the same full feature-set as the mainnet networks. It is also a "true" L2 that runs on top of the Goerli testnet (L1), using it for security and settlement.</p>
 
-<p>Users can bridge any asset from the underlying testnet L1 into an Arbitrum testnet (and back!), using the official <a href="https://bridge.arbitrum.io">bridge</a>.</p>
+<p>Users can bridge any asset from the Goerli testnet (L1) into the Nitro Goerli Rollup testnet (and back!), using the official <a href="https://bridge.arbitrum.io">bridge</a>.</p>
 
 <p></p>
 
 
 
 ### Is there any testnet available on Arbitrum? {#is-there-any-testnet-available-on-arbitrum}
-<p>Yes, there's a Goerli Rollup Testnet (421613) that uses the Nitro rollup tech stack, running on top of Ethereum Goerli. You can find more information <a href="https://developer.arbitrum.io/public-chains">here</a>.</p>
+<p>Yes, there's a Goerli Rollup testnet (421613) that uses the Nitro rollup tech stack, running on top of Ethereum Goerli. You can find more information <a href="https://developer.arbitrum.io/public-chains">here</a>.</p>
 
 <p></p>
 

--- a/arbitrum-docs/partials/_troubleshooting-building-partial.md
+++ b/arbitrum-docs/partials/_troubleshooting-building-partial.md
@@ -147,7 +147,18 @@ Once upon a time, Arbitrum developers were required to download supplemental pac
 
 
 
-### Is there any testnet or devnet available on Arbitrum? {#is-there-any-testnet-or-devnet-available-on-arbitrum}
+### What is a testnet or a devnet? {#what-is-a-testnet-or-a-devnet}
+<p>Testnets (or devnets) primarily serve developers who want to test out the applications they're building without having to use any real mainnet funds.</p>
+
+<p>Arbitrum testnets have the same full feature-set as the mainnet networks. They are also "true" L2s that run on top of public testnet Layer 1s, using their underlying networks for security and settlement.</p>
+
+<p>Users can bridge any asset from the underlying testnet L1 into an Arbitrum testnet (and back!), using the official <a href="https://bridge.arbitrum.io">bridge</a>.</p>
+
+<p></p>
+
+
+
+### Is there any testnet available on Arbitrum? {#is-there-any-testnet-available-on-arbitrum}
 <p>Yes, there's a Goerli Rollup Testnet (421613) that uses the Nitro rollup tech stack, running on top of Ethereum Goerli. You can find more information <a href="https://developer.arbitrum.io/public-chains">here</a>.</p>
 
 <p></p>


### PR DESCRIPTION
When using the bridge connected to Goerli, a question pops up "What is Nitro testnet" that sends the user to an outdated FAQ in the support portal.
This PR adds an FAQ to Arbitrum's docs that answers that question better than the one present today.

- FAQ in support portal => https://consensys.zendesk.com/hc/en-us/articles/7277996058395
- Current FAQ => https://developer.arbitrum.io/for-devs/troubleshooting-building#is-there-any-testnet-or-devnet-available-on-arbitrum
- New FAQ => https://nitro-docs-git-improve-testnets-faqs-offchain-labs.vercel.app/for-devs/troubleshooting-building#what-is-a-testnet-or-a-devnet