### PR TITLE
Fix 403 error on contributions from forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,7 @@ name: Check format
 run-name: Checking format
 
 on:
-  pull_request_target:
-    branches:
-      - master
+  - pull_request_target
 
 jobs:
   install:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,9 @@ name: Check format
 run-name: Checking format
 
 on:
-  - pull_request_target
+  pull_request_target:
+    branches:
+      - master
 
 jobs:
   install:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,9 @@ name: Check format
 run-name: Checking format
 
 on:
-  - pull_request
+  pull_request:
+    branches:
+      - master
 
 jobs:
   install:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,7 @@ name: Check format
 run-name: Checking format
 
 on:
-  pull_request:
-    branches:
-      - master
+  - pull_request
 
 jobs:
   install:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,9 @@ name: Check format
 run-name: Checking format
 
 on:
-  - pull_request
+  pull_request:
+    branches:
+      - master
 
 jobs:
   install:
@@ -48,7 +50,7 @@ jobs:
       - name: Output formatting error
         if: |
           steps.prettier-check.outputs.format-check-result == 1 &&
-          ${{ github.event.pull_request.head.repo.full_name == 'OffchainLabs/arbitrum-docs' }}
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,7 @@ name: Check format
 run-name: Checking format
 
 on:
-  pull_request:
-    branches:
-      - master
+  - pull_request_target
 
 jobs:
   install:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Check format
 run-name: Checking format
 
 on:
-  - pull_request_target
+  - pull_request
 
 jobs:
   install:
@@ -46,7 +46,9 @@ jobs:
           echo "format-check-result=$?" >> $GITHUB_OUTPUT
       
       - name: Output formatting error
-        if: steps.prettier-check.outputs.format-check-result == 1
+        if: |
+          steps.prettier-check.outputs.format-check-result == 1 &&
+          ${{ github.event.pull_request.head.repo.full_name == 'OffchainLabs/arbitrum-docs' }}
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/arbitrum-docs/node-running/how-tos/build-nitro-locally.md
+++ b/arbitrum-docs/node-running/how-tos/build-nitro-locally.md
@@ -13,6 +13,9 @@ import PublicPreviewBannerPartial from '../../partials/_public-preview-banner-pa
 
 This how-to assumes that you're running one of the following operating systems:
 
+
+
+
 - [Debian 11.7 (arm64)](https://cdimage.debian.org/cdimage/archive/11.7.0/arm64/iso-cd/debian-11.7.0-arm64-netinst.iso)
 - [Ubuntu 22.04 (amd64)](https://releases.ubuntu.com/22.04.2/ubuntu-22.04.2-desktop-amd64.iso)
 - [MacOS Ventura 13.4](https://developer.apple.com/documentation/macos-release-notes/macos-13_4-release-notes).

--- a/arbitrum-docs/node-running/how-tos/build-nitro-locally.md
+++ b/arbitrum-docs/node-running/how-tos/build-nitro-locally.md
@@ -13,9 +13,6 @@ import PublicPreviewBannerPartial from '../../partials/_public-preview-banner-pa
 
 This how-to assumes that you're running one of the following operating systems:
 
-
-
-
 - [Debian 11.7 (arm64)](https://cdimage.debian.org/cdimage/archive/11.7.0/arm64/iso-cd/debian-11.7.0-arm64-netinst.iso)
 - [Ubuntu 22.04 (amd64)](https://releases.ubuntu.com/22.04.2/ubuntu-22.04.2-desktop-amd64.iso)
 - [MacOS Ventura 13.4](https://developer.apple.com/documentation/macos-release-notes/macos-13_4-release-notes).


### PR DESCRIPTION
This PR temporarily disables the format checker for contributions coming from forked repositories. For context, contributions from forked repositories that contain formatting errors, throw when trying to write the comment on the PR (the contribution is coming from a different repository which doesn't have rights to access the writing API for this repo).

Until a better solution is found, disabling seems to be the best option to unblock those external contributions.