### PR TITLE
Refactors the node running page

### DIFF
--- a/arbitrum-docs/node-running/gentle-introduction-run-node.md
+++ b/arbitrum-docs/node-running/gentle-introduction-run-node.md
@@ -12,7 +12,7 @@ In order to be able to _interact with_ or _build applications on_ any of the Arb
 
 Here, you can find resources that help you run different types of Arbitrum nodes:
 
-- Step-by-step instructions for running different Arbitrum nodes, including [full Nitro node](./running-a-node.md), [full Classic node](./how-tos/running-a-classic-node.mdx), [local dev node](./how-tos/local-dev-node.mdx), [feed relay](./how-tos/running-a-feed-relay.mdx), and [validator](./how-tos/running-a-validator.mdx)
+- Step-by-step instructions for running different Arbitrum nodes, including [full Nitro node](./how-tos/running-a-full-node.mdx), [full Classic node](./how-tos/running-a-classic-node.mdx), [local dev node](./how-tos/local-dev-node.mdx), [feed relay](./how-tos/running-a-feed-relay.mdx), and [validator](./how-tos/running-a-validator.mdx)
 - Step-by-step instructions for how to [read the sequencer feed](./how-tos/read-sequencer-feed.md), [build the Nitro locally](./how-tos/build-nitro-locally.md), and [run a DAS](../das/daserver-instructions.mdx)
 - [Troubleshooting page](./troubleshooting-running-nodes.md)
 - [Frequently asked questions](./faq.md)

--- a/arbitrum-docs/node-running/how-tos/running-a-full-node.mdx
+++ b/arbitrum-docs/node-running/how-tos/running-a-full-node.mdx
@@ -4,9 +4,9 @@ description: Learn how to run an Arbitrum node on your local machine.
 content-type: how-to
 ---
 
-⚠️ Note: There is no protocol level incentive to run an Arbitum full node. If you’re interested in accessing an Arbitrum chain, but you don’t want to set up your own node, see our [Node Providers](./node-providers.mdx) to get RPC access to fully-managed nodes hosted by a third party provider.
+⚠️ Note: There is no protocol level incentive to run an Arbitum full node. If you’re interested in accessing an Arbitrum chain, but you don’t want to set up your own node, see our [Node Providers](../node-providers.mdx) to get RPC access to fully-managed nodes hosted by a third party provider.
 
-### Minimum Hardware Configuration
+### Minimum hardware configuration
 
 - Followings specify the minimum hardware configuration required to setup a Nitro full node (not archival):
   - RAM: 4-8 GB
@@ -16,7 +16,7 @@ content-type: how-to
 
 ⚠️ Note: The minimum storage requirements will change over time as the Nitro chain grows. It is recommended to use more than the minimum requirements to run a robust full node.
 
-### Required Artifacts
+### Required artifacts
 
 - Latest Docker Image: <code>@latestNitroNodeImage@</code>
 
@@ -79,7 +79,7 @@ content-type: how-to
 ### Optional parameters
 
 - `--init.url=https://snapshot.arbitrum.io/mainnet/nitro.tar`
-  - URL to download genesis database from. Only needed when starting Arbitrum One without database. If you want to run an archive node, use the url in [running an archive node](./how-tos/running-an-archive-node.mdx).
+  - URL to download genesis database from. Only needed when starting Arbitrum One without database. If you want to run an archive node, use the url in [running an archive node](./running-an-archive-node.mdx).
 - `--node.rpc.classic-redirect=<classic node RPC>`
   - If set, will redirect archive requests for pre-nitro blocks to the designated RPC, which should be an Arbitrum Classic node with archive database. Only valid for Arbitrum One.
 - `--http.api`

--- a/arbitrum-docs/node-running/how-tos/running-a-full-node.mdx
+++ b/arbitrum-docs/node-running/how-tos/running-a-full-node.mdx
@@ -1,10 +1,7 @@
 ---
-title: "Quickstart: Run a full node (Nitro)"
+title: "How to run a full node (Nitro)"
 description: Learn how to run an Arbitrum node on your local machine.
-author-objective: build a quickstart that helps readers understand how to run an Arbitrum node, and why they might want to
-reader-audience: moderately-technical readers who are familiar with command lines, but not Ethereum / Arbitrum infrastructure
-reader-task: run a node with minimal effort and maximum understanding
-content-type: quickstart
+content-type: how-to
 ---
 
 ⚠️ Note: There is no protocol level incentive to run an Arbitum full node. If you’re interested in accessing an Arbitrum chain, but you don’t want to set up your own node, see our [Node Providers](./node-providers.mdx) to get RPC access to fully-managed nodes hosted by a third party provider.
@@ -86,7 +83,7 @@ content-type: quickstart
 - `--node.rpc.classic-redirect=<classic node RPC>`
   - If set, will redirect archive requests for pre-nitro blocks to the designated RPC, which should be an Arbitrum Classic node with archive database. Only valid for Arbitrum One.
 - `--http.api`
-  - APIs offered over the HTTP-RPC interface (default `net,web3,eth`)
+  - APIs offered over the HTTP-RPC interface (default `net,web3,eth,arb`)
   - Add `debug` to enable tracing
 - `--http.corsdomain`
   - Comma separated list of domains from which to accept cross origin requests (browser enforced)

--- a/arbitrum-docs/node-running/how-tos/running-an-archive-node.mdx
+++ b/arbitrum-docs/node-running/how-tos/running-an-archive-node.mdx
@@ -18,12 +18,12 @@ Running an Arbitrum One **full node** in **archive mode** lets you access both p
 | Use case                                                                         | Required node type(s)                                     | Docs                                                                        |
 | -------------------------------------------------------------------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------- |
 | Access the **Arbitrum network** without running your own node                    | Fully managed by third-parties, exposed via RPC endpoints | [Node Providers](../node-providers.mdx)                                     |
-| Run an **archive node** for **Arbitrum Goerli (testnet)** or **Arbitrum Nova**   | Full node (Nitro)                                         | [How to run a full node (Nitro)](../running-a-node.md)                      |
-| Send **post-Nitro** archive requests                                             | Full node (Nitro)                                         | [How to run a full node (Nitro)](../running-a-node.md)                      |
+| Run an **archive node** for **Arbitrum Goerli (testnet)** or **Arbitrum Nova**   | Full node (Nitro)                                         | [How to run a full node (Nitro)](./running-a-full-node.mdx)                                     |
+| Send **post-Nitro** archive requests                                             | Full node (Nitro)                                         | [How to run a full node (Nitro)](./running-a-full-node.mdx)                     |
 | Send **pre-Nitro** archive requests                                              | Full node (Classic)                                       | [How to run a full node (Classic, pre-Nitro)](./running-a-classic-node.mdx) |
 | Send **post-Nitro** _and_ **pre-Nitro** archive requests                         | Full node (Nitro) _and_ full node (Classic)               | That's what this how-to is for; you're in the right place.                  |
 
-### System requirements
+### System requirements 
 
 :::caution
 

--- a/arbitrum-docs/node-running/how-tos/running-an-archive-node.mdx
+++ b/arbitrum-docs/node-running/how-tos/running-an-archive-node.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'How to run an Archive node'
+title: 'How to run an archive node'
 description: Learn how to run an Arbitrum archive node on your local machine.
 author: jason-wanxt
 content-type: how-to
@@ -104,4 +104,4 @@ chmod -fR 777 /some/local/dir/arbitrum-mainnet
 
 ### Troubleshooting
 
-If you run into any issues, visit the [Node-running Troubleshooting guide](../troubleshooting-running-nodes).
+If you run into any issues, visit the [node-running troubleshooting guide](../troubleshooting-running-nodes).

--- a/arbitrum-docs/node-running/quickstart-running-a-node.md
+++ b/arbitrum-docs/node-running/quickstart-running-a-node.md
@@ -30,7 +30,7 @@ For a detailed instruction of how to run an Arbitrum full node , see [here](./ho
 
 While full nodes offer numerous advantages, there are situations where running an archive node may be more appropriate. Archive nodes store the complete history of the Arbitrum network, making them suitable for users who require extensive historical data access or advanced analytical purposes. However, it's important to note that archive nodes are more resource-intensive, requiring significant storage capacity and computational power. For a detailed instruction of how to run an Arbitrum archive node , see [here](./how-tos/running-an-archive-node.mdx).
 
-### Considerations for running afeed relay
+### Considerations for running a feed relay
 
 If you are running a single node, there is no requirement to set up a feed relay. However, if you have multiple nodes, it is highly recommended to have a single feed relay per datacenter. This setup offers several advantages such as reducing ingress fees and enhancing stability within the network.
 

--- a/arbitrum-docs/node-running/quickstart-running-a-node.md
+++ b/arbitrum-docs/node-running/quickstart-running-a-node.md
@@ -26,7 +26,7 @@ When it comes to intercating with the Arbitrum network, users have the option to
 
 For a detailed instruction of how to run an Arbitrum full node , see [here](./how-tos/running-a-full-node.mdx).
 
-### Considerations for running an archive node
+### Considerations for running an Arbitrum archive node
 
 While full nodes offer numerous advantages, there are situations where running an archive node may be more appropriate. Archive nodes store the complete history of the Arbitrum network, making them suitable for users who require extensive historical data access or advanced analytical purposes. However, it's important to note that archive nodes are more resource-intensive, requiring significant storage capacity and computational power. For a detailed instruction of how to run an Arbitrum archive node , see [here](./how-tos/running-an-archive-node.mdx).
 

--- a/arbitrum-docs/node-running/quickstart-running-a-node.md
+++ b/arbitrum-docs/node-running/quickstart-running-a-node.md
@@ -1,0 +1,39 @@
+---
+title: "Quickstart: Run different types of Arbitrum nodes"
+description: Learn more about what type of ARb node one needs to run.
+author-objective: Build a quickstart that helps readers understand why they might want to run a specific type of an Arbitrum node.
+reader-audience: Moderately-technical readers who are familiar with command lines, but not Ethereum / Arbitrum infrastructure
+reader-task: Run a node with minimal effort and maximum understanding
+content-type: quickstart
+---
+
+import PublicPreviewBannerPartial from '../partials/_public-preview-banner-partial.md'; 
+
+<PublicPreviewBannerPartial />
+
+This quickstart is for who users/developers who want to start running any type of Arbitrum nodes. It makes no assumptions about your prior experience with Ethereum, Arbitrum, or Solidity. Familiarity with command lime expected. 
+
+
+When it comes to ointercating with the Arbitrum network, users have the option to run either a full node or an archive node. There are distinct advantages to running an Arbitrum full node. In this quickstart, we will explore the reasons why a user may prefer to run a full node instead of an archive node. By understanding the benefits and trade-offs of each type of node, users can make an informed decision based on their specific requirements and objectives.
+
+### Considerations running an Arbitrum full node
+
+⚠️ Note: There is no protocol level incentive to run an Arbitum full node. If you’re interested in accessing an Arbitrum chain, but you don’t want to set up your own node, see our [Node Providers](./node-providers.mdx) to get RPC access to fully-managed nodes hosted by a third party provider.
+
+- Transaction validation and security: Running a full node allows users to independently validate transactions and verify the state of the Arbitrum blockchain. Users can have full confidence in the authenticity and integrity of the transactions they interact with.
+- Reduced trust requirements: By running a full node, users can interact with the Arbitrum network without relying on third-party services or infrastructure. This reduces the need to trust external entities and mitigates the risk of potential centralized failures or vulnerabilities.
+- Lower resource requirements: Compared to archive nodes, full nodes generally require fewer resources such as storage and computational power. This makes them more accessible to users with limited hardware capabilities or those operating on resource-constrained environments.
+
+For a detailed instruction of how to run an Arbitrum full node , see [here](./how-tos/running-a-full-node.mdx).
+
+### Considerations for running an Archive node
+
+While full nodes offer numerous advantages, there are situations where running an archive node may be more appropriate. Archive nodes store the complete history of the Arbitrum network, making them suitable for users who require extensive historical data access or advanced analytical purposes. However, it's important to note that archive nodes are more resource-intensive, requiring significant storage capacity and computational power. For a detailed instruction of how to run an Arbitrum archive node , see [here](./how-tos/running-an-archive-node.mdx).
+
+### Considerations for running afeed relay
+
+If you are running a single node, there is no requirement to set up a feed relay. However, if you have multiple nodes, it is highly recommended to have a single feed relay per datacenter. This setup offers several advantages such as reducing ingress fees and enhancing stability within the network.
+
+In the near future, feed endpoints will mandate compression using a custom dictionary. Therefore, if you plan to connect to a feed using anything other than a standard node, it is strongly advised to run a local feed relay. This will ensure that you have access to an uncompressed feed by default, maintaining optimal performance and compatibility.
+
+For a detailed instruction of how to run an Arbitrum full node , see [here](./how-tos/running-a-feed-relay.mdx).

--- a/arbitrum-docs/node-running/quickstart-running-a-node.md
+++ b/arbitrum-docs/node-running/quickstart-running-a-node.md
@@ -14,7 +14,7 @@ import PublicPreviewBannerPartial from '../partials/_public-preview-banner-parti
 This quickstart is for who users/developers who want to start running any type of Arbitrum nodes. It makes no assumptions about your prior experience with Ethereum, Arbitrum, or Solidity. Familiarity with command lime expected. 
 
 
-When it comes to ointercating with the Arbitrum network, users have the option to run either a full node or an archive node. There are distinct advantages to running an Arbitrum full node. In this quickstart, we will explore the reasons why a user may prefer to run a full node instead of an archive node. By understanding the benefits and trade-offs of each type of node, users can make an informed decision based on their specific requirements and objectives.
+When it comes to intercating with the Arbitrum network, users have the option to run either a full node or an archive node. There are distinct advantages to running an Arbitrum full node. In this quickstart, we will explore the reasons why a user may prefer to run a full node instead of an archive node. By understanding the benefits and trade-offs of each type of node, users can make an informed decision based on their specific requirements and objectives.
 
 ### Considerations running an Arbitrum full node
 
@@ -26,7 +26,7 @@ When it comes to ointercating with the Arbitrum network, users have the option t
 
 For a detailed instruction of how to run an Arbitrum full node , see [here](./how-tos/running-a-full-node.mdx).
 
-### Considerations for running an Archive node
+### Considerations for running an archive node
 
 While full nodes offer numerous advantages, there are situations where running an archive node may be more appropriate. Archive nodes store the complete history of the Arbitrum network, making them suitable for users who require extensive historical data access or advanced analytical purposes. However, it's important to note that archive nodes are more resource-intensive, requiring significant storage capacity and computational power. For a detailed instruction of how to run an Arbitrum archive node , see [here](./how-tos/running-an-archive-node.mdx).
 

--- a/arbitrum-docs/node-running/quickstart-running-a-node.md
+++ b/arbitrum-docs/node-running/quickstart-running-a-node.md
@@ -1,5 +1,5 @@
 ---
-title: "Quickstart: Run different types of Arbitrum nodes"
+title: "Quickstart: Run a node"
 description: Learn more about what type of ARb node one needs to run.
 author-objective: Build a quickstart that helps readers understand why they might want to run a specific type of an Arbitrum node.
 reader-audience: Moderately-technical readers who are familiar with command lines, but not Ethereum / Arbitrum infrastructure
@@ -10,9 +10,6 @@ content-type: quickstart
 import PublicPreviewBannerPartial from '../partials/_public-preview-banner-partial.md'; 
 
 <PublicPreviewBannerPartial />
-
-This quickstart is for who users/developers who want to start running any type of Arbitrum nodes. It makes no assumptions about your prior experience with Ethereum, Arbitrum, or Solidity. Familiarity with command lime expected. 
-
 
 When it comes to intercating with the Arbitrum network, users have the option to run either a full node or an archive node. There are distinct advantages to running an Arbitrum full node. In this quickstart, we will explore the reasons why a user may prefer to run a full node instead of an archive node. By understanding the benefits and trade-offs of each type of node, users can make an informed decision based on their specific requirements and objectives.
 

--- a/arbitrum-docs/node-running/troubleshooting-running-nodes.md
+++ b/arbitrum-docs/node-running/troubleshooting-running-nodes.md
@@ -56,16 +56,16 @@ If you're running into unexpected outputs or errors, the following checklist may
                             ]}>
                             <TabItem className="unclickable-element" value="label"></TabItem>
                             <TabItem value="arb-one-nitro">
-                                <p>The <a href='/node-running/running-a-node'>Quickstart: Run a full node (Nitro)</a> may address your issue.</p>
+                                <p>The <a href='/node-running/how-tos/running-a-full-node'>How to run a full node (Nitro)</a> may address your issue.</p>
                             </TabItem>
                             <TabItem value="arb-one-classic">
                                 <p><a href='/node-running/how-tos/running-a-classic-node'>How to run a full node (Classic, pre-Nitro)</a> may address your issue.</p>
                             </TabItem>
                             <TabItem value="arb-nova">
-                                <p>The <a href='/node-running/running-a-node'>Quickstart: Run a full node (Nitro)</a> may address your issue.</p>
+                                <p>The <a href='/node-running/how-tos/running-a-full-node'>How to run a full node (Nitro)</a> may address your issue.</p>
                             </TabItem>
                             <TabItem value="arb-goerli">
-                                <p>The <a href='/node-running/running-a-node'>Quickstart: Run a full node (Nitro)</a> may address your issue.</p>
+                                <p>The <a href='/node-running/how-tos/running-a-full-node'>How to run a full node (Nitro)</a> may address your issue.</p>
                             </TabItem>
                             <TabItem value="localhost">
                                 <p>The <a href='/node-running/how-tos/local-dev-node'>How to run a local dev node</a> may address your issue.</p>

--- a/arbitrum-docs/partials/_troubleshooting-building-partial.md
+++ b/arbitrum-docs/partials/_troubleshooting-building-partial.md
@@ -110,7 +110,7 @@ To let's find out which is custom error this signature represents, we can use th
 
 
 ### Why am I getting error "429 Too Many Requests" when using one of Offchain Labs' Public RPCs? {#why-am-i-getting-error-429-too-many-requests-when-using-one-of-offchain-labs-public-rpcs}
-<p>Offchain Labs offers public RPCs for free, but limits requests to prevent DOSing. Hitting the rate limit could come from your request frequency and/or the resources required to process the requests. If you are hitting our rate limit, we recommend <a href="https://developer.arbitrum.io/node-running/running-a-node">running your own node</a> or <a href="https://developer.arbitrum.io/node-running/node-providers">using a third party node provider</a>.</p>
+<p>Offchain Labs offers public RPCs for free, but limits requests to prevent DOSing. Hitting the rate limit could come from your request frequency and/or the resources required to process the requests. If you are hitting our rate limit, we recommend <a href="https://developer.arbitrum.io/node-running/how-tos/running-a-full-node">running your own node</a> or <a href="https://developer.arbitrum.io/node-running/node-providers">using a third party node provider</a>.</p>
 
 <p></p>
 

--- a/arbitrum-docs/partials/_troubleshooting-nodes-partial.md
+++ b/arbitrum-docs/partials/_troubleshooting-nodes-partial.md
@@ -65,9 +65,7 @@
 
 
 ### How can I verify that my node is syncing at a desirable speed? {#how-can-i-verify-that-my-node-is-syncing-at-a-desirable-speed}
-<p>Syncing speed can vary depending on multiple factors. You can find the minimum hardware requirements to run your node <a href="https://developer.arbitrum.io/node-running/running-a-node#minimum-hardware-configuration">in this page</a>. You should also verify your network and disk speed.</p>
-
-<p></p>
+<p>Syncing speed can vary depending on multiple factors. You can find the minimum hardware requirements to run your node <a href="https://developer.arbitrum.io/node-running/how-tos/running-a-full-node#minimum-hardware-configuration">in this page</a>. You should also verify your network and disk speed.</p>
 
 
 
@@ -124,7 +122,7 @@
 
 
 ### **What are the minimum hardware requirements to run a full node?** {#what-are-the-minimum-hardware-requirements-to-run-a-full-node}
-<p>You can see the minimum hardware configuration <a href="https://developer.arbitrum.io/node-running/running-a-node#minimum-hardware-configuration">in this section</a>.</p>
+<p>You can see the minimum hardware configuration <a href="https://developer.arbitrum.io/node-running/how-tos/running-a-full-node#minimum-hardware-configuration">in this section</a>.</p>
 
 <p></p>
 

--- a/arbitrum-docs/partials/_troubleshooting-nodes-partial.md
+++ b/arbitrum-docs/partials/_troubleshooting-nodes-partial.md
@@ -36,7 +36,7 @@
 
 
 ### How do I read messages from the Sequencer feed? {#how-do-i-read-messages-from-the-sequencer-feed}
-<p>Running an Arbitrum relay locally as a <a href="https://developer.offchainlabs.com/node-running/running-a-node#feed-relay">Feed Relay</a> lets you subscribe to the Sequencer feed for real-time data as the Sequencer accepts and orders transactions off-chain. Visit <a href='/node-running/how-tos/read-sequencer-feed'><em>How to read the sequencer feed</em></a> for a detailed how-to.</p>
+<p>Running an Arbitrum relay locally as a <a href="https://developer.offchainlabs.com/node-running/how-tos/running-a-full-node#feed-relay">Feed Relay</a> lets you subscribe to the Sequencer feed for real-time data as the Sequencer accepts and orders transactions off-chain. Visit <a href='/node-running/how-tos/read-sequencer-feed'><em>How to read the sequencer feed</em></a> for a detailed how-to.</p>
 
 <p></p>
 

--- a/arbitrum-docs/partials/_troubleshooting-nodes-partial.md
+++ b/arbitrum-docs/partials/_troubleshooting-nodes-partial.md
@@ -1,5 +1,5 @@
 ### How do I run a node? {#how-do-i-run-a-node}
-<p>See instructions <a href="https://developer.arbitrum.io/node-running/running-a-node">here</a>! </p>
+<p>See instructions <a href="https://developer.arbitrum.io/node-running/how-tos/running-a-full-node">here</a>! </p>
 
 <p></p>
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -116,7 +116,7 @@ const config = {
           },
           {
             type: "doc",
-            docId: "node-running/running-a-node",
+            docId: "node-running/quickstart-running-a-node",
             label: "Run a node",
             position: "left",
           },

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -238,14 +238,19 @@ const sidebars = {
     },
     {
       type: "doc",
-      id: "node-running/running-a-node",
-      label: "Quickstart: Run a full node (Nitro)"
+      id: "node-running/quickstart-running-a-node",
+      label: "Quickstart: Run Arbitrum nodes"
     },
     {
       type: "category",
       label: "How-to guides",
       collapsed: false,
       items: [
+        {
+          type: "doc",
+          id: "node-running/how-tos/running-a-full-node",
+          label: "Run a full node (Nitro)"
+        },
         {
           type: "doc",
           id: "node-running/how-tos/running-a-classic-node",

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -20,15 +20,15 @@ const oldPathToNewPath = {
   "/docs/anytrust": "/inside-anytrust",
   "/docs/node_providers": "/node-running/node-providers",
   "/docs/useful_addresses": "/for-devs/useful-addresses",
-  "/docs/running_node": "/node-running/running-a-node",
-  "/docs/running_nitro_node": "/node-running/running-a-node",
-  "/docs/running_goerli_nitro_node": "/node-running/running-a-node",
-  "/docs/running_rinkeby_nitro_node": "/node-running/running-a-node",
+  "/docs/running_node": "/node-running/how-tos/running-a-full-node",
+  "/docs/running_nitro_node": "/node-running/how-tos/running-a-full-node",
+  "/docs/running_goerli_nitro_node": "/node-running/how-tos/running-a-full-node",
+  "/docs/running_rinkeby_nitro_node": "/node-running/how-tos/running-a-full-node",
   "/docs/public_testnet": "/for-devs/concepts/public-chains",
   "/docs/public_nitro_testnet": "/for-devs/concepts/public-chains",
   "/docs/public_nitro_devnet": "/for-devs/concepts/public-chains",
   "/docs/developer_quickstart": "/",
-  "/docs/installation": "/node-running/running-a-node",
+  "/docs/installation": "/node-running/how-tos/running-a-full-node",
   "/docs/rollup_basics": "/intro",
   "/docs/tutorials": "/getting-started-devs",
   "/docs/security_considerations": "/arbitrum-ethereum-differences",
@@ -67,6 +67,7 @@ const oldPathToNewPath = {
   "/node-running/running-a-validator": "/node-running/how-tos/running-a-validator",
   "/node-running/read-sequencer-feed": "/node-running/how-tos/read-sequencer-feed",
   "/node-running/build-nitro-locally": "/node-running/how-tos/build-nitro-locally",
+  "node-running/running-a-node": "/node-running/how-tos/running-a-full-node",
 };
 
 const getNewPath = (_path) => {


### PR DESCRIPTION
Refactoring the node running section:
- Moving the body of the Quickstart page to the how-to
- Creating a new Quickstart page with an overview of when one wants to just run a full node, run archive/classic node, and  run a feed relay.
- Updating the links in the node FAQs
- A few edits on different sub-pages

[preview](https://nitro-docs-ozf1l67uj-offchain-labs.vercel.app/node-running/quickstart-running-a-node)