### PR TITLE
fix(quickstart-hardhat): update deploy.js code to work with latest ve…

### DIFF
--- a/arbitrum-docs/for-devs/quickstart-solidity-hardhat.md
+++ b/arbitrum-docs/for-devs/quickstart-solidity-hardhat.md
@@ -173,11 +173,9 @@ Open `scripts/deploy.js` and replace its contents with the following:
 const hre = require('hardhat');
 
 async function main() {
-  const VendingMachineFactory = await hre.ethers.getContractFactory('VendingMachine');
-  const vendingMachine = await VendingMachineFactory.deploy();
-  await vendingMachine.deployed();
-
-  console.log(`Cupcake vending machine deployed to ${vendingMachine.address}`);
+  const vendingMachine = await hre.ethers.deployContract("VendingMachine");
+  await vendingMachine.waitForDeployment();
+  console.log(`Cupcake vending machine deployed to ${vendingMachine.target}`);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
…rsion of hardhat

The previous code with latest hardhat update doesn't work anymore, this produces the same output compiles correctly.

before:

```
% yarn hardhat run scripts/deploy.js --network localhost
yarn run v1.22.19
$ /Documents/GitHub/arbitrum-test/node_modules/.bin/hardhat run scripts/deploy.js --network localhost
TypeError: vendingMachine.deployed is not a function
    at main (/Documents/GitHub/arbitrum-test/scripts/deploy.js:6:24)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
error Command failed with exit code 1.
```

after:
```
% yarn hardhat run scripts/deploy.js --network localhost
yarn run v1.22.19
$ /Documents/GitHub/arbitrum-test/node_modules/.bin/hardhat run scripts/deploy.js --network localhost
Cupcake vending machine deployed to <address>
✨  Done in 1.51s.
```
