### PR TITLE
Add Blockpi to Arb Nova providers

### DIFF
--- a/arbitrum-docs/node-running/node-providers.mdx
+++ b/arbitrum-docs/node-running/node-providers.mdx
@@ -40,7 +40,7 @@ Alternatively, to interact with public Arbitrum chains, you can rely on many of 
 | [Alchemy](https://docs.alchemy.com/reference/arbitrum-api-quickstart)       | ✅       |           | ✅          |
 | [Ankr](https://www.ankr.com/docs/build-blockchain/chains/v1/arb-api)        | ✅       |           |             |
 | [Blast](https://blastapi.io/public-api/arbitrum)                            | ✅       | ✅        | ✅         |
-| [BlockPi](https://docs.blockpi.io/)                                         | ✅       |           |             |
+| [BlockPi](https://docs.blockpi.io/)                                         | ✅       | ✅        |             |
 | [BlockVision](https://dashboard.blockvision.org/connect)                    | ✅       |           | ✅          |
 | [Chainbase](https://docs.chainbase.online/r/welcome-to-chainbase/readme)    | ✅       |           |             |
 | [Chainnodes](https://www.chainnodes.org/)                                   | ✅       |           |             |


### PR DESCRIPTION
Reference: #346 
[Preview](https://nitro-docs-git-add-blockpi-to-nova-offchain-labs.vercel.app/node-running/node-providers)