### PR TITLE
Local build fix

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -239,6 +239,7 @@ const config = {
 const isRunningLocally = process.env.NODE_ENV === 'development';
 const isRunningOnWindows = process.platform === 'win32';
 if (isRunningLocally && isRunningOnWindows) {
+  // removes the arbitrum-sdk docs plugin
   config.plugins = [
     require.resolve("docusaurus-plugin-fathom"),
     require.resolve("docusaurus-lunr-search"),

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -65,6 +65,20 @@ const config = {
       }),
     ],
   ],
+  plugins: [
+    // See below - this gets modified if you're running locally on windows
+    [
+      "@docusaurus/plugin-content-docs",
+      {
+        id: "arbitrum-sdk",
+        path: "../arbitrum-sdk/docs",
+        routeBasePath: "sdk",
+        // ... other options
+      },
+    ],
+    require.resolve("docusaurus-plugin-fathom"),
+    require.resolve("docusaurus-lunr-search"),
+  ],
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
@@ -217,23 +231,15 @@ const config = {
     }),
 };
 
-const isRunningLocally = process.env.NODE_ENV === 'development';
 
-if (!isRunningLocally) {
+// HACK
+// this was originally included above
+// it broke local builds on Windows, not sure why yet. Works fine on Mac
+// `generate_sdk_docs` runs fine, no difference in outputs between environments, so it's not easy to debug - low pri
+const isRunningLocally = process.env.NODE_ENV === 'development';
+const isRunningOnWindows = process.platform === 'win32';
+if (isRunningLocally && isRunningOnWindows) {
   config.plugins = [
-    // HACK
-    // this was originally included above
-    // it broke local builds on Windows, not sure why yet. Works fine on Mac
-    // `generate_sdk_docs` runs fine, no difference in outputs between environments, so it's not easy to debug - low pri
-    [
-      "@docusaurus/plugin-content-docs",
-      {
-        id: "arbitrum-sdk",
-        path: "../arbitrum-sdk/docs",
-        routeBasePath: "sdk",
-        // ... other options
-      },
-    ],
     require.resolve("docusaurus-plugin-fathom"),
     require.resolve("docusaurus-lunr-search"),
   ];

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -65,23 +65,6 @@ const config = {
       }),
     ],
   ],
-  plugins: [
-    // todo: this breaks local builds on Windows
-    // could detect env and auto-disable when local + windows so I don't need to manually disable / remember to re-enable;
-    // ideally would be able to get `arbitrum-sdk/docs` generating on windows
-    // oddly `generate_sdk_docs` runs fine, just not seeing the docs folder appear. need to investigate
-    [
-      "@docusaurus/plugin-content-docs",
-      {
-        id: "arbitrum-sdk",
-        path: "../arbitrum-sdk/docs",
-        routeBasePath: "sdk",
-        // ... other options
-      },
-    ],
-    require.resolve("docusaurus-plugin-fathom"),
-    require.resolve("docusaurus-lunr-search"),
-  ],
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
@@ -233,5 +216,27 @@ const config = {
       }
     }),
 };
+
+const isRunningLocally = process.env.NODE_ENV === 'development';
+
+if (!isRunningLocally) {
+  config.plugins = [
+    // HACK
+    // this was originally included above
+    // it broke local builds on Windows, not sure why yet. Works fine on Mac
+    // `generate_sdk_docs` runs fine, no difference in outputs between environments, so it's not easy to debug - low pri
+    [
+      "@docusaurus/plugin-content-docs",
+      {
+        id: "arbitrum-sdk",
+        path: "../arbitrum-sdk/docs",
+        routeBasePath: "sdk",
+        // ... other options
+      },
+    ],
+    require.resolve("docusaurus-plugin-fathom"),
+    require.resolve("docusaurus-lunr-search"),
+  ];
+}
 
 module.exports = config;

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -239,11 +239,12 @@ const config = {
 const isRunningLocally = process.env.NODE_ENV === 'development';
 const isRunningOnWindows = process.platform === 'win32';
 if (isRunningLocally && isRunningOnWindows) {
-  // removes the arbitrum-sdk docs plugin
-  config.plugins = [
-    require.resolve("docusaurus-plugin-fathom"),
-    require.resolve("docusaurus-lunr-search"),
-  ];
+  config.plugins = config.plugins.filter(plugin => {
+    if (Array.isArray(plugin) && plugin[0] === "@docusaurus/plugin-content-docs") {
+      return false;  // remove the offending plugin config
+    }
+    return true;  // keep everything else
+  });
 }
 
 module.exports = config;

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -66,7 +66,7 @@ const config = {
     ],
   ],
   plugins: [
-    // See below - this gets modified if you're running locally on windows
+    // See below hack - this gets modified if you're running locally on windows
     [
       "@docusaurus/plugin-content-docs",
       {


### PR DESCRIPTION
 - When building docs locally on Win10/Win11, builds fail
 - Builds don't fail when building locally on MacOS
 - I was able to isolate the issue to the `arbitrum-sdk` plugin configuration in `docusaurus.config.js` - commenting this out gets builds working on Win-local
 - commenting out code / adding `docusaurus.config.js` to `.gitignore` isn't clean and requires constant "remembering"; this hack solves the problem in a way that keeps Windows contributors unblocked without having to think about this (sdk gen still works locally & remotely; ci/cd isn't impacted)