### PR TITLE
Update nitro version to v2.1.0

### DIFF
--- a/arbitrum-docs/launch-orbit-chain/how-tos/customize-precompile.mdx
+++ b/arbitrum-docs/launch-orbit-chain/how-tos/customize-precompile.mdx
@@ -20,7 +20,7 @@ There are two ways to customize your chain's precompiles:
 Clone the Nitro repository before you begin:
 
 ```shell
-git clone --branch @orbitVersionTag@ <https://github.com/OffchainLabs/nitro.git>
+git clone --branch @nitroVersionTag@ <https://github.com/OffchainLabs/nitro.git>
 cd nitro
 git submodule update --init --recursive --force
 ```
@@ -46,7 +46,7 @@ Next, build Nitro by following steps 3-7 of the instructions in [How to build Ni
 Run Nitro with the following command:
 
 ```shell
-docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 @latestOrbitNodeImage@ --parent-chain.connection.url=<YourParentChainUrl> --chain.id=<YourOrbitChainId> --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=*
+docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 @latestNitroNodeImage@ --parent-chain.connection.url=<YourParentChainUrl> --chain.id=<YourOrbitChainId> --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=*
 ```
 
 :::info
@@ -127,7 +127,7 @@ Next, build Nitro by following the instructions in [How to build Nitro locally](
 Run Nitro with the following command:
 
 ```shell
-docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 @latestOrbitNodeImage@ --parent-chain.connection.url=<YourParentChainUrl> --chain.id=<YourOrbitChainId> --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=*
+docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 @latestNitroNodeImage@ --parent-chain.connection.url=<YourParentChainUrl> --chain.id=<YourOrbitChainId> --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=*
 ```
 
 :::info
@@ -173,6 +173,6 @@ The same goes for the path to precompiles interface.
 We can use the @nitroContractsRepositorySlug@ and @nitroContractsPathToPrecompilesInterface@ variables once we release nitro version 2.1.0 or above.
 -->
 
-[precompile_impl_dir_link]: https://github.com/OffchainLabs/@nitroRepositorySlug@/blob/@orbitVersionTag@/@nitroPathToPrecompiles@/
+[precompile_impl_dir_link]: https://github.com/OffchainLabs/@nitroRepositorySlug@/blob/@nitroVersionTag@/@nitroPathToPrecompiles@/
 [precompile_interface_dir_link]: https://github.com/OffchainLabs/nitro-contracts/blob/@orbitNitroContractsCommit@/src/precompiles/
-[precompile_main_file_link]: https://github.com/OffchainLabs/@nitroRepositorySlug@/blob/@orbitVersionTag@/@nitroPathToPrecompiles@/precompile.go
+[precompile_main_file_link]: https://github.com/OffchainLabs/@nitroRepositorySlug@/blob/@nitroVersionTag@/@nitroPathToPrecompiles@/precompile.go

--- a/arbitrum-docs/node-running/command-line-options.md
+++ b/arbitrum-docs/node-running/command-line-options.md
@@ -14,6 +14,17 @@ This is for Arbitrum Nitro Node:
       --auth.jwtsecret string                                                                           Path to file holding JWT secret (32B hex)
       --auth.origins strings                                                                            Origins from which to accept AUTH requests (default [localhost])
       --auth.port int                                                                                   AUTH-RPC server listening port (default 8549)
+      --chain.dev-wallet.account string                                                                 account to use (default is first account in keystore)
+      --chain.dev-wallet.only-create-key                                                                if true, creates new key then exits
+      --chain.dev-wallet.password string                                                                wallet passphrase (default "PASSWORD_NOT_SET")
+      --chain.dev-wallet.pathname string                                                                pathname for wallet
+      --chain.dev-wallet.private-key string                                                             private key for wallet
+      --chain.id uint                                                                                   L2 chain ID (determines Arbitrum network)
+      --chain.info-files strings                                                                        L2 chain info json files
+      --chain.info-ipfs-download-path string                                                            path to save temp downloaded file (default "/tmp/")
+      --chain.info-ipfs-url string                                                                      url to download chain info file
+      --chain.info-json string                                                                          L2 chain info in json string format
+      --chain.name string                                                                               L2 chain name (determines Arbitrum network)
       --conf.dump                                                                                       print out currently active configuration file
       --conf.env-prefix string                                                                          environment variables with given prefix will be loaded as configuration values
       --conf.file strings                                                                               name of configuration file
@@ -56,59 +67,52 @@ This is for Arbitrum Nitro Node:
       --init.import-file string                                                                         path for json data to import
       --init.prune string                                                                               pruning for a given use: "full" for full nodes serving RPC requests, or "validator" for validators
       --init.prune-bloom-size uint                                                                      the amount of memory in megabytes to use for the pruning bloom filter (higher values prune better) (default 2048)
+      --init.reset-to-message int                                                                       forces a reset to an old message height. Also set max-reorg-resequence-depth=0 to force re-reading messages (default -1)
       --init.then-quit                                                                                  quit after init is done
       --init.url string                                                                                 url to download initializtion data - will poll if download fails
       --ipc.path string                                                                                 Requested location to place the IPC endpoint. An empty path disables IPC.
-      --l1.chain-id uint                                                                                if set other than 0, will be used to validate database and L1 connection
-      --l1.connection-attempts int                                                                      layer 1 RPC connection attempts (spaced out at least 1 second per attempt, 0 to retry infinitely) (default 15)
-      --l1.rollup.bridge string                                                                         the bridge contract address
-      --l1.rollup.deployed-at uint                                                                      the block number at which the rollup was deployed
-      --l1.rollup.inbox string                                                                          the inbox contract address
-      --l1.rollup.rollup string                                                                         the rollup contract address
-      --l1.rollup.sequencer-inbox string                                                                the sequencer inbox contract address
-      --l1.rollup.validator-utils string                                                                the validator utils contract address
-      --l1.rollup.validator-wallet-creator string                                                       the validator wallet creator contract address
-      --l1.url string                                                                                   layer 1 ethereum node RPC URL
-      --l1.wallet.account string                                                                        account to use (default is first account in keystore)
-      --l1.wallet.only-create-key                                                                       if true, creates new key then exits
-      --l1.wallet.password string                                                                       wallet passphrase (default "PASSWORD_NOT_SET")
-      --l1.wallet.pathname string                                                                       pathname for wallet (default "wallet")
-      --l1.wallet.private-key string                                                                    private key for wallet
-      --l2.chain-id uint                                                                                L2 chain ID (determines Arbitrum network)
-      --l2.dev-wallet.account string                                                                    account to use (default is first account in keystore)
-      --l2.dev-wallet.only-create-key                                                                   if true, creates new key then exits
-      --l2.dev-wallet.password string                                                                   wallet passphrase (default "PASSWORD_NOT_SET")
-      --l2.dev-wallet.pathname string                                                                   pathname for wallet
-      --l2.dev-wallet.private-key string                                                                private key for wallet
       --log-level int                                                                                   log level (default 3)
       --log-type string                                                                                 log type (plaintext or json) (default "plaintext")
       --metrics                                                                                         enable metrics
       --metrics-server.addr string                                                                      metrics server address (default "127.0.0.1")
       --metrics-server.port int                                                                         metrics server port (default 6070)
-      --metrics-server.pprof                                                                            enable profiling for Go
       --metrics-server.update-interval duration                                                         metrics server update interval (default 3s)
       --node.archive                                                                                    retain past block state (deprecated, please use node.caching.archive)
       --node.batch-poster.compression-level int                                                         batch compression level (default 11)
       --node.batch-poster.das-retention-period duration                                                 In AnyTrust mode, the period which DASes are requested to retain the stored batches. (default 360h0m0s)
-      --node.batch-poster.data-poster.max-mempool-transactions uint                                     the maximum number of transactions to have queued in the mempool at once (0 = unlimited) (default 64)
-      --node.batch-poster.data-poster.max-queued-transactions uint                                      the maximum number of unconfirmed transactions to track at once (0 = unlimited)
+      --node.batch-poster.data-poster.allocate-mempool-balance                                          if true, don't put transactions in the mempool that spend a total greater than the batch poster's balance (default true)
+      --node.batch-poster.data-poster.dangerous.clear-leveldb                                           clear leveldb
+      --node.batch-poster.data-poster.legacy-storage-encoding                                           encodes items in a legacy way (as it was before dropping generics) (default true)
+      --node.batch-poster.data-poster.max-mempool-transactions uint                                     the maximum number of transactions to have queued in the mempool at once (0 = unlimited) (default 10)
+      --node.batch-poster.data-poster.max-queued-transactions int                                       the maximum number of unconfirmed transactions to track at once (0 = unlimited)
+      --node.batch-poster.data-poster.max-tip-cap-gwei float                                            the maximum tip cap to post transactions at (default 5)
       --node.batch-poster.data-poster.min-fee-cap-gwei float                                            the minimum fee cap to post transactions at
       --node.batch-poster.data-poster.min-tip-cap-gwei float                                            the minimum tip cap to post transactions at (default 0.05)
+      --node.batch-poster.data-poster.nonce-rbf-soft-confs uint                                         the maximum probable reorg depth, used to determine when a transaction will no longer likely need replaced-by-fee (default 1)
       --node.batch-poster.data-poster.redis-signer.dangerous.disable-signature-verification             disable message signature verification
       --node.batch-poster.data-poster.redis-signer.fallback-verification-key string                     a fallback key used for message verification
       --node.batch-poster.data-poster.redis-signer.signing-key string                                   a 32-byte (64-character) hex string used to sign messages, or a path to a file containing it
       --node.batch-poster.data-poster.replacement-times string                                          comma-separated list of durations since first posting to attempt a replace-by-fee (default "5m,10m,20m,30m,1h,2h,4h,6h,8h,12h,16h,18h,20h,22h")
       --node.batch-poster.data-poster.target-price-gwei float                                           the target price to use for maximum fee cap calculation (default 60)
       --node.batch-poster.data-poster.urgency-gwei float                                                the urgency to use for maximum fee cap calculation (default 2)
+      --node.batch-poster.data-poster.use-leveldb                                                       uses leveldb when enabled (default true)
+      --node.batch-poster.data-poster.use-noop-storage                                                  uses noop storage, it doesn't store anything
       --node.batch-poster.data-poster.wait-for-l1-finality                                              only treat a transaction as confirmed after L1 finality has been achieved (recommended) (default true)
       --node.batch-poster.disable-das-fallback-store-data-on-chain                                      If unable to batch to DAS, disable fallback storing data on chain
       --node.batch-poster.enable                                                                        enable posting batches to l1
       --node.batch-poster.error-delay duration                                                          how long to delay after error posting batch (default 10s)
       --node.batch-poster.extra-batch-gas uint                                                          use this much more gas than estimation says is necessary to post batches (default 50000)
       --node.batch-poster.gas-refunder-address string                                                   The gas refunder contract address (optional)
+      --node.batch-poster.l1-block-bound string                                                         only post messages to batches when they're within the max future block/timestamp as of this L1 block tag ("safe", "finalized", "latest", or "ignore" to ignore this check)
+      --node.batch-poster.l1-block-bound-bypass duration                                                post batches even if not within the layer 1 future bounds if we're within this margin of the max delay (default 1h0m0s)
       --node.batch-poster.max-delay duration                                                            maximum batch posting delay (default 1h0m0s)
       --node.batch-poster.max-size int                                                                  maximum batch size (default 100000)
-      --node.batch-poster.poll-delay duration                                                           how long to delay after successfully posting batch (default 10s)
+      --node.batch-poster.parent-chain-wallet.account string                                            account to use (default is first account in keystore)
+      --node.batch-poster.parent-chain-wallet.only-create-key                                           if true, creates new key then exits
+      --node.batch-poster.parent-chain-wallet.password string                                           wallet passphrase (default "PASSWORD_NOT_SET")
+      --node.batch-poster.parent-chain-wallet.pathname string                                           pathname for wallet (default "batch-poster-wallet")
+      --node.batch-poster.parent-chain-wallet.private-key string                                        private key for wallet
+      --node.batch-poster.poll-interval duration                                                        how long to wait after no batches are ready to be posted before checking again (default 10s)
       --node.batch-poster.redis-lock.background-lock                                                    should node always try grabing lock in background
       --node.batch-poster.redis-lock.key string                                                         key for lock (default "node.batch-poster.redis-lock.simple-lock-key")
       --node.batch-poster.redis-lock.lockout-duration duration                                          how long lock is held (default 1m0s)
@@ -116,27 +120,33 @@ This is for Arbitrum Nitro Node:
       --node.batch-poster.redis-lock.refresh-duration duration                                          how long between consecutive calls to redis (default 10s)
       --node.batch-poster.redis-url string                                                              if non-empty, the Redis URL to store queued transactions in
       --node.batch-poster.wait-for-max-delay                                                            wait for the max batch delay, even if the batch is full
-      --node.block-validator.check-validations-poll duration                                            poll time to check validations (default 1s)
       --node.block-validator.current-module-root string                                                 current wasm module root ('current' read from chain, 'latest' from machines/latest dir, or provide hash) (default "current")
       --node.block-validator.dangerous.reset-block-validation                                           resets block-by-block validation, starting again at genesis
       --node.block-validator.enable                                                                     enable block-by-block validation
       --node.block-validator.failure-is-fatal                                                           failing a validation is treated as a fatal error (default true)
       --node.block-validator.forward-blocks uint                                                        prepare entries for up to that many blocks ahead of validation (small footprint) (default 1024)
-      --node.block-validator.jwtsecret string                                                           path to file with jwtsecret for validation - empty disables jwt, 'self' uses the server's jwt (default "self")
       --node.block-validator.pending-upgrade-module-root string                                         pending upgrade wasm module root to additionally validate (hash, 'latest' or empty) (default "latest")
       --node.block-validator.prerecorded-blocks uint                                                    record that many blocks ahead of validation (larger footprint) (default 128)
-      --node.block-validator.url string                                                                 url for valiation (default "ws://127.0.0.1:8549/")
+      --node.block-validator.validation-poll duration                                                   poll time to check validations (default 1s)
+      --node.block-validator.validation-server.arg-log-limit uint                                       limit size of arguments in log entries (default 2048)
+      --node.block-validator.validation-server.connection-wait duration                                 how long to wait for initial connection
+      --node.block-validator.validation-server.jwtsecret string                                         path to file with jwtsecret for validation - ignored if url is self or self-auth
+      --node.block-validator.validation-server.retries uint                                             number of retries in case of failure(0 mean one attempt)
+      --node.block-validator.validation-server.retry-errors string                                      Errors matching this regular expression are automatically retried
+      --node.block-validator.validation-server.timeout duration                                         per-response timeout (0-disabled)
+      --node.block-validator.validation-server.url string                                               url of server, use self for loopback websocket, self-auth for loopback with authentication (default "self-auth")
       --node.caching.archive                                                                            retain past block state
-      --node.caching.block-age duration                                                                 minimum age a block must be to be pruned (default 30m0s)
+      --node.caching.block-age duration                                                                 minimum age of recent blocks to keep in memory (default 30m0s)
       --node.caching.block-count uint                                                                   minimum number of recent blocks to keep in memory (default 128)
       --node.caching.database-cache int                                                                 amount of memory in megabytes to cache database contents with (default 2048)
+      --node.caching.max-amount-of-gas-to-skip-state-saving uint                                        maximum amount of gas in blocks to skip saving state to Persistent storage (archive node only) (default 15000000)
+      --node.caching.max-number-of-blocks-to-skip-state-saving uint32                                   maximum number of blocks to skip state saving to persistent storage (archive node only) (default 127)
       --node.caching.snapshot-cache int                                                                 amount of memory in megabytes to cache state snapshots with (default 400)
       --node.caching.snapshot-restore-gas-limit uint                                                    maximum gas rolled back to recover snapshot (default 300000000000)
       --node.caching.trie-clean-cache int                                                               amount of memory in megabytes to cache unchanged state trie nodes with (default 600)
       --node.caching.trie-dirty-cache int                                                               amount of memory in megabytes to cache state diffs against disk with (larger cache lowers database growth) (default 1024)
       --node.caching.trie-time-limit duration                                                           maximum block processing time before trie is written to hard-disk (default 1h0m0s)
       --node.dangerous.no-l1-listener                                                                   DANGEROUS! disables listening to L1. To be used in test nodes only
-      --node.dangerous.reorg-to-block int                                                               DANGEROUS! forces a reorg to an old block height. To be used for testing only. -1 to disable (default -1)
       --node.data-availability.enable                                                                   enable Anytrust Data Availability mode
       --node.data-availability.ipfs-storage.enable                                                      enable storage/retrieval of sequencer batch data from IPFS
       --node.data-availability.ipfs-storage.peers strings                                               list of IPFS peers to connect to, eg /ip4/1.2.3.4/tcp/12345/p2p/abc...xyz
@@ -145,9 +155,9 @@ This is for Arbitrum Nitro Node:
       --node.data-availability.ipfs-storage.profiles string                                             comma separated list of IPFS profiles to use, see https://docs.ipfs.tech/how-to/default-profile
       --node.data-availability.ipfs-storage.read-timeout duration                                       timeout for IPFS reads, since by default it will wait forever. Treat timeout as not found (default 1m0s)
       --node.data-availability.ipfs-storage.repo-dir string                                             directory to use to store the local IPFS repo
-      --node.data-availability.l1-connection-attempts int                                               layer 1 RPC connection attempts (spaced out at least 1 second per attempt, 0 to retry infinitely), only used in standalone daserver; when running as part of a node that node's L1 configuration is used (default 15)
-      --node.data-availability.l1-node-url string                                                       URL for L1 node, only used in standalone daserver; when running as part of a node that node's L1 configuration is used
       --node.data-availability.panic-on-error                                                           whether the Data Availability Service should fail immediately on errors (not recommended)
+      --node.data-availability.parent-chain-connection-attempts int                                     layer 1 RPC connection attempts (spaced out at least 1 second per attempt, 0 to retry infinitely), only used in standalone daserver; when running as part of a node that node's L1 configuration is used (default 15)
+      --node.data-availability.parent-chain-node-url string                                             URL for L1 node, only used in standalone daserver; when running as part of a node that node's L1 configuration is used
       --node.data-availability.request-timeout duration                                                 Data Availability Service timeout duration for Store requests (default 5s)
       --node.data-availability.rest-aggregator.enable                                                   enable retrieval of sequencer batch data from a list of remote REST endpoints; if other DAS storage types are enabled, this mode is used as a fallback
       --node.data-availability.rest-aggregator.max-per-endpoint-stats int                               number of stats entries (latency and success rate) to keep for each REST endpoint; controls whether strategy is faster or slower to respond to changing conditions (default 20)
@@ -162,19 +172,18 @@ This is for Arbitrum Nitro Node:
       --node.data-availability.rest-aggregator.sync-to-storage.eager                                    eagerly sync batch data to this DAS's storage from the rest endpoints, using L1 as the index of batch data hashes; otherwise only sync lazily
       --node.data-availability.rest-aggregator.sync-to-storage.eager-lower-bound-block uint             when eagerly syncing, start indexing forward from this L1 block. Only used if there is no sync state
       --node.data-availability.rest-aggregator.sync-to-storage.ignore-write-errors                      log only on failures to write when syncing; otherwise treat it as an error (default true)
-      --node.data-availability.rest-aggregator.sync-to-storage.l1-blocks-per-read uint                  when eagerly syncing, max l1 blocks to read per poll (default 100)
+      --node.data-availability.rest-aggregator.sync-to-storage.parent-chain-blocks-per-read uint        when eagerly syncing, max l1 blocks to read per poll (default 100)
       --node.data-availability.rest-aggregator.sync-to-storage.retention-period duration                period to retain synced data (defaults to forever) (default 2562047h47m16.854775807s)
       --node.data-availability.rest-aggregator.sync-to-storage.state-dir string                         directory to store the sync state in, ie the block number currently synced up to, so that we don't sync from scratch each time
       --node.data-availability.rest-aggregator.urls strings                                             list of URLs including 'http://' or 'https://' prefixes and port numbers to REST DAS endpoints; additive with the online-url-list option
       --node.data-availability.rest-aggregator.wait-before-try-next duration                            time to wait until trying the next set of REST endpoints while waiting for a response; the next set of REST endpoints is determined by the strategy selected (default 2s)
       --node.data-availability.rpc-aggregator.assumed-honest int                                        Number of assumed honest backends (H). If there are N backends, K=N+1-H valid responses are required to consider an Store request to be successful.
       --node.data-availability.rpc-aggregator.backends string                                           JSON RPC backend configuration
-      --node.data-availability.rpc-aggregator.dump-keyset                                               Dump the keyset encoded in hexadecimal for the backends string
       --node.data-availability.rpc-aggregator.enable                                                    enable storage/retrieval of sequencer batch data from a list of RPC endpoints; this should only be used by the batch poster and not in combination with other DAS storage types
       --node.data-availability.sequencer-inbox-address string                                           L1 address of SequencerInbox contract
-      --node.delayed-sequencer.enable                                                                   enable sequence coordinator
+      --node.delayed-sequencer.enable                                                                   enable delayed sequencer
       --node.delayed-sequencer.finalize-distance int                                                    how many blocks in the past L1 block is considered final (ignored when using Merge finality) (default 20)
-      --node.delayed-sequencer.require-full-finality                                                    whether to wait for full finality before sequencing delayed messages (default true)
+      --node.delayed-sequencer.require-full-finality                                                    whether to wait for full finality before sequencing delayed messages
       --node.delayed-sequencer.use-merge-finality                                                       whether to use The Merge's notion of finality before sequencing delayed messages (default true)
       --node.feed.input.enable-compression                                                              enable per message deflate compression support (default true)
       --node.feed.input.reconnect-initial-backoff duration                                              initial duration to wait before reconnect (default 1s)
@@ -201,10 +210,11 @@ This is for Arbitrum Nitro Node:
       --node.feed.output.limit-catchup                                                                  only supply catchup buffer if requested sequence number is reasonable
       --node.feed.output.log-connect                                                                    log every client connect
       --node.feed.output.log-disconnect                                                                 log every client disconnect
+      --node.feed.output.max-catchup int                                                                the maximum size of the catchup buffer (-1 means unlimited) (default -1)
       --node.feed.output.max-send-queue int                                                             maximum number of messages allowed to accumulate before client is disconnected (default 4096)
       --node.feed.output.ping duration                                                                  duration for ping interval (default 5s)
       --node.feed.output.port string                                                                    port to bind the relay feed output to (default "9642")
-      --node.feed.output.queue int                                                                      queue size (default 100)
+      --node.feed.output.queue int                                                                      queue size for HTTP to WS upgrade (default 100)
       --node.feed.output.read-timeout duration                                                          duration to wait before timing out reading data (i.e. pings) from clients (default 1s)
       --node.feed.output.require-compression                                                            require clients to use compression
       --node.feed.output.require-version                                                                don't connect if client version not present
@@ -217,7 +227,7 @@ This is for Arbitrum Nitro Node:
       --node.forwarder.redis-url string                                                                 the Redis URL to recomend target via
       --node.forwarder.retry-interval duration                                                          minimal time between update retries (default 100ms)
       --node.forwarder.update-interval duration                                                         forwarding target update interval (default 1s)
-      --node.forwarding-target string                                                                   transaction forwarding target URL, or "null" to disable forwarding (iff not sequencer)
+      --node.forwarding-target string                                                                   transaction forwarding target URL, or "null" to disable forwarding (if not sequencer)
       --node.inbox-reader.check-delay duration                                                          the maximum time to wait between inbox checks (if not enough new blocks are found) (default 1m0s)
       --node.inbox-reader.default-blocks-to-read uint                                                   the default number of blocks to read at once (will vary based on traffic by default) (default 100)
       --node.inbox-reader.delay-blocks uint                                                             number of latest blocks to ignore to reduce reorgs
@@ -225,16 +235,28 @@ This is for Arbitrum Nitro Node:
       --node.inbox-reader.max-blocks-to-read uint                                                       if adjust-blocks-to-read is enabled, the maximum number of blocks to read at once (default 2000)
       --node.inbox-reader.min-blocks-to-read uint                                                       the minimum number of blocks to read at once (when caught up lowers load on L1) (default 1)
       --node.inbox-reader.target-messages-read uint                                                     if adjust-blocks-to-read is enabled, the target number of messages to read at once (default 500)
-      --node.l1-reader.enable                                                                           enable reader connection (default true)
-      --node.l1-reader.old-header-timeout duration                                                      warns if the latest l1 block is at least this old (default 5m0s)
-      --node.l1-reader.poll-interval duration                                                           interval when polling endpoint (default 15s)
-      --node.l1-reader.poll-only                                                                        do not attempt to subscribe to header events
-      --node.l1-reader.tx-timeout duration                                                              timeout when waiting for a transaction (default 5m0s)
-      --node.l1-reader.use-finality-data                                                                use l1 data about finalized/safe blocks (default true)
+      --node.maintenance.lock.background-lock                                                           should node always try grabing lock in background
+      --node.maintenance.lock.key string                                                                key for lock (default "node.maintenance.lock.simple-lock-key")
+      --node.maintenance.lock.lockout-duration duration                                                 how long lock is held (default 1m0s)
+      --node.maintenance.lock.my-id string                                                              this node's id prefix when acquiring the lock (optional)
+      --node.maintenance.lock.refresh-duration duration                                                 how long between consecutive calls to redis (default 10s)
       --node.maintenance.time-of-day string                                                             UTC 24-hour time of day to run maintenance (currently only db compaction) at (e.g. 15:00)
+      --node.message-pruner.enable                                                                      enable message pruning (default true)
+      --node.message-pruner.min-batches-left uint                                                       min number of batches not pruned (default 2)
+      --node.message-pruner.prune-interval duration                                                     interval for running message pruner (default 1m0s)
+      --node.parent-chain-reader.enable                                                                 enable reader connection (default true)
+      --node.parent-chain-reader.old-header-timeout duration                                            warns if the latest l1 block is at least this old (default 5m0s)
+      --node.parent-chain-reader.poll-interval duration                                                 interval when polling endpoint (default 15s)
+      --node.parent-chain-reader.poll-only                                                              do not attempt to subscribe to header events
+      --node.parent-chain-reader.tx-timeout duration                                                    timeout when waiting for a transaction (default 5m0s)
+      --node.parent-chain-reader.use-finality-data                                                      use l1 data about finalized/safe blocks (default true)
+      --node.recording-database.trie-clean-cache int                                                    like trie-clean-cache for the separate, recording database (used for validation) (default 16)
+      --node.recording-database.trie-dirty-cache int                                                    like trie-dirty-cache for the separate, recording database (used for validation) (default 1024)
+      --node.resource-mgmt.mem-free-limit string                                                        RPC calls are throttled if free system memory excluding the page cache is below this amount, expressed in bytes or multiples of bytes with suffix B, K, M, G. The limit should be set such that sufficient free memory is left for the page cache in order for the system to be performant
       --node.rpc.arbdebug.block-range-bound uint                                                        bounds the number of blocks arbdebug calls may return (default 256)
       --node.rpc.arbdebug.timeout-queue-bound uint                                                      bounds the length of timeout queues arbdebug calls may return (default 512)
       --node.rpc.bloom-bits-blocks uint                                                                 number of blocks a single bloom bit section vector holds (default 16384)
+      --node.rpc.bloom-confirms uint                                                                    number of confirmation blocks before a bloom section is considered final (default 256)
       --node.rpc.classic-redirect string                                                                url to redirect classic requests, use "error:[CODE:]MESSAGE" to return specified error instead of redirecting
       --node.rpc.classic-redirect-timeout duration                                                      timeout for forwarded classic requests, where 0 = no timeout
       --node.rpc.evm-timeout duration                                                                   timeout used for eth_call (0=infinite) (default 5s)
@@ -242,6 +264,8 @@ This is for Arbitrum Nitro Node:
       --node.rpc.filter-log-cache-size int                                                              log filter system maximum number of cached blocks (default 32)
       --node.rpc.filter-timeout duration                                                                log filter system maximum time filters stay active (default 5m0s)
       --node.rpc.gas-cap uint                                                                           cap on computation gas that can be used in eth_call/estimateGas (0=infinite) (default 50000000)
+      --node.rpc.max-recreate-state-depth int                                                           maximum depth for recreating state, measured in l2 gas (0=don't recreate state, -1=infinite, -2=use default value for archive or non-archive node (whichever is configured)) (default -2)
+      --node.rpc.tx-allow-unprotected                                                                   allow transactions that aren't EIP-155 replay protected to be submitted over the RPC (default true)
       --node.rpc.tx-fee-cap float                                                                       cap on transaction fee (in ether) that can be sent via the RPC APIs (0 = no cap) (default 1)
       --node.seq-coordinator.chosen-healthcheck-addr string                                             if non-empty, launch an HTTP service binding to this address that returns status code 200 when chosen and 503 otherwise
       --node.seq-coordinator.enable                                                                     enable sequence coordinator
@@ -284,14 +308,45 @@ This is for Arbitrum Nitro Node:
       --node.sequencer.sender-whitelist string                                                          comma separated whitelist of authorized senders (if empty, everyone is allowed)
       --node.staker.confirmation-blocks int                                                             confirmation blocks (default 12)
       --node.staker.contract-wallet-address string                                                      validator smart contract wallet public address
+      --node.staker.dangerous.ignore-rollup-wasm-module-root                                            DANGEROUS! make assertions even when the wasm module root is wrong
       --node.staker.dangerous.without-block-validator                                                   DANGEROUS! allows running an L1 validator without a block validator
+      --node.staker.data-poster.allocate-mempool-balance                                                if true, don't put transactions in the mempool that spend a total greater than the batch poster's balance (default true)
+      --node.staker.data-poster.dangerous.clear-leveldb                                                 clear leveldb
+      --node.staker.data-poster.legacy-storage-encoding                                                 encodes items in a legacy way (as it was before dropping generics) (default true)
+      --node.staker.data-poster.max-mempool-transactions uint                                           the maximum number of transactions to have queued in the mempool at once (0 = unlimited) (default 10)
+      --node.staker.data-poster.max-queued-transactions int                                             the maximum number of unconfirmed transactions to track at once (0 = unlimited)
+      --node.staker.data-poster.max-tip-cap-gwei float                                                  the maximum tip cap to post transactions at (default 5)
+      --node.staker.data-poster.min-fee-cap-gwei float                                                  the minimum fee cap to post transactions at
+      --node.staker.data-poster.min-tip-cap-gwei float                                                  the minimum tip cap to post transactions at (default 0.05)
+      --node.staker.data-poster.nonce-rbf-soft-confs uint                                               the maximum probable reorg depth, used to determine when a transaction will no longer likely need replaced-by-fee (default 1)
+      --node.staker.data-poster.redis-signer.dangerous.disable-signature-verification                   disable message signature verification
+      --node.staker.data-poster.redis-signer.fallback-verification-key string                           a fallback key used for message verification
+      --node.staker.data-poster.redis-signer.signing-key string                                         a 32-byte (64-character) hex string used to sign messages, or a path to a file containing it
+      --node.staker.data-poster.replacement-times string                                                comma-separated list of durations since first posting to attempt a replace-by-fee (default "5m,10m,20m,30m,1h,2h,4h,6h,8h,12h,16h,18h,20h,22h")
+      --node.staker.data-poster.target-price-gwei float                                                 the target price to use for maximum fee cap calculation (default 60)
+      --node.staker.data-poster.urgency-gwei float                                                      the urgency to use for maximum fee cap calculation (default 2)
+      --node.staker.data-poster.use-leveldb                                                             uses leveldb when enabled (default true)
+      --node.staker.data-poster.use-noop-storage                                                        uses noop storage, it doesn't store anything
+      --node.staker.data-poster.wait-for-l1-finality                                                    only treat a transaction as confirmed after L1 finality has been achieved (recommended) (default true)
       --node.staker.disable-challenge                                                                   disable validator challenge
       --node.staker.enable                                                                              enable validator (default true)
+      --node.staker.extra-gas uint                                                                      use this much more gas than estimation says is necessary to post transactions (default 50000)
       --node.staker.gas-refunder-address string                                                         The gas refunder contract address (optional)
       --node.staker.make-assertion-interval duration                                                    if configured with the makeNodes strategy, how often to create new assertions (bypassed in case of a dispute) (default 1h0m0s)
       --node.staker.only-create-wallet-contract                                                         only create smart wallet contract and exit
+      --node.staker.parent-chain-wallet.account string                                                  account to use (default is first account in keystore)
+      --node.staker.parent-chain-wallet.only-create-key                                                 if true, creates new key then exits
+      --node.staker.parent-chain-wallet.password string                                                 wallet passphrase (default "PASSWORD_NOT_SET")
+      --node.staker.parent-chain-wallet.pathname string                                                 pathname for wallet (default "validator-wallet")
+      --node.staker.parent-chain-wallet.private-key string                                              private key for wallet
       --node.staker.posting-strategy.high-gas-delay-blocks int                                          high gas delay blocks
       --node.staker.posting-strategy.high-gas-threshold float                                           high gas threshold
+      --node.staker.redis-lock.background-lock                                                          should node always try grabing lock in background
+      --node.staker.redis-lock.key string                                                               key for lock (default "node.staker.redis-lock.simple-lock-key")
+      --node.staker.redis-lock.lockout-duration duration                                                how long lock is held (default 1m0s)
+      --node.staker.redis-lock.my-id string                                                             this node's id prefix when acquiring the lock (optional)
+      --node.staker.redis-lock.refresh-duration duration                                                how long between consecutive calls to redis (default 10s)
+      --node.staker.redis-url string                                                                    redis url for L1 validator
       --node.staker.staker-interval duration                                                            how often the L1 validator should check the status of the L1 rollup and maybe take action with its stake (default 1m0s)
       --node.staker.start-validation-from-staked                                                        assume staked nodes are valid (default true)
       --node.staker.strategy string                                                                     L1 validator strategy, either watchtower, defensive, stakeLatest, or makeNodes (default "Watchtower")
@@ -306,10 +361,27 @@ This is for Arbitrum Nitro Node:
       --node.tx-pre-checker.required-state-age int                                                      how long ago should the storage conditions from eth_SendRawTransactionConditional be true, 0 = don't check old state (default 2)
       --node.tx-pre-checker.required-state-max-blocks uint                                              maximum number of blocks to look back while looking for the <required-state-age> seconds old state, 0 = don't limit the search (default 4)
       --node.tx-pre-checker.strictness uint                                                             how strict to be when checking txs before forwarding them. 0 = accept anything, 10 = should never reject anything that'd succeed, 20 = likely won't reject anything that'd succeed, 30 = full validation which may reject txs that would succeed
+      --parent-chain.connection.arg-log-limit uint                                                      limit size of arguments in log entries
+      --parent-chain.connection.connection-wait duration                                                how long to wait for initial connection (default 1m0s)
+      --parent-chain.connection.jwtsecret string                                                        path to file with jwtsecret for validation - ignored if url is self or self-auth
+      --parent-chain.connection.retries uint                                                            number of retries in case of failure(0 mean one attempt) (default 2)
+      --parent-chain.connection.retry-errors string                                                     Errors matching this regular expression are automatically retried
+      --parent-chain.connection.timeout duration                                                        per-response timeout (0-disabled) (default 1m0s)
+      --parent-chain.connection.url string                                                              url of server, use self for loopback websocket, self-auth for loopback with authentication
+      --parent-chain.id uint                                                                            if set other than 0, will be used to validate database and L1 connection
+      --parent-chain.wallet.account string                                                              account to use (default is first account in keystore)
+      --parent-chain.wallet.only-create-key                                                             if true, creates new key then exits
+      --parent-chain.wallet.password string                                                             wallet passphrase (default "PASSWORD_NOT_SET")
+      --parent-chain.wallet.pathname string                                                             pathname for wallet (default "wallet")
+      --parent-chain.wallet.private-key string                                                          private key for wallet
       --persistent.ancient string                                                                       directory of ancient where the chain freezer can be opened
       --persistent.chain string                                                                         directory to store chain state
       --persistent.global-config string                                                                 directory to store global config (default ".arbitrum")
       --persistent.handles int                                                                          number of file descriptor handles to use for the database (default 512)
+      --persistent.log-dir string                                                                       directory to store log file
+      --pprof                                                                                           enable pprof
+      --pprof-cfg.addr string                                                                           pprof server address (default "127.0.0.1")
+      --pprof-cfg.port int                                                                              pprof server port (default 6071)
       --rpc.max-batch-response-size int                                                                 the maximum response size for a JSON-RPC request measured in bytes (-1 means no limit) (default 10000000)
       --validation.api-auth                                                                             validate is an authenticated API (default true)
       --validation.api-public                                                                           validate is a public API
@@ -328,7 +400,7 @@ This is for Arbitrum Nitro Node:
       --ws.origins strings                                                                              Origins from which to accept websockets requests
       --ws.port int                                                                                     WS-RPC server listening port (default 8548)
       --ws.rpcprefix string                                                                             WS path path prefix on which JSON-RPC is served. Use '/' to serve on all paths
-Version: v2.0.14-2baa834
+Version: v2.1.0-72ccc0c
 ```
 
 ### Classic Node

--- a/arbitrum-docs/node-running/how-tos/running-a-feed-relay.mdx
+++ b/arbitrum-docs/node-running/how-tos/running-a-feed-relay.mdx
@@ -12,11 +12,11 @@ The feed relay is in the same docker image as the Nitro node.
 
 - Here is an example of how to run the feed relay for Arbitrum One:
   ```shell
-  docker run --rm -it  -p 0.0.0.0:9642:9642 --entrypoint relay @latestNitroNodeImage@ --node.feed.output.addr=0.0.0.0 --node.feed.input.url=wss://arb1.arbitrum.io/feed --l2.chain-id=42161
+  docker run --rm -it  -p 0.0.0.0:9642:9642 --entrypoint relay @latestNitroNodeImage@ --node.feed.output.addr=0.0.0.0 --node.feed.input.url=wss://arb1.arbitrum.io/feed --chain.id=42161
   ```
 - Here is an example of how to run nitro-node for Arbitrum One with custom relay:
   ```shell
-  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 @latestNitroNodeImage@ --l1.url=https://l1-mainnet-node:8545 --l2.chain-id=42161 --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=* --node.feed.input.url=ws://local-relay-address:9642
+  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 @latestNitroNodeImage@ --parent-chain.connection.url=https://l1-mainnet-node:8545 --chain.id=42161 --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=* --node.feed.input.url=ws://local-relay-address:9642
   ```
 
 Note that Arbitrum classic does not communicate with Nitro sequencer, so classic relay is no longer used.

--- a/arbitrum-docs/node-running/how-tos/running-a-full-node.mdx
+++ b/arbitrum-docs/node-running/how-tos/running-a-full-node.mdx
@@ -58,7 +58,7 @@ The minimum storage requirements will change over time as the Nitro chain grows.
   - Note that is important that `/some/local/dir/arbitrum` already exists, otherwise the directory might be created with `root` as owner, and the docker container won't be able to write to it
 
   ```shell
-  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 @latestNitroNodeImage@ --l1.url https://l1-node:8545 --l2.chain-id=<L2ChainId> --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=*
+  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 @latestNitroNodeImage@ --parent-chain.connection.url https://l1-node:8545 --chain.id=<L2ChainId> --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=*
   ```
 
   - Note that if you are running L1 node on localhost, you may need to add `--network host` right after `docker run` to use docker host-based networking

--- a/arbitrum-docs/node-running/how-tos/running-a-validator.mdx
+++ b/arbitrum-docs/node-running/how-tos/running-a-validator.mdx
@@ -43,7 +43,7 @@ Here we describe different strategies that validators follow and provide instruc
 - All other validators require a funded wallet to immediately post stake, as well as additional funds that will be spent at regular intervals
 - Here is an example of how to tell Nitro to create validator wallet for Arbitrum One and exit:
   ```shell
-  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum @latestNitroNodeImage@ --l1.url=https://l1-mainnet-node:8545 --l2.chain-id=42161 --node.staker.enable --l1.wallet.only-create-key --l1.wallet.password="SOME SECURE PASSWORD"
+  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum @latestNitroNodeImage@ --parent-chain.connection.url=https://l1-mainnet-node:8545 --l2.chain-id=42161 --node.staker.enable --parent-chain.wallet.only-create-key --parent-chain.wallet.password="SOME SECURE PASSWORD"
   ```
 - Wallet file will be created under the mounted directory inside the `arb1/wallet/` directory for Arb1, or `nova/wallet/` directory for Nova. Be sure to backup the wallet, it will be the only way to withdraw stake when desired
 
@@ -54,7 +54,7 @@ Here we describe different strategies that validators follow and provide instruc
 - If a defensive validator detects a deviation, it will log `bringing defensive validator online because of incorrect assertion`, and wait for funds to be added to wallet so stake can be posted and a dispute created
 - Here is an example of how to run an allowlisted defensive validator for Arbitrum One:
   ```shell
-  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum @latestNitroNodeImage@ --l1.url=https://l1-mainnet-node:8545 --l2.chain-id=42161 --node.staker.enable --node.staker.strategy=Defensive --l1.wallet.password="SOME SECURE PASSWORD"
+  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum @latestNitroNodeImage@ --parent-chain.connection.url=https://l1-mainnet-node:8545 --l2.chain-id=42161 --node.staker.enable --node.staker.strategy=Defensive --parent-chain.wallet.password="SOME SECURE PASSWORD"
   ```
 - To verify validator is working, this log line shows the wallet is setup correctly:
   ```shell

--- a/arbitrum-docs/node-running/how-tos/running-an-archive-node.mdx
+++ b/arbitrum-docs/node-running/how-tos/running-an-archive-node.mdx
@@ -76,7 +76,7 @@ To run both Arbitrum Nitro and/or Arbitrum Classic in archive mode, follow one o
 
 - **Arbitrum One Nitro archive node**:
   ```shell
-  docker run --rm -it -v /some/local/dir/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 @latestNitroNodeImage@ --l1.url https://l1-node:8545 --l2.chain-id= --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=* --node.caching.archive
+  docker run --rm -it -v /some/local/dir/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 @latestNitroNodeImage@ --parent-chain.connection.url https://l1-node:8545 --chain.id=42161 --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=* --node.caching.archive
   ```
 - **Arbitrum One Classic archive node**:
   ```shell
@@ -84,7 +84,7 @@ To run both Arbitrum Nitro and/or Arbitrum Classic in archive mode, follow one o
   ```
 - **Arbitrum One Nitro archive node with forwarding classic execution support**:
   ```shell
-  docker run --rm -it -v /some/local/dir/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 @latestNitroNodeImage@ --l1.url https://l1-node:8545 --l2.chain-id=42161 --node.rpc.classic-redirect=<classic node RPC> --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=* --node.caching.archive
+  docker run --rm -it -v /some/local/dir/arbitrum:/home/user/.arbitrum -p 0.0.0.0:8547:8547 -p 0.0.0.0:8548:8548 @latestNitroNodeImage@ --parent-chain.connection.url https://l1-node:8545 --chain.id=42161 --node.rpc.classic-redirect=<classic node RPC> --http.api=net,web3,eth,debug --http.corsdomain=* --http.addr=0.0.0.0 --http.vhosts=* --node.caching.archive
   ```
 
 Note that the above commands both map to port `8547` on their hosts. If you want to run both on the same host, you should edit those mapping to different ports, and specify your Classic node RPC url as `<classic node RPC>` in your Nitro start command. To verify the connection health of your node(s), see [Docker network between containers - Docker Networking Example](https://www.middlewareinventory.com/blog/docker-network-example/).

--- a/website/src/resources/globalVars.js
+++ b/website/src/resources/globalVars.js
@@ -12,7 +12,7 @@ const sepoliaForceIncludePeriodBlocks = 5760;
 
 const globalVars = {
   // Node docker images
-  latestNitroNodeImage: 'offchainlabs/nitro-node:v2.0.14-2baa834',
+  latestNitroNodeImage: 'offchainlabs/nitro-node:v2.1.0-72ccc0c',
   latestOrbitNodeImage: `offchainlabs/nitro-node:v2.1.0-beta.16-ad8cfe5`,
   latestClassicNodeImage: 'offchainlabs/arb-node:v1.4.5-e97c1a4',
 
@@ -30,7 +30,7 @@ const globalVars = {
 
   // Nitro Github references
   nitroRepositorySlug: 'nitro',
-  nitroVersionTag: 'v2.0.14',
+  nitroVersionTag: 'v2.1.0',
   nitroPathToPrecompiles: 'precompiles',
 
   nitroContractsRepositorySlug: 'nitro',

--- a/website/src/resources/globalVars.js
+++ b/website/src/resources/globalVars.js
@@ -13,7 +13,6 @@ const sepoliaForceIncludePeriodBlocks = 5760;
 const globalVars = {
   // Node docker images
   latestNitroNodeImage: 'offchainlabs/nitro-node:v2.1.0-72ccc0c',
-  latestOrbitNodeImage: `offchainlabs/nitro-node:v2.1.0-beta.16-ad8cfe5`,
   latestClassicNodeImage: 'offchainlabs/arb-node:v1.4.5-e97c1a4',
 
   // Node snapshots (taken around April 20th, 2013)
@@ -38,7 +37,6 @@ const globalVars = {
   nitroContractsPathToPrecompilesInterface: 'contracts/src/precompiles',
 
   // Orbit Github references
-  orbitVersionTag: 'v2.1.0-beta.16',
   orbitNitroContractsCommit: '97cfbe00ff0eea4d7f5f5f3afb01598c19ddabc4',
 
   // gas floor


### PR DESCRIPTION
Nitro v2.1.0 was recently released: https://github.com/OffchainLabs/nitro/releases/tag/v2.1.0

This updates the docs to reference that version and its command line argument changes :) 

In a future PR, we should consider documenting how to run a node for an existing orbit chain as part of the "Running a full node" page, as opposed to the orbit guide which walks you through deploying a new orbit chain.