### PR TITLE
Update precompiles info with new nitro version

### DIFF
--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbAddressTable.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbAddressTable.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbAddressTable.sol#L17"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAddressTable.sol#L17"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbAddressTable.go#L17"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAddressTable.go#L17"
           target="_blank"
         >
           Implementation
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbAddressTable.sol#L24"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAddressTable.sol#L24"
           target="_blank"
         >
           Interface
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbAddressTable.go#L22"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAddressTable.go#L22"
           target="_blank"
         >
           Implementation
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbAddressTable.sol#L32"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAddressTable.sol#L32"
           target="_blank"
         >
           Interface
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbAddressTable.go#L27"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAddressTable.go#L27"
           target="_blank"
         >
           Implementation
@@ -82,7 +82,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbAddressTable.sol#L41"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAddressTable.sol#L41"
           target="_blank"
         >
           Interface
@@ -90,7 +90,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbAddressTable.go#L40"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAddressTable.go#L40"
           target="_blank"
         >
           Implementation
@@ -104,7 +104,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbAddressTable.sol#L47"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAddressTable.sol#L47"
           target="_blank"
         >
           Interface
@@ -112,7 +112,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbAddressTable.go#L52"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAddressTable.go#L52"
           target="_blank"
         >
           Implementation
@@ -126,7 +126,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbAddressTable.sol#L54"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAddressTable.sol#L54"
           target="_blank"
         >
           Interface
@@ -134,7 +134,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbAddressTable.go#L67"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAddressTable.go#L67"
           target="_blank"
         >
           Implementation
@@ -148,7 +148,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbAddressTable.sol#L59"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAddressTable.sol#L59"
           target="_blank"
         >
           Interface
@@ -156,7 +156,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbAddressTable.go#L73"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAddressTable.go#L73"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbAggregator.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbAggregator.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbAggregator.sol#L14"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAggregator.sol#L14"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbAggregator.go#L24"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAggregator.go#L24"
           target="_blank"
         >
           Implementation
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbAggregator.sol#L18"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAggregator.sol#L18"
           target="_blank"
         >
           Interface
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbAggregator.go#L30"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAggregator.go#L30"
           target="_blank"
         >
           Implementation
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbAggregator.sol#L22"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAggregator.sol#L22"
           target="_blank"
         >
           Interface
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbAggregator.go#L35"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAggregator.go#L35"
           target="_blank"
         >
           Implementation
@@ -80,7 +80,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbAggregator.sol#L27"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAggregator.sol#L27"
           target="_blank"
         >
           Interface
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbAggregator.go#L39"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAggregator.go#L39"
           target="_blank"
         >
           Implementation
@@ -102,7 +102,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbAggregator.sol#L32"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAggregator.sol#L32"
           target="_blank"
         >
           Interface
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbAggregator.go#L62"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAggregator.go#L62"
           target="_blank"
         >
           Implementation
@@ -124,7 +124,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbAggregator.sol#L38"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAggregator.sol#L38"
           target="_blank"
         >
           Interface
@@ -132,7 +132,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbAggregator.go#L71"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAggregator.go#L71"
           target="_blank"
         >
           Implementation
@@ -149,7 +149,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbAggregator.sol#L43"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAggregator.sol#L43"
           target="_blank"
         >
           Interface
@@ -157,7 +157,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbAggregator.go#L93"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAggregator.go#L93"
           target="_blank"
         >
           Implementation
@@ -171,7 +171,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbAggregator.sol#L51"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAggregator.sol#L51"
           target="_blank"
         >
           Interface
@@ -179,7 +179,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbAggregator.go#L99"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAggregator.go#L99"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbDebug.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbDebug.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbDebug.sol#L13"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbDebug.sol#L13"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbDebug.go#L55"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbDebug.go#L55"
           target="_blank"
         >
           Implementation
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbDebug.sol#L16"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbDebug.sol#L16"
           target="_blank"
         >
           Interface
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbDebug.go#L27"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbDebug.go#L27"
           target="_blank"
         >
           Implementation
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbDebug.sol#L19"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbDebug.sol#L19"
           target="_blank"
         >
           Interface
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbDebug.go#L45"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbDebug.go#L45"
           target="_blank"
         >
           Implementation
@@ -80,7 +80,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbDebug.sol#L38"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbDebug.sol#L38"
           target="_blank"
         >
           Interface
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbDebug.go#L50"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbDebug.go#L50"
           target="_blank"
         >
           Implementation
@@ -102,7 +102,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbDebug.sol#L40"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbDebug.sol#L40"
           target="_blank"
         >
           Interface
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbDebug.go#L59"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbDebug.go#L59"
           target="_blank"
         >
           Implementation
@@ -136,7 +136,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbDebug.sol#L22"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbDebug.sol#L22"
           target="_blank"
         >
           Interface
@@ -144,7 +144,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbDebug.go#L32"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbDebug.go#L32"
           target="_blank"
         >
           Implementation
@@ -160,7 +160,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbDebug.sol#L23"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbDebug.sol#L23"
           target="_blank"
         >
           Interface
@@ -168,7 +168,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbDebug.go#L37"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbDebug.go#L37"
           target="_blank"
         >
           Implementation
@@ -184,7 +184,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbDebug.sol#L30"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbDebug.sol#L30"
           target="_blank"
         >
           Interface
@@ -192,7 +192,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbDebug.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbDebug.go#L0"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbFunctionTable.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbFunctionTable.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbFunctionTable.sol#L15"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbFunctionTable.sol#L15"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbFunctionTable.go#L19"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbFunctionTable.go#L19"
           target="_blank"
         >
           Implementation
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbFunctionTable.sol#L18"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbFunctionTable.sol#L18"
           target="_blank"
         >
           Interface
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbFunctionTable.go#L24"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbFunctionTable.go#L24"
           target="_blank"
         >
           Implementation
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbFunctionTable.sol#L21"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbFunctionTable.sol#L21"
           target="_blank"
         >
           Interface
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbFunctionTable.go#L29"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbFunctionTable.go#L29"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbGasInfo.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbGasInfo.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbGasInfo.sol#L22"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L22"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbGasInfo.go#L26"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L26"
           target="_blank"
         >
           Implementation
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbGasInfo.sol#L44"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L44"
           target="_blank"
         >
           Interface
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbGasInfo.go#L91"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L91"
           target="_blank"
         >
           Implementation
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbGasInfo.sol#L58"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L58"
           target="_blank"
         >
           Interface
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbGasInfo.go#L96"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L96"
           target="_blank"
         >
           Implementation
@@ -82,7 +82,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbGasInfo.sol#L69"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L69"
           target="_blank"
         >
           Interface
@@ -90,7 +90,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbGasInfo.go#L138"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L138"
           target="_blank"
         >
           Implementation
@@ -104,7 +104,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbGasInfo.sol#L80"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L80"
           target="_blank"
         >
           Interface
@@ -112,7 +112,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbGasInfo.go#L143"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L143"
           target="_blank"
         >
           Implementation
@@ -126,7 +126,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbGasInfo.sol#L90"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L90"
           target="_blank"
         >
           Interface
@@ -134,7 +134,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbGasInfo.go#L151"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L151"
           target="_blank"
         >
           Implementation
@@ -148,7 +148,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbGasInfo.sol#L93"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L93"
           target="_blank"
         >
           Interface
@@ -156,7 +156,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbGasInfo.go#L156"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L156"
           target="_blank"
         >
           Implementation
@@ -170,7 +170,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbGasInfo.sol#L96"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L96"
           target="_blank"
         >
           Interface
@@ -178,7 +178,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbGasInfo.go#L161"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L161"
           target="_blank"
         >
           Implementation
@@ -190,11 +190,11 @@
     </tr>
     <tr>
       <td>
-        <code>getL1GasPriceEstimate()</code>
+        <code>getL1RewardRate()</code>
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbGasInfo.sol#L99"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L100"
           target="_blank"
         >
           Interface
@@ -202,7 +202,51 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbGasInfo.go#L166"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L166"
+          target="_blank"
+        >
+          Implementation
+        </a>
+      </td>
+      <td>GetL1RewardRate gets the L1 pricer reward rate</td>
+    </tr>
+    <tr>
+      <td>
+        <code>getL1RewardRecipient()</code>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L104"
+          target="_blank"
+        >
+          Interface
+        </a>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L171"
+          target="_blank"
+        >
+          Implementation
+        </a>
+      </td>
+      <td>GetL1RewardRecipient gets the L1 pricer reward recipient</td>
+    </tr>
+    <tr>
+      <td>
+        <code>getL1GasPriceEstimate()</code>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L107"
+          target="_blank"
+        >
+          Interface
+        </a>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L176"
           target="_blank"
         >
           Implementation
@@ -216,7 +260,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbGasInfo.sol#L102"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L110"
           target="_blank"
         >
           Interface
@@ -224,7 +268,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbGasInfo.go#L171"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L181"
           target="_blank"
         >
           Implementation
@@ -238,7 +282,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbGasInfo.sol#L105"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L113"
           target="_blank"
         >
           Interface
@@ -246,7 +290,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbGasInfo.go#L176"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L186"
           target="_blank"
         >
           Implementation
@@ -260,7 +304,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbGasInfo.sol#L108"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L116"
           target="_blank"
         >
           Interface
@@ -268,7 +312,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbGasInfo.go#L181"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L191"
           target="_blank"
         >
           Implementation
@@ -282,7 +326,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbGasInfo.sol#L111"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L119"
           target="_blank"
         >
           Interface
@@ -290,7 +334,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbGasInfo.go#L186"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L196"
           target="_blank"
         >
           Implementation
@@ -307,7 +351,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbGasInfo.sol#L114"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L122"
           target="_blank"
         >
           Interface
@@ -315,7 +359,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbGasInfo.go#L190"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L200"
           target="_blank"
         >
           Implementation
@@ -329,7 +373,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbGasInfo.sol#L117"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L125"
           target="_blank"
         >
           Interface
@@ -337,7 +381,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbGasInfo.go#L226"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L236"
           target="_blank"
         >
           Implementation
@@ -353,7 +397,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbGasInfo.sol#L120"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L128"
           target="_blank"
         >
           Interface
@@ -361,7 +405,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbGasInfo.go#L230"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L240"
           target="_blank"
         >
           Implementation
@@ -375,7 +419,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbGasInfo.sol#L123"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L131"
           target="_blank"
         >
           Interface
@@ -383,7 +427,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbGasInfo.go#L234"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L244"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbInfo.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbInfo.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbInfo.sol#L11"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbInfo.sol#L11"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbInfo.go#L17"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbInfo.go#L17"
           target="_blank"
         >
           Implementation
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbInfo.sol#L14"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbInfo.sol#L14"
           target="_blank"
         >
           Interface
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbInfo.go#L25"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbInfo.go#L25"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbOwner.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbOwner.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L16"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L16"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L30"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L34"
           target="_blank"
         >
           Implementation
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L19"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L19"
           target="_blank"
         >
           Interface
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L35"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L39"
           target="_blank"
         >
           Implementation
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L22"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L22"
           target="_blank"
         >
           Interface
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L44"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L48"
           target="_blank"
         >
           Implementation
@@ -80,7 +80,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L25"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L25"
           target="_blank"
         >
           Interface
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L49"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L53"
           target="_blank"
         >
           Implementation
@@ -102,7 +102,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L28"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L28"
           target="_blank"
         >
           Interface
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L54"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L58"
           target="_blank"
         >
           Implementation
@@ -126,7 +126,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L31"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L31"
           target="_blank"
         >
           Interface
@@ -134,7 +134,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L59"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L63"
           target="_blank"
         >
           Implementation
@@ -148,7 +148,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L34"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L34"
           target="_blank"
         >
           Interface
@@ -156,7 +156,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L64"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L68"
           target="_blank"
         >
           Implementation
@@ -170,7 +170,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L37"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L37"
           target="_blank"
         >
           Interface
@@ -178,7 +178,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L69"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L73"
           target="_blank"
         >
           Implementation
@@ -192,7 +192,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L40"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L40"
           target="_blank"
         >
           Interface
@@ -200,7 +200,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L74"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L78"
           target="_blank"
         >
           Implementation
@@ -214,7 +214,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L43"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L43"
           target="_blank"
         >
           Interface
@@ -222,7 +222,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L79"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L83"
           target="_blank"
         >
           Implementation
@@ -236,7 +236,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L46"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L46"
           target="_blank"
         >
           Interface
@@ -244,7 +244,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L84"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L88"
           target="_blank"
         >
           Implementation
@@ -258,7 +258,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L49"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L49"
           target="_blank"
         >
           Interface
@@ -266,7 +266,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L89"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L93"
           target="_blank"
         >
           Implementation
@@ -280,7 +280,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L52"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L52"
           target="_blank"
         >
           Interface
@@ -288,7 +288,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L94"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L98"
           target="_blank"
         >
           Implementation
@@ -302,7 +302,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L55"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L55"
           target="_blank"
         >
           Interface
@@ -310,7 +310,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L99"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L103"
           target="_blank"
         >
           Implementation
@@ -324,7 +324,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L58"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L58"
           target="_blank"
         >
           Interface
@@ -332,7 +332,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L104"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L108"
           target="_blank"
         >
           Implementation
@@ -346,7 +346,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L61"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L61"
           target="_blank"
         >
           Interface
@@ -354,7 +354,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L109"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L113"
           target="_blank"
         >
           Implementation
@@ -368,7 +368,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L64"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L64"
           target="_blank"
         >
           Interface
@@ -376,7 +376,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L113"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L117"
           target="_blank"
         >
           Implementation
@@ -390,7 +390,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L67"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L67"
           target="_blank"
         >
           Interface
@@ -398,7 +398,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L117"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L121"
           target="_blank"
         >
           Implementation
@@ -412,7 +412,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L70"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L70"
           target="_blank"
         >
           Interface
@@ -420,7 +420,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L121"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L125"
           target="_blank"
         >
           Implementation
@@ -434,7 +434,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L73"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L73"
           target="_blank"
         >
           Interface
@@ -442,7 +442,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L125"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L129"
           target="_blank"
         >
           Implementation
@@ -456,7 +456,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L76"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L76"
           target="_blank"
         >
           Interface
@@ -464,7 +464,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L129"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L133"
           target="_blank"
         >
           Implementation
@@ -478,7 +478,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L79"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L79"
           target="_blank"
         >
           Interface
@@ -486,7 +486,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L133"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L137"
           target="_blank"
         >
           Implementation
@@ -500,7 +500,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L82"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L82"
           target="_blank"
         >
           Interface
@@ -508,7 +508,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L137"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L141"
           target="_blank"
         >
           Implementation
@@ -522,7 +522,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L85"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L85"
           target="_blank"
         >
           Interface
@@ -530,13 +530,35 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L141"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L145"
           target="_blank"
         >
           Implementation
         </a>
       </td>
       <td>Releases surplus funds from L1PricerFundsPoolAddress for use</td>
+    </tr>
+    <tr>
+      <td>
+        <code>setChainConfig(string calldata chainConfig)</code>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L88"
+          target="_blank"
+        >
+          Interface
+        </a>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L165"
+          target="_blank"
+        >
+          Implementation
+        </a>
+      </td>
+      <td></td>
     </tr>
   </tbody>
 </table>
@@ -556,7 +578,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwner.sol#L88"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L91"
           target="_blank"
         >
           Interface
@@ -564,7 +586,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwner.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L0"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbOwnerPublic.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbOwnerPublic.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwnerPublic.sol#L11"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwnerPublic.sol#L11"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwnerPublic.go#L23"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwnerPublic.go#L34"
           target="_blank"
         >
           Implementation
@@ -32,11 +32,11 @@
     </tr>
     <tr>
       <td>
-        <code>getAllChainOwners()</code>
+        <code>rectifyChainOwner(address ownerToRectify)</code>
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwnerPublic.sol#L14"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwnerPublic.sol#L18"
           target="_blank"
         >
           Interface
@@ -44,7 +44,29 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwnerPublic.go#L18"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwnerPublic.go#L25"
+          target="_blank"
+        >
+          Implementation
+        </a>
+      </td>
+      <td>RectifyChainOwner checks if the account is a chain owner</td>
+    </tr>
+    <tr>
+      <td>
+        <code>getAllChainOwners()</code>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwnerPublic.sol#L21"
+          target="_blank"
+        >
+          Interface
+        </a>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwnerPublic.go#L20"
           target="_blank"
         >
           Implementation
@@ -58,7 +80,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwnerPublic.sol#L17"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwnerPublic.sol#L24"
           target="_blank"
         >
           Interface
@@ -66,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwnerPublic.go#L28"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwnerPublic.go#L39"
           target="_blank"
         >
           Implementation
@@ -80,7 +102,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbOwnerPublic.sol#L20"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwnerPublic.sol#L27"
           target="_blank"
         >
           Interface
@@ -88,13 +110,47 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbOwnerPublic.go#L33"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwnerPublic.go#L44"
           target="_blank"
         >
           Implementation
         </a>
       </td>
       <td>GetInfraFeeAccount gets the infrastructure fee collector</td>
+    </tr>
+  </tbody>
+</table>
+<table>
+  <thead>
+    <tr>
+      <th>Event</th>
+      <th>Solidity interface</th>
+      <th>Go implementation</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>ChainOwnerRectified</code>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwnerPublic.sol#L29"
+          target="_blank"
+        >
+          Interface
+        </a>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwnerPublic.go#L30"
+          target="_blank"
+        >
+          Implementation
+        </a>
+      </td>
+      <td></td>
     </tr>
   </tbody>
 </table>

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbRetryableTx.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbRetryableTx.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbRetryableTx.sol#L18"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L18"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbRetryableTx.go#L50"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L49"
           target="_blank"
         >
           Implementation
@@ -39,7 +39,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbRetryableTx.sol#L24"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L24"
           target="_blank"
         >
           Interface
@@ -47,7 +47,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbRetryableTx.go#L135"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L134"
           target="_blank"
         >
           Implementation
@@ -61,7 +61,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbRetryableTx.sol#L31"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L31"
           target="_blank"
         >
           Interface
@@ -69,7 +69,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbRetryableTx.go#L140"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L139"
           target="_blank"
         >
           Implementation
@@ -83,7 +83,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbRetryableTx.sol#L41"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L41"
           target="_blank"
         >
           Interface
@@ -91,7 +91,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbRetryableTx.go#L157"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L156"
           target="_blank"
         >
           Implementation
@@ -105,7 +105,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbRetryableTx.sol#L49"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L49"
           target="_blank"
         >
           Interface
@@ -113,7 +113,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbRetryableTx.go#L185"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L184"
           target="_blank"
         >
           Implementation
@@ -127,7 +127,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbRetryableTx.sol#L56"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L56"
           target="_blank"
         >
           Interface
@@ -135,7 +135,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbRetryableTx.go#L198"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L197"
           target="_blank"
         >
           Implementation
@@ -149,7 +149,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbRetryableTx.sol#L63"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L63"
           target="_blank"
         >
           Interface
@@ -157,7 +157,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbRetryableTx.go#L226"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L225"
           target="_blank"
         >
           Implementation
@@ -171,7 +171,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbRetryableTx.sol#L69"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L69"
           target="_blank"
         >
           Interface
@@ -179,7 +179,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbRetryableTx.go#L234"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L232"
           target="_blank"
         >
           Implementation
@@ -208,7 +208,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbRetryableTx.sol#L83"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L83"
           target="_blank"
         >
           Interface
@@ -216,7 +216,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbRetryableTx.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L0"
           target="_blank"
         >
           Implementation
@@ -230,7 +230,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbRetryableTx.sol#L84"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L84"
           target="_blank"
         >
           Interface
@@ -238,7 +238,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbRetryableTx.go#L180"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L179"
           target="_blank"
         >
           Implementation
@@ -252,7 +252,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbRetryableTx.sol#L85"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L85"
           target="_blank"
         >
           Interface
@@ -260,7 +260,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbRetryableTx.go#L117"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L116"
           target="_blank"
         >
           Implementation
@@ -274,7 +274,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbRetryableTx.sol#L94"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L94"
           target="_blank"
         >
           Interface
@@ -282,7 +282,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbRetryableTx.go#L223"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L222"
           target="_blank"
         >
           Implementation
@@ -296,7 +296,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbRetryableTx.sol#L97"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L97"
           target="_blank"
         >
           Interface
@@ -304,7 +304,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbRetryableTx.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L0"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbStatistics.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbStatistics.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbStatistics.sol#L18"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbStatistics.sol#L18"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbStatistics.go#L18"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbStatistics.go#L18"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbSys.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbSys.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbSys.sol#L17"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L17"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbSys.go#L33"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L33"
           target="_blank"
         >
           Implementation
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbSys.sol#L23"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L23"
           target="_blank"
         >
           Interface
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbSys.go#L38"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L38"
           target="_blank"
         >
           Implementation
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbSys.sol#L29"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L29"
           target="_blank"
         >
           Interface
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbSys.go#L61"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L59"
           target="_blank"
         >
           Implementation
@@ -80,7 +80,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbSys.sol#L35"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L35"
           target="_blank"
         >
           Interface
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbSys.go#L66"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L64"
           target="_blank"
         >
           Implementation
@@ -102,7 +102,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbSys.sol#L41"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L41"
           target="_blank"
         >
           Interface
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbSys.go#L72"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L70"
           target="_blank"
         >
           Implementation
@@ -124,7 +124,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbSys.sol#L48"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L48"
           target="_blank"
         >
           Interface
@@ -132,7 +132,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbSys.go#L77"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L75"
           target="_blank"
         >
           Implementation
@@ -146,7 +146,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbSys.sol#L56"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L56"
           target="_blank"
         >
           Interface
@@ -154,7 +154,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbSys.go#L82"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L80"
           target="_blank"
         >
           Implementation
@@ -168,7 +168,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbSys.sol#L65"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L65"
           target="_blank"
         >
           Interface
@@ -176,7 +176,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbSys.go#L87"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L85"
           target="_blank"
         >
           Implementation
@@ -190,7 +190,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbSys.sol#L71"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L71"
           target="_blank"
         >
           Interface
@@ -198,7 +198,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbSys.go#L97"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L95"
           target="_blank"
         >
           Implementation
@@ -214,7 +214,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbSys.sol#L79"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L79"
           target="_blank"
         >
           Interface
@@ -222,7 +222,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbSys.go#L205"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L207"
           target="_blank"
         >
           Implementation
@@ -236,7 +236,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbSys.sol#L89"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L89"
           target="_blank"
         >
           Interface
@@ -244,7 +244,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbSys.go#L113"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L111"
           target="_blank"
         >
           Implementation
@@ -258,7 +258,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbSys.sol#L100"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L100"
           target="_blank"
         >
           Interface
@@ -266,7 +266,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbSys.go#L189"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L191"
           target="_blank"
         >
           Implementation
@@ -295,7 +295,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbSys.sol#L113"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L113"
           target="_blank"
         >
           Interface
@@ -303,7 +303,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbSys.go#L168"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L170"
           target="_blank"
         >
           Implementation
@@ -317,7 +317,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbSys.sol#L126"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L126"
           target="_blank"
         >
           Interface
@@ -325,7 +325,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbSys.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L0"
           target="_blank"
         >
           Implementation
@@ -341,7 +341,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbSys.sol#L145"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L145"
           target="_blank"
         >
           Interface
@@ -349,7 +349,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbSys.go#L154"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L154"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbosTest.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/ArbosTest.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/precompiles/ArbosTest.sol#L13"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbosTest.sol#L13"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.0.14/precompiles/ArbosTest.go#L16"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbosTest.go#L16"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/launch-orbit-chain/how-tos/customize-precompile.mdx
+++ b/arbitrum-docs/launch-orbit-chain/how-tos/customize-precompile.mdx
@@ -109,7 +109,7 @@ Then, update [precompile.go][precompile_main_file_link] to register the new prec
 insert(MakePrecompile(templates.ArbHiMetaData, &ArbHi{Address: hex("11a")})) // 0x011a here is an example address
 ```
 
-Navigate to the [precompiles interface][precompile_impl_dir_link] directory, `/@nitroContractsPathToPrecompilesInterface@`, create `ArbHi.sol`, and add the required interface. Ensure that the method name on the interface matches the name of the function you introduced in the previous step, `camelCased`:
+Navigate to the [precompiles interface][precompile_interface_dir_link] directory, `/@nitroContractsPathToPrecompilesInterface@`, create `ArbHi.sol`, and add the required interface. Ensure that the method name on the interface matches the name of the function you introduced in the previous step, `camelCased`:
 
 ```solidity
 pragma solidity >=0.4.21 <0.9.0;
@@ -174,5 +174,5 @@ We can use the @nitroContractsRepositorySlug@ and @nitroContractsPathToPrecompil
 -->
 
 [precompile_impl_dir_link]: https://github.com/OffchainLabs/@nitroRepositorySlug@/blob/@nitroVersionTag@/@nitroPathToPrecompiles@/
-[precompile_interface_dir_link]: https://github.com/OffchainLabs/nitro-contracts/blob/@orbitNitroContractsCommit@/src/precompiles/
+[precompile_interface_dir_link]: https://github.com/OffchainLabs/@nitroContractsRepositorySlug@/blob/@nitroContractsCommit@/@nitroContractsPathToPrecompilesInterface@/
 [precompile_main_file_link]: https://github.com/OffchainLabs/@nitroRepositorySlug@/blob/@nitroVersionTag@/@nitroPathToPrecompiles@/precompile.go

--- a/arbitrum-docs/node-running/how-tos/running-a-full-node.mdx
+++ b/arbitrum-docs/node-running/how-tos/running-a-full-node.mdx
@@ -35,10 +35,14 @@ The minimum storage requirements will change over time as the Nitro chain grows.
 
 ### Required parameters
 
-- `--l1.url=<Layer 1 Ethereum RPC URL>`
-  - Must provide standard layer 1 node RPC endpoint that you run yourself or from a node provider
-- `--l2.chain-id=<L2 Chain ID>`
-  - See [RPC endpoints and providers](/node-running/node-providers.mdx#rpc-endpoints) for a list of Arbitrum chains and the respective L2 Chain Ids
+- L1 RPC URL
+  - Use the parameter `--parent-chain.connection.url=<Layer 1 Ethereum RPC URL>`
+  - It must provide a standard layer 1 node RPC endpoint that you run yourself or from a node provider
+  - Note: this parameter was called --l1.url in versions prior to `v2.1.0`
+- L2 chain id or name
+  - Use the parameter `--chain.id=<L2 chain ID>` to set the L2 chain from its chain id. See [RPC endpoints and providers](/node-running/node-providers.mdx#rpc-endpoints) for a list of Arbitrum chains and their respective L2 chain ids.
+  - Alternatively, you can use the parameter `--chain.name=<L2 chain name>` to set the L2 chain from its name (options are: `arb1`, `nova` and `goerli-rollup`)
+  - Note: this parameter was called --l2.chain-id and only accepted chain ids in versions prior to `v2.1.0`
 
 ### Important ports
 

--- a/arbitrum-docs/node-running/how-tos/running-an-archive-node.mdx
+++ b/arbitrum-docs/node-running/how-tos/running-an-archive-node.mdx
@@ -55,13 +55,13 @@ The minimum storage requirements will change over time as the Nitro chain grows 
 
 ### Review and configure parameters
 
-| Parameter                                   | Description                                                                                                                                                               |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--l1.url=<Layer 1 Ethereum RPC URL>`       | Provide an standard L1 node RPC endpoint that you run yourself or from a third-party node provider (see [RPC endpoints and providers](/node-running/node-providers.mdx) ) |
-| `--l2.chain-id=<L2 Chain ID>`               | See [RPC endpoints and providers](/node-running/node-providers.mdx#rpc-endpoints) for a list of Arbitrum chains and the respective L2 chain IDs                           |
-| `--node.caching.archive`                    | Required for running an **Arbitrum One Nitro** archival node and retains past block state                                                                                 |
-| `--node.cache.allow-slow-lookup`            | Required for running an **Arbitrum One Classic** archival node. When this option is present, will load old blocks from disk if not in memory cache.                       |
-| `--core.checkpoint-gas-frequency=156250000` | Required for running an **Arbitrum One Classic** archival node.                                                                                                           |
+| Arbitrum Nitro                                             | Arbitrum Classic                            | Description                                                                                                                                                                            |
+| ---------------------------------------------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--parent-chain.connection.url=<Layer 1 Ethereum RPC URL>` | `--l1.url=<Layer 1 Ethereum RPC URL>`       | Provide an standard L1 node RPC endpoint that you run yourself or from a third-party node provider (see [RPC endpoints and providers](/node-running/node-providers.mdx#rpc-providers)) |
+| `--chain.id=<L2 chain ID>`                                 | `--l2.chain-id=<L2 Chain ID>`               | See [RPC endpoints and providers](/node-running/node-providers.mdx#rpc-endpoints) for a list of Arbitrum chains and the respective L2 chain IDs                                        |
+| `--node.caching.archive`                                   | `--node.caching.archive`                    | Required for running an **Arbitrum One Nitro** archival node and retains past block state                                                                                              |
+| `--node.cache.allow-slow-lookup`                           | `--node.cache.allow-slow-lookup`            | Required for running an **Arbitrum One Classic** archival node. When this option is present, it will load old blocks from disk if not in memory cache.                                 |
+| `--core.checkpoint-gas-frequency=156250000`                | `--core.checkpoint-gas-frequency=156250000` | Required for running an **Arbitrum One Classic** archival node.                                                                                                                        |
 
 ### Run the Docker image(s)
 

--- a/website/src/resources/globalVars.js
+++ b/website/src/resources/globalVars.js
@@ -32,12 +32,9 @@ const globalVars = {
   nitroVersionTag: 'v2.1.0',
   nitroPathToPrecompiles: 'precompiles',
 
-  nitroContractsRepositorySlug: 'nitro',
-  nitroContractsCommit: 'v2.0.14',
-  nitroContractsPathToPrecompilesInterface: 'contracts/src/precompiles',
-
-  // Orbit Github references
-  orbitNitroContractsCommit: '97cfbe00ff0eea4d7f5f5f3afb01598c19ddabc4',
+  nitroContractsRepositorySlug: 'nitro-contracts',
+  nitroContractsCommit: '9edc1b943ed0255f050f91f265d96bc1ad9de1a2',
+  nitroContractsPathToPrecompilesInterface: 'src/precompiles',
 
   // gas floor
   arbOneGasFloorGwei: '0.1',

--- a/website/src/scripts/precompile-reference-generator.ts
+++ b/website/src/scripts/precompile-reference-generator.ts
@@ -25,7 +25,8 @@ type PrecompileEventOverrides = {
   [key: string]: PrecompileEventInfo;
 };
 
-const partialTablesBasePath = '../arbitrum-docs/arbos/_partials/precompile-tables';
+const partialTablesBasePath =
+  '../arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables';
 const interfaceBaseUrl = `https://github.com/OffchainLabs/${globalVars.nitroContractsRepositorySlug}/blob/${globalVars.nitroContractsCommit}/${globalVars.nitroContractsPathToPrecompilesInterface}/`;
 const implementationBaseUrl = `https://github.com/OffchainLabs/${globalVars.nitroRepositorySlug}/blob/${globalVars.nitroVersionTag}/${globalVars.nitroPathToPrecompiles}/`;
 const defaultDeprecationNotice = `<p>Note: methods marked with ⚠️ are deprecated and their use is not supported.</p>`;


### PR DESCRIPTION
This PR updates the reference information of the precompiles and adds a few changes in other pages:
- Since 2.1.0, precompiles live in a different repository than [nitro](https://github.com/OffchainLabs/nitro/), they are now in [nitro-contracts](https://github.com/OffchainLabs/nitro-contracts)
- Updated references to the nitro and nitro-contracts repositories in the Orbit section of how to add new precompiles
- Moved a few changes from #336 to this repo
