### PR TITLE
docs: patch snapshot link

### DIFF
--- a/arbitrum-docs/node-running/running-a-node.md
+++ b/arbitrum-docs/node-running/running-a-node.md
@@ -33,7 +33,7 @@ content-type: quickstart
 
 - Other chains do not have classic blocks, and do not require an initial genesis database
 
-- Snapshot list: "https://snapshot.arbitrum.foundation/index.html"
+- Snapshot list: "[https://snapshot.arbitrum.foundation/index.html](https://snapshot.arbitrum.foundation/index.html)"
 
 ### Required parameter
 


### PR DESCRIPTION
There is `%22` in the snapshot link, I fixed link in this PR.

<img width="1369" alt="image" src="https://github.com/OffchainLabs/arbitrum-docs/assets/10494397/cc4c90dc-2096-4c5b-9d66-f4fab33182e6">
