### PR TITLE
Fix broken git repo link for zig-on-stylus

### DIFF
--- a/arbitrum-docs/stylus/how-tos/adding-support-for-new-languages.mdx
+++ b/arbitrum-docs/stylus/how-tos/adding-support-for-new-languages.mdx
@@ -49,7 +49,7 @@ cargo install cargo-stylus
 First, let's clone the repository:
 
 ```
-git clone https://offchainlabs/zig-on-stylus && cd zig-on-stylus
+git clone https://github.com/offchainlabs/zig-on-stylus && cd zig-on-stylus
 ```
 
 then delete everything inside of `main.zig`. We'll be filling it out ourselves in this tutorial.


### PR DESCRIPTION
https://github.com/offchainlabs/zig-on-stylus resolves to a repo while https://offchainlabs/zig-on-stylus does not

In response to issue https://github.com/OffchainLabs/arbitrum-docs/issues/613