### PR TITLE
Remove list of validators and DAC members from the Dev Docs

### DIFF
--- a/arbitrum-docs/for-devs/concepts/public-chains.mdx
+++ b/arbitrum-docs/for-devs/concepts/public-chains.mdx
@@ -8,7 +8,7 @@ content-type: concept
 
 import { AddressExplorerLink as AEL } from '@site/src/components/AddressExplorerLink'
 
-Arbitrum chains are Layer 2 solutions built on top of the Ethereum blockchain, designed to increase scalability and reduce transaction costs. In this conceptual overview, we’ll learn about the different Arbitrum chains and how they relate to each other. We’ll describe the available Arbitrum production and testnet chains, their differences, and the technology stacks that these chains use. We will finally list the current validators in each chain, as well as the members of the data availability committee (DAC) in Arbitrum Nova.
+Arbitrum chains are Layer 2 solutions built on top of the Ethereum blockchain, designed to increase scalability and reduce transaction costs. In this conceptual overview, we’ll learn about the different Arbitrum chains and how they relate to each other. We’ll describe the available Arbitrum production and testnet chains, their differences, and the technology stacks that these chains use.
 
 ## What Arbitrum production chains are available?
 
@@ -49,57 +49,6 @@ AnyTrust is a variant of the Nitro technology stack that lowers costs by accepti
 ### Classic (deprecated)
 
 The Classic technology stack is the original version of Arbitrum. It has been deprecated and replaced by the Nitro technology stack.
-
-## Allowlisted validators
-
-These are the whitelisted validators for every public Arbitrum chain (more information in **["state of progressive decentralization"](https://docs.arbitrum.foundation/state-of-progressive-decentralization)**):
-
-#### Arbitrum One
-
-- <AEL address={"0x0fF813f6BD577c3D1cDbE435baC0621BE6aE34B4"} chainID={1} />
-- <AEL address={"0x54c0D3d6C101580dB3be8763A2aE2c6bb9dc840c"} chainID={1} />
-- <AEL address={"0x56D83349c2B8DCF74d7E92D5b6B33d0BADD52D78"} chainID={1} />
-- <AEL address={"0x610Aa279989F440820e14248BD3879B148717974"} chainID={1} />
-- <AEL address={"0x6Fb914de4653eC5592B7c15F4d9466Cbd03F2104"} chainID={1} />
-- <AEL address={"0x758C6bB08B3ea5889B5cddbdeF9A45b3a983c398"} chainID={1} />
-- <AEL address={"0x7CF3d537733F6Ba4183A833c9B021265716cE9d0"} chainID={1} />
-- <AEL address={"0x83215480dB2C6A7E56f9E99EF93AB9B36F8A3DD5"} chainID={1} />
-- <AEL address={"0xAB1A39332e934300eBCc57B5f95cA90631a347FF"} chainID={1} />
-- <AEL address={"0xB0CB1384e3f4a9a9b2447e39b05e10631E1D34B0"} chainID={1} />
-- <AEL address={"0xF8D3E1cF58386c92B27710C6a0D8A54c76BC6ab5"} chainID={1} />
-- <AEL address={"0xdDf2F71Ab206C0138A8eceEb54386567D5abF01E"} chainID={1} />
-- <AEL address={"0xf59caf75e8A4bFBA4e6e07aD86C7E498E4d2519b"} chainID={1} />
-
-#### Arbitrum Nova
-
-- <AEL address={"0x1732BE6738117e9d22A84181AF68C8d09Cd4FF23"} chainID={1} />
-- <AEL address={"0x24Ca61c31C7f9Af3ab104dB6B9A444F28e9071e3"} chainID={1} />
-- <AEL address={"0x3B0369CAD35d257793F51c28213a4Cf4001397AC"} chainID={1} />
-- <AEL address={"0x54c0D3d6C101580dB3be8763A2aE2c6bb9dc840c"} chainID={1} />
-- <AEL address={"0x57004b440Cc4eb2FEd8c4d1865FaC907F9150C76"} chainID={1} />
-- <AEL address={"0x658e8123722462F888b6fa01a7dbcEFe1D6DD709"} chainID={1} />
-- <AEL address={"0xDfB23DFE9De7dcC974467195C8B7D5cd21C9d7cB"} chainID={1} />
-- <AEL address={"0xE27d4Ed355e5273A3D4855c8e11BC4a8d3e39b87"} chainID={1} />
-- <AEL address={"0xB51EDdfc9A945e2B909905e4F242C4796Ac0C61d"} chainID={1} />
-
-#### Arbitrum Goerli (testnet)
-
-- <AEL address={"0x3EABe7e5e3fcDdFB8fb8c5972EB151bF4fddf2ce"} chainID={5} />
-- <AEL address={"0x9549263185294a7FB24bf357b0050252d3653C74"} chainID={5} />
-- <AEL address={"0xAa01D5570E932a13eF9a06677eaf97d56a33393f"} chainID={5} />
-- <AEL address={"0xe08339b8Da134f1e39876b7523586c4D2a4173d8"} chainID={5} />
-
-## Data Availability Committee members
-
-These are the members of the 6-of-7 data availability committee (DAC) in Arbitrum Nova:
-
-- Reddit, Inc.
-- ConsenSys Software Inc.
-- QuickNode, Inc.
-- P2P
-- Google Cloud
-- Offchain Labs, Inc.
-- Opensea Innovation Labs Private Limited
 
 ## Conclusion
 

--- a/arbitrum-docs/partials/_troubleshooting-bridging-partial.md
+++ b/arbitrum-docs/partials/_troubleshooting-bridging-partial.md
@@ -48,7 +48,7 @@
 
 
 ### Can I use a smart contract wallet in the bridge? {#can-i-use-a-smart-contract-wallet-in-the-bridge}
-<p>Support for Smart Contract Wallets is currently limited to token depositing and withdrawal. Keep in mind that when withdrawing funds, you won't be able to claim them on L1 using the <strong><a href="https://bridge.arbitrum.io">bridge</a></strong><strong> </strong>(unless you also control that address on L1). In that case, you can use the <strong><a href="https://retryable-dashboard.arbitrum.io/tx">cross-chain dashboard</a></strong> to claim your funds on L1.</p>
+<p>Support for Smart Contract Wallets is currently limited to token depositing and withdrawal. Keep in mind that when withdrawing funds, you won't be able to claim them on L1 using the <a href="https://bridge.arbitrum.io/">bridge</a> (unless you also control that address on L1). In that case, you can use the <a href="https://retryable-dashboard.arbitrum.io/tx">cross-chain dashboard</a> to claim your funds on L1.</p>
 
 <p>ETH deposits and withdrawals using a Smart Contract Wallet are currently not supported, but will soon be available.</p>
 

--- a/arbitrum-docs/partials/_troubleshooting-building-partial.md
+++ b/arbitrum-docs/partials/_troubleshooting-building-partial.md
@@ -152,7 +152,7 @@ Once upon a time, Arbitrum developers were required to download supplemental pac
 
 <p>Arbitrum Goerli testnet has the same full feature-set as the mainnet networks. It is also a "true" L2 that runs on top of the Goerli testnet (L1), using it for security and settlement.</p>
 
-<p>Users can bridge any asset from the Goerli testnet (L1) into the Arbitrum Goerli testnet (and back!), using the official <a href="https://bridge.arbitrum.io">bridge</a>.</p>
+<p>Users can bridge any asset from the Goerli testnet (L1) into the Arbitrum Goerli testnet (and back!), using the official <a href="https://bridge.arbitrum.io/">bridge</a>.</p>
 
 <p></p>
 

--- a/arbitrum-docs/partials/_troubleshooting-nodes-partial.md
+++ b/arbitrum-docs/partials/_troubleshooting-nodes-partial.md
@@ -8,7 +8,7 @@
 ### How  to verify the integrity of the Nitro database I currently have? {#how--to-verify-the-integrity-of-the-nitro-database-i-currently-have}
 <p>We have an accumulator hash on all messages, which means that a message can't be added to the database without the previous message being correct. </p>
 
-<p>To confirm that everything's working properly, you could just make sure that it's syncing and that the latest block is consistent with other Arbitrum nodes; e.g., you could check it against <a href="https://arbiscan.io">Arbiscan</a>  (note that Arbiscan's search field doesn't support searching by block hash).</p>
+<p>To confirm that everything's working properly, you could just make sure that it's syncing and that the latest block is consistent with other Arbitrum nodes; e.g., you could check it against <a href="https://arbiscan.io/">Arbiscan</a>  (note that Arbiscan's search field doesn't support searching by block hash).</p>
 
 <p></p>
 

--- a/arbitrum-docs/partials/_troubleshooting-users-partial.md
+++ b/arbitrum-docs/partials/_troubleshooting-users-partial.md
@@ -142,3 +142,17 @@ A week is expected to be more than enough time for validators to carry out an in
 
 
 
+### Where can I find a list of the current validators of the Arbitrum chains? {#where-can-i-find-a-list-of-the-current-validators-of-the-arbitrum-chains}
+<p>Validation on both Arbitrum One and Arbitrum Nova is currently allow-listed to a committee of public entities. You can see the list of validators <strong><a href="https://docs.arbitrum.foundation/state-of-progressive-decentralization#allowlisted-validators">here</a></strong>. Governance currently has the power to change this status.</p>
+
+<p></p>
+
+
+
+### Where can I find the current Data Availability Committee members? {#where-can-i-find-the-current-data-availability-committee-members}
+<p>The Arbitrum Nova chain has a 7-party DAC, whose members can be seen <strong><a href="https://docs.arbitrum.foundation/state-of-progressive-decentralization#data-availability-committee-members">here</a></strong>. Governance has the ability to remove or add members to the committee.</p>
+
+<p></p>
+
+
+


### PR DESCRIPTION
Validators and DAC members are now in the [foundation site](https://docs.arbitrum.foundation/state-of-progressive-decentralization#allowlisted-validators).

Also added 2 new FAQs (other FAQs were updated with minor changes)

- [Preview Arbitrum chains](https://nitro-docs-git-remove-validators-and-dac-offchain-labs.vercel.app/for-devs/concepts/public-chains)
- [Preview new FAQs](https://nitro-docs-git-remove-validators-and-dac-offchain-labs.vercel.app/learn-more/faq#where-can-i-find-a-list-of-the-current-validators-of-the-arbitrum-chains)