### PR TITLE
Add clarifications in the helper texts of the Troubleshooting run a node page

### DIFF
--- a/arbitrum-docs/node-running/troubleshooting-running-nodes.md
+++ b/arbitrum-docs/node-running/troubleshooting-running-nodes.md
@@ -153,9 +153,9 @@ import {GenerateTroubleshootingReportWidget} from '@site/src/components/Generate
 
 <div className='troubleshooting-report-area'>
     <p>Node startup command</p>
-    <textarea id="vn-cmd" rows="3" placeholder='Optional. Paste something like "{example command}" (or Docker config) here...'></textarea>
+    <textarea id="vn-cmd" rows="3" placeholder='Paste here the command you use to run your node: "docker run ..."'></textarea>
     <p>Unexpected output</p>
-    <span><strong>Tip:</strong> Paste the ~100 lines of output <strong>before and including</strong> the unexpected output you're asking about.</span>
+    <span><strong>Tip:</strong> Paste the ~100 lines of output <strong>before and including</strong> the unexpected output you're asking about. You can use the following command to get the logs: </span><code>docker logs --tail 100 YOUR_CONTAINER_ID</code>
     <textarea id="output" rows="3" placeholder='Paste your unexpected output here...'></textarea>
     <a id='generate-report' className='generate-report'>Generate troubleshooting report</a>
     <div id='generated-report' className='generated-report'>Complete the checklist above before generating...</div>

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -154,10 +154,10 @@
   --prysm-pink: var(--prysm-pink-light);
   --tab-gray: #aaa;
 }
-[data-theme="dark"] .dynamic-content-tabs .tabs__item:first-child {
+[data-theme="dark"] .dynamic-content-tabs .tabgroup-with-label .tabs__item:first-child {
   color: #eee;
 }
-[data-theme="dark"] .dynamic-content-tabs .tabs__item:first-child:hover {
+[data-theme="dark"] .dynamic-content-tabs .tabgroup-with-label .tabs__item:first-child:hover {
   background-color: transparent !important;
 }
 [data-theme="dark"] .troubleshooting-report-area > span {
@@ -598,6 +598,9 @@ article .markdown p > code {
   margin-top: 0;
   font-size: 13px;
   color: #333;
+}
+.troubleshooting-report-area > code {
+  font-size: 13px;
 }
 .troubleshooting-report-area > textarea {
   -ms-overflow-style: none;

--- a/website/src/css/custom.less
+++ b/website/src/css/custom.less
@@ -49,12 +49,14 @@
   --tab-gray: #aaa;
 
   .dynamic-content-tabs {
-    .tabs__item {
-      &:first-child {
-        color: #eee;
+    .tabgroup-with-label {
+      .tabs__item {
+        &:first-child {
+          color: #eee;
 
-        &:hover {
-          background-color: transparent !important;
+          &:hover {
+            background-color: transparent !important;
+          }
         }
       }
     }
@@ -622,6 +624,10 @@ article {
     margin-top: 0;
     font-size: 13px;
     color: #333;
+  }
+
+  > code {
+    font-size: 13px;
   }
 
   > textarea {


### PR DESCRIPTION
Some users have trouble finding the right commands to run to get all information needed for the report. Also fixes a small styling error in dark mode.

[Preview](https://nitro-docs-git-add-helpers-in-troubleshoot-ad75d8-offchain-labs.vercel.app/node-running/troubleshooting-running-nodes)