### PR TITLE
Remove "beta"

### DIFF
--- a/arbitrum-docs/getting-started-users.mdx
+++ b/arbitrum-docs/getting-started-users.mdx
@@ -8,7 +8,7 @@ import PublicPreviewBannerPartial from './partials/_public-preview-banner-partia
 
 <PublicPreviewBannerPartial />
 
-_**Note: before interacting with a mainnet chain, users should familiarize themselves with the risks; see [Mainnet Beta](mainnet-beta)**_.
+_**Note: before interacting with a mainnet chain, users should familiarize themselves with the risks; see [Mainnet risks](mainnet-risks)**_.
 
 #### 1- Get Some Native Currency
 

--- a/arbitrum-docs/mainnet-risks.mdx
+++ b/arbitrum-docs/mainnet-risks.mdx
@@ -1,9 +1,8 @@
 ---
 title: 'Arbitrum: Understanding the risks'
-description: "Understand the risks associated with cutting-edge software development"
+description: 'Understand the risks associated with cutting-edge software development'
 author: dzgoldman
 ---
-
 
 # Arbitrum: Understanding the risks
 

--- a/arbitrum-docs/mainnet-risks.mdx
+++ b/arbitrum-docs/mainnet-risks.mdx
@@ -1,17 +1,24 @@
-# Mainnet Beta: Understanding the Risks
+---
+title: 'Arbitrum: Understanding the risks'
+description: "Understand the risks associated with cutting-edge software development"
+author: dzgoldman
+---
+
+
+# Arbitrum: Understanding the risks
 
 Arbitrum One — the first permissionless Ethereum layer 2 rollup with full Ethereum smart contract functionality — is [live on mainnet](https://offchain.medium.com/mainnet-for-everyone-27ce0f67c85e) — as is [Nova](https://medium.com/offchainlabs/its-time-for-a-new-dawn-nova-is-open-to-the-public-a081df1e4ad2), our first [AnyTrust chain](./inside-anytrust.mdx); We're sure you're (almost) as excited as we are!
 Here are some risks you should know about before using the system:
 
-### State Of Progressive Decentralization
+### State Of progressive decentralization
 
 The Arbitrum DAO system is the owner of both the Arbitrum One and Arbitrum AnyTrust chains; see [“State of Progressive Decentralization”](https://docs.arbitrum.foundation/state-of-progressive-decentralization) for more.
 
-### General Words Of Caution: Software Bugs
+### General words of caution: Software bugs
 
 Offchain Labs’ [implementation](https://github.com/OffchainLabs/nitro) of the Arbitrum protocol has been carefully constructed, is perpetually being audited by several independent firms, and is continuously reviewed and tested following best engineering practices.
 That said, there remains a non-zero chance that our codebase contains some undiscovered vulnerabilities that put user funds at risk. Users should carefully factor this risk into their decision to use Arbitrum One and/or Arbitrum Nova, and in deciding how much of their value to entrust into the system. Note that Offchain Labs also sponsors a [multi-million dollar bug bounty program](https://immunefi.com/bounty/arbitrum/) to incentivize any party who funds such a critical bug to disclose it responsibly.
 
-### General Words of Caution: Scams
+### General words of caution: Scams
 
 Arbitrum, like Ethereum, is permissionless; on both platforms, anybody can deploy any smart contract code they want. Users should treat interacting with contracts on Arbitrum exactly as they do with Ethereum, i.e., they should only do so if they have good reason to trust that the application is secure.

--- a/arbitrum-docs/partials/_troubleshooting-users-partial.md
+++ b/arbitrum-docs/partials/_troubleshooting-users-partial.md
@@ -91,7 +91,7 @@
 
 <p>Which is to say — the more important thing than decentralizing the Sequencer, i.e., the thing you ought to care more about — is decentralizing the <em>Validators</em>.</p>
 
-<p>Arbitrum One's Validator set is currently allowlisted; overtime, the allowlist will grow and then be removed entirely. For more info see <a href="https://developer.arbitrum.io/mainnet-beta">"Mainnet Beta"</a>.</p>
+<p>Arbitrum One's Validator set is currently allowlisted; overtime, the allowlist will grow and then be removed entirely. For more info see <a href="https://developer.arbitrum.io/mainnet-risks">"Mainnet risks"</a>.</p>
 
 
 

--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,12 @@
         },
         {
             "source": "/docs/mainnet",
-            "destination": "/mainnet-beta",
+            "destination": "/mainnet-risks",
+            "permanent": false
+        },
+        {
+            "source": "/docs/mainnet-beta",
+            "destination": "/mainnet-risks",
             "permanent": false
         },
         {
@@ -237,7 +242,7 @@
         },
         {
             "source": "/faqs/beta-status",
-            "destination": "/mainnet-beta",
+            "destination": "/mainnet-risks",
             "permanent": false
         },
         {

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -496,8 +496,8 @@ const sidebars = {
     },
     {
       type: 'doc',
-      id: 'mainnet-beta',
-      label: 'Mainnet Beta status',
+      id: 'mainnet-risks',
+      label: 'Mainnet risks',
     },
     {
       type: 'link',


### PR DESCRIPTION
This PR:

 - Removes "beta" language from docs
 - Renames the "Mainnet beta" page title to "Mainnet risks"
 - Renames the `mainnet-beta` file to `mainnet-risks`
 - Configures vercel redirects accordingly
 - Updates links accordingly
 - Adds YAML frontmatter to `mainnet-risks` page
 - Applies formatting conventions to `mainnet-risks` page