### PR TITLE
Add missing precompiles to addresses and order them like in All precompiles page

### DIFF
--- a/arbitrum-docs/for-devs/useful-addresses.mdx
+++ b/arbitrum-docs/for-devs/useful-addresses.mdx
@@ -97,16 +97,18 @@ The following precompiles are deployed on every L2 chain and always have the sam
 
 |                  | Address                                                                      |
 | ---------------- | ---------------------------------------------------------------------------- |
-| ArbSys           | <AEL address="0x0000000000000000000000000000000000000064" chainID={42161} /> |
-| ArbRetryableTx   | <AEL address="0x000000000000000000000000000000000000006E" chainID={42161} /> |
-| ArbGasInfo       | <AEL address="0x000000000000000000000000000000000000006C" chainID={42161} /> |
 | ArbAddressTable  | <AEL address="0x0000000000000000000000000000000000000066" chainID={42161} /> |
-| ArbStatistics    | <AEL address="0x000000000000000000000000000000000000006F" chainID={42161} /> |
-| NodeInterface    | <AEL address="0x00000000000000000000000000000000000000C8" chainID={42161} /> |
-| ArbBLS           | <AEL address="0x0000000000000000000000000000000000000067" chainID={42161} /> |
-| ArbInfo          | <AEL address="0x0000000000000000000000000000000000000065" chainID={42161} /> |
 | ArbAggregator    | <AEL address="0x000000000000000000000000000000000000006D" chainID={42161} /> |
+| ArbBLS           | <AEL address="0x0000000000000000000000000000000000000067" chainID={42161} /> |
 | ArbFunctionTable | <AEL address="0x0000000000000000000000000000000000000068" chainID={42161} /> |
+| ArbGasInfo       | <AEL address="0x000000000000000000000000000000000000006C" chainID={42161} /> |
+| ArbInfo          | <AEL address="0x0000000000000000000000000000000000000065" chainID={42161} /> |
+| ArbOwner         | <AEL address="0x0000000000000000000000000000000000000070" chainID={42161} /> |
+| ArbOwnerPublic   | <AEL address="0x000000000000000000000000000000000000006b" chainID={42161} /> |
+| ArbRetryableTx   | <AEL address="0x000000000000000000000000000000000000006E" chainID={42161} /> |
+| ArbStatistics    | <AEL address="0x000000000000000000000000000000000000006F" chainID={42161} /> |
+| ArbSys           | <AEL address="0x0000000000000000000000000000000000000064" chainID={42161} /> |
+| NodeInterface    | <AEL address="0x00000000000000000000000000000000000000C8" chainID={42161} /> |
 
 ## Misc
 


### PR DESCRIPTION
ArbOwner and ArbOwnerPublic were missing from the "Smart contract addresses" page. This PR adds them and also orders that table alphabetically, like the "All precompiles" page.

[Preview](https://nitro-docs-git-add-missing-precompile-offchain-labs.vercel.app/for-devs/useful-addresses#precompiles)