### PR TITLE
Improve local feed relay info

### DIFF
--- a/arbitrum-docs/node-running/how-tos/read-sequencer-feed.md
+++ b/arbitrum-docs/node-running/how-tos/read-sequencer-feed.md
@@ -8,7 +8,7 @@ todos:
   - Align on what we want to treat as proper nouns vs common nouns
 ---
 
-Running an Arbitrum relay locally as a Feed Relay lets you subscribe to the Sequencer feed for real-time data as the Sequencer accepts and orders transactions off-chain. 
+[Running an Arbitrum relay locally as a feed relay](/node-running/how-tos/running-a-feed-relay.mdx) lets you subscribe to the sequencer feed for real-time data as the sequencer accepts and orders transactions off-chain. 
 
 When connected to websocket port `9642` of the local relay, you'll receive feed data that looks something like this:
 

--- a/arbitrum-docs/node-running/how-tos/read-sequencer-feed.md
+++ b/arbitrum-docs/node-running/how-tos/read-sequencer-feed.md
@@ -8,7 +8,7 @@ todos:
   - Align on what we want to treat as proper nouns vs common nouns
 ---
 
-[Running an Arbitrum relay locally as a feed relay](/node-running/how-tos/running-a-feed-relay.mdx) lets you subscribe to the sequencer feed for real-time data as the sequencer accepts and orders transactions off-chain. 
+[Running an Arbitrum relay locally as a feed relay](/node-running/how-tos/running-a-feed-relay.mdx) lets you subscribe to an uncompressed sequencer feed for real-time data as the sequencer accepts and orders transactions off-chain.
 
 When connected to websocket port `9642` of the local relay, you'll receive feed data that looks something like this:
 

--- a/arbitrum-docs/node-running/how-tos/running-a-feed-relay.mdx
+++ b/arbitrum-docs/node-running/how-tos/running-a-feed-relay.mdx
@@ -4,7 +4,11 @@ description: Learn how to run an Arbitrum feed relay on your local machine.
 content-type: how-to
 ---
 
-When running more than one node, you want to run a single feed relay per datacenter, which will reduce ingress fees and improve stability. The feed relay is in the same docker image.
+⚠️ Feed endpoints will soon require compression with a custom dictionary. It is strongly suggested to run a local feed relay to connect to it, which won't require compression.
+
+⚠️ When running more than one node, it is strongly suggested to run a single feed relay per datacenter, which will reduce ingress fees and improve stability.
+
+The feed relay is in the same docker image as the Nitro node.
 
 - Here is an example of how to run the feed relay for Arbitrum One:
   ```shell

--- a/arbitrum-docs/node-running/how-tos/running-a-feed-relay.mdx
+++ b/arbitrum-docs/node-running/how-tos/running-a-feed-relay.mdx
@@ -4,9 +4,9 @@ description: Learn how to run an Arbitrum feed relay on your local machine.
 content-type: how-to
 ---
 
-⚠️ Feed endpoints will soon require compression with a custom dictionary. It is strongly suggested to run a local feed relay to connect to it, which won't require compression.
+⚠️ If running a single node, there is no need to run a feed relay. When running more that one node, it is strongly suggested to run a single feed relay per datacenter, which will reduce ingress fees and improve stability.
 
-⚠️ When running more than one node, it is strongly suggested to run a single feed relay per datacenter, which will reduce ingress fees and improve stability.
+⚠️ Feed endpoints will soon require compression with a custom dictionary, so if connecting to feed with anything other than a standard node, it is strongly suggested to run a local feed relay which will provide an uncompressed feed by default.
 
 The feed relay is in the same docker image as the Nitro node.
 

--- a/arbitrum-docs/node-running/running-a-node.md
+++ b/arbitrum-docs/node-running/running-a-node.md
@@ -95,7 +95,8 @@ content-type: quickstart
 - `--node.caching.archive`
   - Retain past block state
 - `--node.feed.input.url=<feed address>`
-  - Defaults to `wss://<chainName>.arbitrum.io/feed`. If running more than a couple nodes, you will want to provide one feed relay per datacenter, see further instructions below
+  - Defaults to `wss://<chainName>.arbitrum.io/feed`.
+  - ⚠️ When running more than one node, it is strongly suggested to provide one feed relay per datacenter. See further instructions in [How to run a feed relay](/node-running/how-tos/running-a-feed-relay.mdx).
 - `--node.forwarding-target=<sequencer RPC>`
   - Defaults to appropriate L2 Sequencer RPC depending on L1 and L2 chain IDs provided
 - `--node.rpc.evm-timeout`


### PR DESCRIPTION
Improve information regarding local feed relay for nodes.

- [How to run a feed relay](https://nitro-docs-git-improve-feed-relay-information-offchain-labs.vercel.app/node-running/how-tos/running-a-feed-relay)
- [How to read the Sequencer feed](https://nitro-docs-git-improve-feed-relay-information-offchain-labs.vercel.app/node-running/how-tos/read-sequencer-feed)
- [Quickstart: Run a full node (Nitro)](https://nitro-docs-git-improve-feed-relay-information-offchain-labs.vercel.app/node-running/running-a-node)