### PR TITLE
update precompile file

### DIFF
--- a/arbitrum-docs/arbos/arbos.mdx
+++ b/arbitrum-docs/arbos/arbos.mdx
@@ -14,7 +14,7 @@ The calling, dispatching, and recording of precompile methods are done via runti
 
 Each time a transaction calls a method of an L2-specific precompile, a [`call context`][call_context_link] is created to track and record the gas burnt. For convenience, it also provides access to the public fields of the underlying [`TxProcessor`][txprocessor_link]. Because sub-transactions could revert without updates to this struct, the [`TxProcessor`][txprocessor_link] only makes public that which is safe, such as the amount of L1 calldata paid by the top level transaction.
 
-[nitro_precompiles_dir]: https://github.com/OffchainLabs/nitro/tree/master/contracts/src/precompiles
+[nitro_precompiles_dir]: https://github.com/OffchainLabs/nitro-contracts/tree/main/src/precompiles
 [precompiles_dir]: https://github.com/OffchainLabs/nitro/tree/master/precompiles
 [installer_link]: https://github.com/OffchainLabs/nitro/blob/bc6b52daf7232af2ca2fec3f54a5b546f1196c45/precompiles/precompile.go#L379
 [installation_link]: https://github.com/OffchainLabs/nitro/blob/bc6b52daf7232af2ca2fec3f54a5b546f1196c45/precompiles/precompile.go#L403


### PR DESCRIPTION
The older url is 404 now as we move nitro-contracts to a new branch