### PR TITLE
Updates the docs for stylus

### DIFF
--- a/arbitrum-docs/for-devs/concepts/public-chains.mdx
+++ b/arbitrum-docs/for-devs/concepts/public-chains.mdx
@@ -30,8 +30,13 @@ Arbitrum Sepolia serves as a testnet chain replicating the capabilities of Arbit
 
 Arbitrum Goerli is a testnet chain that mirrors the functionality of the Arbitrum One mainnet. It's connected to the Ethereum Goerli testnet, allowing developers to test their smart contracts in a risk-free environment before deploying them on the mainnet.
 
-⚠️ Important note: Ethereum Goerli is deprecated in Q1 2023 but will be supported until Q4 2023. Once Arbitrum Sepolia becomes publicly available, we will phase out the usage of Arbitrum Goerli. The support for Arbitrum Goerli will cease prior to the deprecation of L1 Goerli.
+⚠️ Important note: Ethereum Goerli was deprecated in Q1 2023 but will be supported until Q4 2023. Once Arbitrum Sepolia becomes publicly available, we will phase out the usage of Arbitrum Goerli. Support for Arbitrum Goerli will cease prior to the conclusion of Ethereum Goerli.
+
 ⚠️ The old testnet RinkArby was deprecated on December 20th, 2022.
+
+### Stylus testnet
+
+Stylus uses the Nitro technology and allows for efficient smart contract creation using languages like Rust, C, and C++. Leveraging Arbitrum's EVM equivalence, Stylus contracts achieve remarkable speed and low gas fees. With full interoperability between Solidity and Stylus contracts, new horizons emerge, while significantly cheaper memory costs unlock novel blockchain use cases.
 
 ## What differences there are between the available Arbitrum chains?
 
@@ -39,7 +44,7 @@ The main differences between the Arbitrum chains lie in their purpose and the en
 
 Arbitrum One and Arbitrum Nova are production chains designed for real-world use. They're connected to the Ethereum mainnet and handle real, valuable transactions. They both use Arbitrum's Nitro technology stack under the hood, but Arbitrum One implements the Rollup protocol, while Nova implements the AnyTrust protocol. Arbitrum One is designed for general use, providing a scalable and cost-effective solution for running Ethereum-compatible smart contracts. On the other hand, Arbitrum Nova is designed for applications that require a higher transaction throughput and don’t require the full decentralization that rollups provide.
 
-Finally, Arbitrum Goerli is a testnet chain. It's designed for testing purposes and is connected to the Ethereum Goerli testnet, which uses test Ether with no real-world value.
+Finally, Arbitrum Sepolia is a testnet chain. It's designed for testing purposes and is connected to the Sepolia testnet, which uses test Ether with no real-world value.
 
 ## What technology stacks use the Arbitrum chains?
 

--- a/arbitrum-docs/for-devs/concepts/public-chains.mdx
+++ b/arbitrum-docs/for-devs/concepts/public-chains.mdx
@@ -38,7 +38,7 @@ Arbitrum Goerli is a testnet chain that mirrors the functionality of the Arbitru
 
 Stylus uses the Nitro technology and allows for efficient smart contract creation using languages like Rust, C, and C++. Leveraging Arbitrum's EVM equivalence, Stylus contracts achieve remarkable speed and low gas fees. With full interoperability between Solidity and Stylus contracts, new horizons emerge, while significantly cheaper memory costs unlock novel blockchain use cases.
 
-⚠️ Important note: Stylus testnet will be deprecated Once stylus comes out of beta and is enabled on the Sepolia testnet.
+⚠️ Important note: Stylus testnet will be deprecated once stylus comes out of beta and is enabled on the Sepolia testnet.
 
 ## What differences there are between the available Arbitrum chains?
 

--- a/arbitrum-docs/for-devs/concepts/public-chains.mdx
+++ b/arbitrum-docs/for-devs/concepts/public-chains.mdx
@@ -38,6 +38,8 @@ Arbitrum Goerli is a testnet chain that mirrors the functionality of the Arbitru
 
 Stylus uses the Nitro technology and allows for efficient smart contract creation using languages like Rust, C, and C++. Leveraging Arbitrum's EVM equivalence, Stylus contracts achieve remarkable speed and low gas fees. With full interoperability between Solidity and Stylus contracts, new horizons emerge, while significantly cheaper memory costs unlock novel blockchain use cases.
 
+⚠️ Important note: Stylus testnet will be deprecated Once stylus comes out of beta and is enabled on the Sepolia testnet.
+
 ## What differences there are between the available Arbitrum chains?
 
 The main differences between the Arbitrum chains lie in their purpose and the environment they operate in.

--- a/arbitrum-docs/node-running/node-providers.mdx
+++ b/arbitrum-docs/node-running/node-providers.mdx
@@ -16,12 +16,13 @@ Complete [this form](https://docs.google.com/forms/d/e/1FAIpQLSdw0U-9LcLuih5TZ_Q
 
 This section provides an overview of the available public RPC endpoints for different Arbitrum chains and necessary details to interact with them.
 
-| Name                       | RPC Url(s)                             | Chain ID | Block explorer                        | Underlying L1 | Tech stack | Sequencer feed URL                    | Sequencer endpoint<sup>⚠️</sup>                  |
-| -------------------------- | -------------------------------------- | -------- | ------------------------------------- | ------------- | ---------- | ------------------------------------- | ------------------------------------------------ |
-| Arbitrum One               | https://arb1.arbitrum.io/rpc           | 42161    | https://arbiscan.io/                  | Ethereum      | Nitro      | wss://arb1.arbitrum.io/feed           | https://arb1-sequencer.arbitrum.io/rpc           |
-| Arbitrum Nova              | https://nova.arbitrum.io/rpc           | 42170    | https://nova.arbiscan.io/             | Ethereum      | AnyTrust   | wss://nova.arbitrum.io/feed           | https://nova-sequencer.arbitrum.io/rpc           |
-| Arbitrum Goerli (Testnet)  | https://goerli-rollup.arbitrum.io/rpc  | 421613   | https://goerli.arbiscan.io            | Goerli        | Nitro      | wss://goerli-rollup.arbitrum.io/feed  | https://goerli-rollup-sequencer.arbitrum.io/rpc  |
-| Arbitrum Sepolia (Testnet) | https://sepolia-rollup.arbitrum.io/rpc | 421614   | https://sepolia-explorer.arbitrum.io/ | Sepolia       | Nitro      | wss://sepolia-rollup.arbitrum.io/feed | https://sepolia-rollup-sequencer.arbitrum.io/rpc |
+| Name                       | RPC Url(s)                             | Chain ID | Block explorer                               | Underlying L1    | Tech stack       | Sequencer feed URL                    | Sequencer endpoint<sup>⚠️</sup>                  |
+| -------------------------- | -------------------------------------- | -------- | -------------------------------------------- | ---------------- | ---------------- | ------------------------------------- | ------------------------------------------------ |
+| Arbitrum One               | https://arb1.arbitrum.io/rpc           | 42161    | https://arbiscan.io/                         | Ethereum         | Nitro (Rollup)   | wss://arb1.arbitrum.io/feed           | https://arb1-sequencer.arbitrum.io/rpc           |
+| Arbitrum Nova              | https://nova.arbitrum.io/rpc           | 42170    | https://nova.arbiscan.io/                    | Ethereum         | Nitro (AnyTrust) | wss://nova.arbitrum.io/feed           | https://nova-sequencer.arbitrum.io/rpc           |
+| Arbitrum Goerli (Testnet)  | https://goerli-rollup.arbitrum.io/rpc  | 421613   | https://goerli.arbiscan.io                   | Goerli           | Nitro (Rollup)   | wss://goerli-rollup.arbitrum.io/feed  | https://goerli-rollup-sequencer.arbitrum.io/rpc  |
+| Arbitrum Sepolia (Testnet) | https://sepolia-rollup.arbitrum.io/rpc | 421614   | https://sepolia-explorer.arbitrum.io/        | Sepolia          | Nitro (Rollup)   | wss://sepolia-rollup.arbitrum.io/feed | https://sepolia-rollup-sequencer.arbitrum.io/rpc |
+| Stylus Testnet             | https://stylus-testnet.arbitrum.io/rpc | 23011913 | https://stylus-testnet-explorer.arbitrum.io/ | Arbitrum Sepolia | Nitro (Rollup)   | wss://stylus-sepolia.arbitrum.io/feed | https://stylus-testnet-sequencer.arbitrum.io/rpc |
 
 ⚠️ Unlike `https://arb1.arbitrum.io/rpc`, the Sequencer endpoint only supports `eth_sendRawTransaction` and `eth_sendRawTransactionConditional` calls.
 

--- a/arbitrum-docs/node-running/node-providers.mdx
+++ b/arbitrum-docs/node-running/node-providers.mdx
@@ -28,6 +28,8 @@ This section provides an overview of the available public RPC endpoints for diff
 
 ⚠️ Important note: Ethereum Goerli was deprecated in Q1 2023 but will be supported until Q4 2023. Once Arbitrum Sepolia becomes publicly available, we will phase out the usage of Arbitrum Goerli. Support for Arbitrum Goerli will cease prior to the conclusion of Ethereum Goerli.
 
+⚠️ Important note: Stylus testnet will be deprecated Once stylus comes out of beta and is enabled on the Sepolia testnet.
+
 ⚠️ Visit [here](https://faucet.quicknode.com/arbitrum/sepolia) to get Arbitrum Sepolia faucet.
 
 :::info More RPC endpoints

--- a/arbitrum-docs/node-running/node-providers.mdx
+++ b/arbitrum-docs/node-running/node-providers.mdx
@@ -28,7 +28,7 @@ This section provides an overview of the available public RPC endpoints for diff
 
 ⚠️ Important note: Ethereum Goerli was deprecated in Q1 2023 but will be supported until Q4 2023. Once Arbitrum Sepolia becomes publicly available, we will phase out the usage of Arbitrum Goerli. Support for Arbitrum Goerli will cease prior to the conclusion of Ethereum Goerli.
 
-⚠️ Important note: Stylus testnet will be deprecated Once stylus comes out of beta and is enabled on the Sepolia testnet.
+⚠️ Important note: Stylus testnet will be deprecated once stylus comes out of beta and is enabled on the Sepolia testnet.
 
 ⚠️ Visit [here](https://faucet.quicknode.com/arbitrum/sepolia) to get Arbitrum Sepolia faucet.
 

--- a/arbitrum-docs/node-running/node-providers.mdx
+++ b/arbitrum-docs/node-running/node-providers.mdx
@@ -16,7 +16,7 @@ Complete [this form](https://docs.google.com/forms/d/e/1FAIpQLSdw0U-9LcLuih5TZ_Q
 
 This section provides an overview of the available public RPC endpoints for different Arbitrum chains and necessary details to interact with them.
 
-| Name                       | RPC Url(s)                             | Chain ID | Block explorer                               | Underlying L1    | Tech stack       | Sequencer feed URL                    | Sequencer endpoint<sup>⚠️</sup>                  |
+| Name                       | RPC Url(s)                             | Chain ID | Block explorer                               | Underlying Chain    | Tech stack       | Sequencer feed URL                    | Sequencer endpoint<sup>⚠️</sup>                  |
 | -------------------------- | -------------------------------------- | -------- | -------------------------------------------- | ---------------- | ---------------- | ------------------------------------- | ------------------------------------------------ |
 | Arbitrum One               | https://arb1.arbitrum.io/rpc           | 42161    | https://arbiscan.io/                         | Ethereum         | Nitro (Rollup)   | wss://arb1.arbitrum.io/feed           | https://arb1-sequencer.arbitrum.io/rpc           |
 | Arbitrum Nova              | https://nova.arbitrum.io/rpc           | 42170    | https://nova.arbiscan.io/                    | Ethereum         | Nitro (AnyTrust) | wss://nova.arbitrum.io/feed           | https://nova-sequencer.arbitrum.io/rpc           |

--- a/arbitrum-docs/node-running/node-providers.mdx
+++ b/arbitrum-docs/node-running/node-providers.mdx
@@ -16,7 +16,7 @@ Complete [this form](https://docs.google.com/forms/d/e/1FAIpQLSdw0U-9LcLuih5TZ_Q
 
 This section provides an overview of the available public RPC endpoints for different Arbitrum chains and necessary details to interact with them.
 
-| Name                       | RPC Url(s)                             | Chain ID | Block explorer                               | Underlying Chain    | Tech stack       | Sequencer feed URL                    | Sequencer endpoint<sup>⚠️</sup>                  |
+| Name                       | RPC Url(s)                             | Chain ID | Block explorer                               | Underlying chain | Tech stack       | Sequencer feed URL                    | Sequencer endpoint<sup>⚠️</sup>                  |
 | -------------------------- | -------------------------------------- | -------- | -------------------------------------------- | ---------------- | ---------------- | ------------------------------------- | ------------------------------------------------ |
 | Arbitrum One               | https://arb1.arbitrum.io/rpc           | 42161    | https://arbiscan.io/                         | Ethereum         | Nitro (Rollup)   | wss://arb1.arbitrum.io/feed           | https://arb1-sequencer.arbitrum.io/rpc           |
 | Arbitrum Nova              | https://nova.arbitrum.io/rpc           | 42170    | https://nova.arbiscan.io/                    | Ethereum         | Nitro (AnyTrust) | wss://nova.arbitrum.io/feed           | https://nova-sequencer.arbitrum.io/rpc           |


### PR DESCRIPTION
This PR:
- Adds Stylus testnet to the RPC providers table
- Relabels the tech stack for different chains in the RPC providers table
- Adds Stylus testnet to the public chain page

Preview: [here](https://nitro-docs-git-edit-rpc-providers-table-offchain-labs.vercel.app/node-running/node-providers#rpc-endpoints) and [here](https://nitro-docs-git-edit-rpc-providers-table-offchain-labs.vercel.app/for-devs/concepts/public-chains#stylus-testnet) 