### PR TITLE
Fix: glossary reference to Arbitrum Rollup protocol

### DIFF
--- a/arbitrum-docs/for-devs/quickstart-solidity-hardhat.md
+++ b/arbitrum-docs/for-devs/quickstart-solidity-hardhat.md
@@ -61,9 +61,10 @@ We'll install the rest of our dependencies as we go.
   - These transactions can be expensive when the network is under heavy load.
 - **Arbitrum**
   - Arbitrum is a suite of L2 scaling solutions for dApp developers.
-  - <a data-quicklook-from="arbitrum-one">Arbitrum One</a> is an L2 chain that implements the <a data-quicklook-from="arbitrum-rollup">
-      Arbitrum Rollup
-    </a> protocol.
+  - <a data-quicklook-from="arbitrum-one">Arbitrum One</a> is an L2 chain that implements the <a data-quicklook-from="arbitrum-rollup-protocol">
+      Arbitrum Rollup protocol
+    </a>
+    .
   - You can use Arbitrum One to build user-friendly dApps with high throughput, low latency, and low transaction costs while inheriting Ethereum's high security standards[^4].
 
 Let's review our vending machine's Javascript implementation, then convert it into a Solidity smart contract, then deploy it to Arbitrum One.


### PR DESCRIPTION
[Preview](https://nitro-docs-git-glossary-ref-fix-offchain-labs.vercel.app/for-devs/quickstart-solidity-hardhat#ethereum-and-arbitrum-in-a-nutshell)

Formatting error fixed in #673 