### PR TITLE
Add 1RPC to providers

### DIFF
--- a/arbitrum-docs/node-running/node-providers.mdx
+++ b/arbitrum-docs/node-running/node-providers.mdx
@@ -36,6 +36,7 @@ Alternatively, to interact with public Arbitrum chains, you can rely on many of 
 
 | Provider                                                                    | Arb One? | Arb Nova? | Arb Goerli? |
 | --------------------------------------------------------------------------- | -------- | --------- | ----------- |
+| [1RPC](https://docs.ata.network/1rpc/introduction/#supported-networks)      | ✅       |           |             |
 | [Alchemy](https://docs.alchemy.com/reference/arbitrum-api-quickstart)       | ✅       |           | ✅          |
 | [Ankr](https://www.ankr.com/docs/build-blockchain/chains/v1/arb-api)        | ✅       |           |             |
 | [Blast](https://blastapi.io/public-api/arbitrum)                            | ✅       | ✅        | ✅         |


### PR DESCRIPTION
Already in the [Portal](https://portal.arbitrum.io/one?categories=rpc)[https://portal.arbitrum.io/one?categories=rpc](https://portal.arbitrum.io/one?categories=rpc#nodeproviders).

Solves #340 

[Preview](https://nitro-docs-git-add-1rpc-to-providers-offchain-labs.vercel.app/node-running/node-providers)