### PR TITLE
Make format check action CI informative

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
           cache-key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
   
   check-formatting:
-    name: "Check Formatting"
+    name: "Check Formatting - does not fail, only comments on error"
     runs-on: ubuntu-latest
     needs: install
     steps:
@@ -40,5 +40,22 @@ jobs:
           cache-key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
 
       - name: Check formatting with Prettier
+        id: prettier-check
         working-directory: ./website
-        run: yarn format:check
+        run: |
+          set +e
+          yarn format:check
+          echo "format-check-result=$?" >> $GITHUB_OUTPUT
+      
+      - name: Output formatting error
+        if: steps.prettier-check.outputs.format-check-result == 1
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'Hey there!\nIt looks like your changes are not well formatted. You can merge this PR, but we recommend to format your code with:\n```\ncd website && yarn format\n```\nThanks!💙🧡'
+            })

--- a/arbitrum-docs/node-running/quickstart-running-a-node.md
+++ b/arbitrum-docs/node-running/quickstart-running-a-node.md
@@ -42,3 +42,5 @@ If you are running a single node, there is no requirement to set up a feed relay
 In the near future, feed endpoints will mandate compression using a custom dictionary. Therefore, if you plan to connect to a feed using anything other than a standard node, it is strongly advised to run a local feed relay. This will ensure that you have access to an uncompressed feed by default, maintaining optimal performance and compatibility.
 
 For detailed instructions on how to run a feed relay, see [here](./how-tos/running-a-feed-relay.mdx).
+
+

--- a/arbitrum-docs/node-running/quickstart-running-a-node.md
+++ b/arbitrum-docs/node-running/quickstart-running-a-node.md
@@ -42,5 +42,3 @@ If you are running a single node, there is no requirement to set up a feed relay
 In the near future, feed endpoints will mandate compression using a custom dictionary. Therefore, if you plan to connect to a feed using anything other than a standard node, it is strongly advised to run a local feed relay. This will ensure that you have access to an uncompressed feed by default, maintaining optimal performance and compatibility.
 
 For detailed instructions on how to run a feed relay, see [here](./how-tos/running-a-feed-relay.mdx).
-
-


### PR DESCRIPTION
This PR removes the restriction of needing to have all changes formatted to be able to merge successive PRs. Instead, it displays a comment asking the contributor to run the formatter before merging.