### PR TITLE
Change RPC endpoints and providers section

### DIFF
--- a/arbitrum-docs/devs-how-tos/bridge-tokens/how-to-bridge-tokens-custom-generic.mdx
+++ b/arbitrum-docs/devs-how-tos/bridge-tokens/how-to-bridge-tokens-custom-generic.mdx
@@ -381,4 +381,4 @@ Yes, if your token has a standard ERC20 counterpart on L2, you can go through th
 
 1. [Concept page: Token Bridge](/asset-bridging.mdx)
 2. [Arbitrum SDK](https://github.com/OffchainLabs/arbitrum-sdk)
-3. [Token bridge contract addresses](/useful-addresses.mdx)
+3. [Token bridge contract addresses](/for-devs/useful-addresses.mdx)

--- a/arbitrum-docs/devs-how-tos/bridge-tokens/how-to-bridge-tokens-standard.mdx
+++ b/arbitrum-docs/devs-how-tos/bridge-tokens/how-to-bridge-tokens-standard.mdx
@@ -97,7 +97,7 @@ Now, here’s an explanation of the contracts and methods that need to be called
 - When bridging from Ethereum (L1) to Arbitrum (L2), you’ll need to interact with the `L1GatewayRouter` contract, by calling the `outboundTransferCustomRefund` method. This router contract will relay your request to the appropriate gateway contract, in this case, the `L1ERC20Gateway` contract. To get the address of the gateway contract that’s going to be used, you can call the `getGateway` function in the `L1GatewayRouter` contract.
 - When bridging from Arbitrum (L2) to Ethereum (L1), you’ll need to interact with the `L2GatewayRouter` contract, by calling the `outBoundTransfer` method. This router contract will relay your request to the appropriate gateway contract, in this case, the `L2ERC20Gateway` contract. To get the address of the gateway contract that’s going to be used, you can call the `getGateway` function in the `L2GatewayRouter` contract.
 
-You can find the addresses of the contracts involved in the process in [this page](/useful-addresses.mdx#token-bridge).
+You can find the addresses of the contracts involved in the process in [this page](/for-devs/useful-addresses.mdx#token-bridge).
 
 ## Step 3: Approve token allowance for the gateway contract
 
@@ -235,4 +235,4 @@ After finishing this process, you’ll now have a counterpart token contract aut
 
 1. [Concept page: Token Bridge](/asset-bridging.mdx)
 2. [Arbitrum SDK](https://github.com/OffchainLabs/arbitrum-sdk)
-3. [Token bridge contract addresses](/useful-addresses.mdx)
+3. [Token bridge contract addresses](/for-devs/useful-addresses.mdx)

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/overview.mdx
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/overview.mdx
@@ -8,8 +8,8 @@ content-type: overview
 
 Each of the following pages contains resources and tools that will help you build your decentralized apps (dApps) on Arbitrum: 
 
-- [Arbitrum chains and smart contract addresses](../useful-addresses.mdx)
-- [RPC providers / node infrastructure](../../node-running/node-providers.mdx)
+- [RPC endpoints and providers](../../node-running/node-providers.mdx)
+- [Smart contract addresses](../useful-addresses.mdx)
 - [Development frameworks](./development-frameworks)
 - [Web3 libraries and tools](./web3-libraries-tools)
 - [Monitoring tools and block explorers](./monitoring-tools-block-explorers)

--- a/arbitrum-docs/for-devs/useful-addresses.mdx
+++ b/arbitrum-docs/for-devs/useful-addresses.mdx
@@ -1,24 +1,14 @@
 ---
-title: "Arbitrum chains and smart contract addresses"
-sidebar_label: Arbitrum chains and smart contract addresses
-description: Information about Arbitrum chains and smart contract addresses of the protocol.
+title: "Smart contract addresses"
+sidebar_label: Smart contract addresses
+description: Information about Arbitrum smart contract addresses of the protocol.
 reader-audience: developers who want to build on Ethereum/Arbitrum
 content-type: overview
 ---
 
 import { AddressExplorerLink as AEL } from '@site/src/components/AddressExplorerLink'
 
-The following information may be useful to those building on Arbitrum. We list the different [Arbitrum chains](/for-devs/concepts/public-chains.mdx) available along with information to interact with them, as well as addresses of the smart contracts related to the protocol, the token bridge and precompiles of the different Arbitrum chains.
-
-## Arbitrum chains information
-
-| Name                      | RPC Url(s)                            | Chain ID | Block explorer             | Underlying L1 | Tech stack | Sequencer feed URL                   |
-| ------------------------- | ------------------------------------- | -------- | -------------------------- | ------------- | ---------- | ------------------------------------ |
-| Arbitrum One              | https://arb1.arbitrum.io/rpc          | 42161    | https://arbiscan.io/       | Ethereum      | Nitro      | wss://arb1.arbitrum.io/feed          |
-| Arbitrum Nova             | https://nova.arbitrum.io/rpc          | 42170    | https://nova.arbiscan.io/  | Ethereum      | AnyTrust   | wss://nova.arbitrum.io/feed          |
-| Arbitrum Goerli (Testnet) | https://goerli-rollup.arbitrum.io/rpc | 421613   | https://goerli.arbiscan.io | Goerli        | Nitro      | wss://goerli-rollup.arbitrum.io/feed |
-
-🔉 Note: See our [Node Providers](/node-running/node-providers.mdx) page to get RPC access to fully-managed nodes hosted by a third party provider.
+The following information may be useful to those building on Arbitrum. We list the addresses of the smart contracts related to the protocol, the token bridge and precompiles of the different Arbitrum chains.
 
 ## Protocol smart contracts
 

--- a/arbitrum-docs/node-running/node-providers.mdx
+++ b/arbitrum-docs/node-running/node-providers.mdx
@@ -1,4 +1,10 @@
-# RPC providers / Node infrastructure
+---
+title: "RPC endpoints and providers"
+sidebar_label: "RPC endpoints and providers"
+description: Find available RPC endpoints and providers in the ecosystem
+reader_audience: developers who want to build on Arbitrum
+content_type: overview
+---
 
 :::info WANT TO BE LISTED HERE?
 
@@ -6,24 +12,38 @@ Complete [this form](https://docs.google.com/forms/d/e/1FAIpQLSdw0U-9LcLuih5TZ_Q
 
 :::
 
-To interact with public Arbitrum chains, you can rely on many of the same popular node providers that you are already using on Ethereum:
+## RPC endpoints
+
+This section provides an overview of the available public RPC endpoints for different Arbitrum chains and necessary details to interact with them.
+
+| Name                      | RPC Url(s)                            | Chain ID | Block explorer             | Underlying L1 | Tech stack | Sequencer feed URL                   |
+| ------------------------- | ------------------------------------- | -------- | -------------------------- | ------------- | ---------- | ------------------------------------ |
+| Arbitrum One              | https://arb1.arbitrum.io/rpc          | 42161    | https://arbiscan.io/       | Ethereum      | Nitro      | wss://arb1.arbitrum.io/feed          |
+| Arbitrum Nova             | https://nova.arbitrum.io/rpc          | 42170    | https://nova.arbiscan.io/  | Ethereum      | AnyTrust   | wss://nova.arbitrum.io/feed          |
+| Arbitrum Goerli (Testnet) | https://goerli-rollup.arbitrum.io/rpc | 421613   | https://goerli.arbiscan.io | Goerli        | Nitro      | wss://goerli-rollup.arbitrum.io/feed |
+
+🔉 Note: You can also find additional RPC endpoints available for Arbitrum chains in Chain Connect: [Arbitrum One](https://www.alchemy.com/chain-connect/chain/arbitrum-one), [Arbitrum Nova](https://www.alchemy.com/chain-connect/chain/arbitrum-nova) and [Arbitrum Goerli](https://www.alchemy.com/chain-connect/chain/arbitrum-goerli).
+
+## RPC providers
+
+Alternatively, to interact with public Arbitrum chains, you can rely on many of the same popular node providers that you are already using on Ethereum:
 
 | Provider                                                                    | Arb One? | Arb Nova? | Arb Goerli? |
 | --------------------------------------------------------------------------- | -------- | --------- | ----------- |
-| [Alchemy](https://docs.alchemy.com/reference/arbitrum-api-quickstart)       | ✅        |           |             |
-| [Ankr](https://www.ankr.com/docs/build-blockchain/chains/v1/arb-api)        | ✅        |           |             |
-| [Blast](https://blastapi.io/public-api/arbitrum)                            | ✅        | ✅         | ✅           |
-| [BlockPi](https://docs.blockpi.io/)                                         | ✅        |           |             |
-| [BlockVision](https://dashboard.blockvision.org/connect)                    | ✅        |           | ✅           |
-| [Chainbase](https://docs.chainbase.online/r/welcome-to-chainbase/readme)    | ✅        |           |             |
-| [Chainnodes](https://www.chainnodes.org/)                                   | ✅        |           |             |
-| [Chainstack](https://chainstack.com/build-better-with-arbitrum/)            | ✅        |           | ✅           |
-| [DataHub](https://datahub.figment.io/)                                      | ✅        |           |             |
-| [GetBlock](https://getblock.io/docs/)                                       | ✅        |           |             |
-| [Infura](https://docs.infura.io/infura/networks/arbitrum)                   | ✅        |           | ✅           |
-| [Lava](https://docs.lavanet.xyz/gateway-access)                             | ✅        | ✅         |             |
-| [Moralis](https://docs.moralis.io/reference/introduction)                   | ✅        |           |             |
-| [NodeReal](https://nodereal.io/meganode/api-marketplace/arbitrum-nitro-rpc) | ✅        | ✅         |             |
-| [NOWNodes](https://nownodes.io/nodes/arbitrum)                              | ✅        |           |             |
-| [Pocket Network](https://www.pokt.network/arbitrum-rpc-service)             | ✅        |           |             |
-| [Quicknode](https://www.quicknode.com/chains/arb)                           | ✅        | ✅         | ✅           |
+| [Alchemy](https://docs.alchemy.com/reference/arbitrum-api-quickstart)       | ✅       |           | ✅          |
+| [Ankr](https://www.ankr.com/docs/build-blockchain/chains/v1/arb-api)        | ✅       |           |             |
+| [Blast](https://blastapi.io/public-api/arbitrum)                            | ✅       | ✅        | ✅         |
+| [BlockPi](https://docs.blockpi.io/)                                         | ✅       |           |             |
+| [BlockVision](https://dashboard.blockvision.org/connect)                    | ✅       |           | ✅          |
+| [Chainbase](https://docs.chainbase.online/r/welcome-to-chainbase/readme)    | ✅       |           |             |
+| [Chainnodes](https://www.chainnodes.org/)                                   | ✅       |           |             |
+| [Chainstack](https://chainstack.com/build-better-with-arbitrum/)            | ✅       |           | ✅          |
+| [DataHub](https://datahub.figment.io/)                                      | ✅       |           |             |
+| [GetBlock](https://getblock.io/docs/)                                       | ✅       |           |             |
+| [Infura](https://docs.infura.io/infura/networks/arbitrum)                   | ✅       |           | ✅          |
+| [Lava](https://docs.lavanet.xyz/gateway-access)                             | ✅       | ✅        |             |
+| [Moralis](https://docs.moralis.io/reference/introduction)                   | ✅       |           |             |
+| [NodeReal](https://nodereal.io/meganode/api-marketplace/arbitrum-nitro-rpc) | ✅       | ✅        |             |
+| [NOWNodes](https://nownodes.io/nodes/arbitrum)                              | ✅       |           |             |
+| [Pocket Network](https://www.pokt.network/arbitrum-rpc-service)             | ✅       |           |             |
+| [Quicknode](https://www.quicknode.com/chains/arb)                           | ✅       | ✅        | ✅         |

--- a/arbitrum-docs/node-running/node-providers.mdx
+++ b/arbitrum-docs/node-running/node-providers.mdx
@@ -22,7 +22,13 @@ This section provides an overview of the available public RPC endpoints for diff
 | Arbitrum Nova             | https://nova.arbitrum.io/rpc          | 42170    | https://nova.arbiscan.io/  | Ethereum      | AnyTrust   | wss://nova.arbitrum.io/feed          |
 | Arbitrum Goerli (Testnet) | https://goerli-rollup.arbitrum.io/rpc | 421613   | https://goerli.arbiscan.io | Goerli        | Nitro      | wss://goerli-rollup.arbitrum.io/feed |
 
-🔉 Note: You can also find additional RPC endpoints available for Arbitrum chains in Chain Connect: [Arbitrum One](https://www.alchemy.com/chain-connect/chain/arbitrum-one), [Arbitrum Nova](https://www.alchemy.com/chain-connect/chain/arbitrum-nova) and [Arbitrum Goerli](https://www.alchemy.com/chain-connect/chain/arbitrum-goerli).
+
+:::info More RPC endpoints
+
+More Arbitrum chain RPC endpoints can be found in Chain Connect: [Arbitrum One](https://www.alchemy.com/chain-connect/chain/arbitrum-one), [Arbitrum Nova](https://www.alchemy.com/chain-connect/chain/arbitrum-nova) and [Arbitrum Goerli](https://www.alchemy.com/chain-connect/chain/arbitrum-goerli).
+
+:::
+
 
 ## RPC providers
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -162,13 +162,13 @@ const sidebars = {
         },
         {
           type: "doc",
-          label: "Arbitrum chains and smart contract addresses",
-          id: "for-devs/useful-addresses"
+          id: "node-running/node-providers",
+          label: "RPC endpoints and providers"
         },
         {
           type: "doc",
-          id: "node-running/node-providers",
-          label: "RPC providers / Node infrastructure"
+          label: "Smart contract addresses",
+          id: "for-devs/useful-addresses"
         },
         {
           type: "doc",


### PR DESCRIPTION
This PR changes the RPC section so it includes information of the public endpoints, as well as a link to the new Chain Connect resource by Alchemy.
Due to that change, it also adapts the title and location of the old "Arbitrum chains and smart contract addresses" page

It also fixes some broken links on the new How-tos for token bridging.

[Preview RPC endpoints and providers](https://nitro-docs-git-add-alchemy-rpc-eps-link-offchain-labs.vercel.app/node-running/node-providers)
[Preview Smart contract addresses](https://nitro-docs-git-add-alchemy-rpc-eps-link-offchain-labs.vercel.app/for-devs/useful-addresses)