### PR TITLE
Fix nitro genesis block number

### DIFF
--- a/arbitrum-docs/node-running/running-an-archive-node.mdx
+++ b/arbitrum-docs/node-running/running-an-archive-node.mdx
@@ -11,7 +11,7 @@ Note that **most users won't need to configure an archive node**. This type of n
 
 ### Before we begin
 
-Before the Nitro upgrade happened, Arbitrum One was running on the Classic stack for about one year (before block height 2207817). Although the Nitro chain uses the latest snapshot of the Classic chain's state as its genesis state (see [state migration](../migration/state-migration.mdx)), **the Nitro stack can't serve archive requests for pre-Nitro blocks**.
+Before the Nitro upgrade happened, Arbitrum One was running on the Classic stack for about one year (before block height 22207817). Although the Nitro chain uses the latest snapshot of the Classic chain's state as its genesis state (see [state migration](../migration/state-migration.mdx)), **the Nitro stack can't serve archive requests for pre-Nitro blocks**.
 
 Running an Arbitrum One **full node** in **archive mode** lets you access both pre-Nitro and post-Nitro blocks, but it requires you to run **both Classic and Nitro nodes** together. You may not need to do this, depending on your use case:
 


### PR DESCRIPTION
Fix the nitro genesis block number in the `how to run an archive node` page.