### PR TITLE
Hide precompile partial views from search engine

### DIFF
--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbAddressTable.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbAddressTable.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAddressTable.go#L17"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbAddressTable.go#L17"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAddressTable.go#L22"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbAddressTable.go#L22"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAddressTable.go#L27"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbAddressTable.go#L27"
           target="_blank"
         >
           Implementation
@@ -90,7 +90,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAddressTable.go#L40"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbAddressTable.go#L40"
           target="_blank"
         >
           Implementation
@@ -112,7 +112,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAddressTable.go#L52"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbAddressTable.go#L52"
           target="_blank"
         >
           Implementation
@@ -134,7 +134,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAddressTable.go#L67"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbAddressTable.go#L67"
           target="_blank"
         >
           Implementation
@@ -156,7 +156,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAddressTable.go#L73"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbAddressTable.go#L73"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbAggregator.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbAggregator.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAggregator.go#L24"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbAggregator.go#L24"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAggregator.go#L30"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbAggregator.go#L30"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAggregator.go#L35"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbAggregator.go#L35"
           target="_blank"
         >
           Implementation
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAggregator.go#L39"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbAggregator.go#L39"
           target="_blank"
         >
           Implementation
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAggregator.go#L62"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbAggregator.go#L62"
           target="_blank"
         >
           Implementation
@@ -132,7 +132,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAggregator.go#L71"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbAggregator.go#L71"
           target="_blank"
         >
           Implementation
@@ -157,7 +157,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAggregator.go#L93"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbAggregator.go#L93"
           target="_blank"
         >
           Implementation
@@ -179,7 +179,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbAggregator.go#L99"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbAggregator.go#L99"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbDebug.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbDebug.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbDebug.go#L55"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbDebug.go#L55"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbDebug.go#L27"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbDebug.go#L27"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbDebug.go#L45"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbDebug.go#L45"
           target="_blank"
         >
           Implementation
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbDebug.go#L50"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbDebug.go#L50"
           target="_blank"
         >
           Implementation
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbDebug.go#L59"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbDebug.go#L59"
           target="_blank"
         >
           Implementation
@@ -144,7 +144,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbDebug.go#L32"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbDebug.go#L32"
           target="_blank"
         >
           Implementation
@@ -168,7 +168,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbDebug.go#L37"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbDebug.go#L37"
           target="_blank"
         >
           Implementation
@@ -192,7 +192,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbDebug.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbDebug.go#L0"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbFunctionTable.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbFunctionTable.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbFunctionTable.go#L19"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbFunctionTable.go#L19"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbFunctionTable.go#L24"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbFunctionTable.go#L24"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbFunctionTable.go#L29"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbFunctionTable.go#L29"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbGasInfo.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbGasInfo.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L26"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbGasInfo.go#L26"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L91"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbGasInfo.go#L91"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L96"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbGasInfo.go#L96"
           target="_blank"
         >
           Implementation
@@ -90,7 +90,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L138"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbGasInfo.go#L138"
           target="_blank"
         >
           Implementation
@@ -112,7 +112,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L143"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbGasInfo.go#L143"
           target="_blank"
         >
           Implementation
@@ -134,7 +134,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L151"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbGasInfo.go#L151"
           target="_blank"
         >
           Implementation
@@ -156,7 +156,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L156"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbGasInfo.go#L156"
           target="_blank"
         >
           Implementation
@@ -178,7 +178,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L161"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbGasInfo.go#L161"
           target="_blank"
         >
           Implementation
@@ -202,7 +202,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L166"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbGasInfo.go#L166"
           target="_blank"
         >
           Implementation
@@ -224,7 +224,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L171"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbGasInfo.go#L171"
           target="_blank"
         >
           Implementation
@@ -246,7 +246,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L176"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbGasInfo.go#L176"
           target="_blank"
         >
           Implementation
@@ -268,7 +268,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L181"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbGasInfo.go#L181"
           target="_blank"
         >
           Implementation
@@ -290,7 +290,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L186"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbGasInfo.go#L186"
           target="_blank"
         >
           Implementation
@@ -312,7 +312,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L191"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbGasInfo.go#L191"
           target="_blank"
         >
           Implementation
@@ -334,7 +334,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L196"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbGasInfo.go#L196"
           target="_blank"
         >
           Implementation
@@ -359,7 +359,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L200"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbGasInfo.go#L200"
           target="_blank"
         >
           Implementation
@@ -381,7 +381,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L236"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbGasInfo.go#L236"
           target="_blank"
         >
           Implementation
@@ -405,7 +405,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L240"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbGasInfo.go#L240"
           target="_blank"
         >
           Implementation
@@ -427,7 +427,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbGasInfo.go#L244"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbGasInfo.go#L244"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbInfo.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbInfo.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbInfo.go#L17"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbInfo.go#L17"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbInfo.go#L25"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbInfo.go#L25"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwner.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwner.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L34"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L34"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L39"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L39"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L48"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L48"
           target="_blank"
         >
           Implementation
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L53"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L53"
           target="_blank"
         >
           Implementation
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L58"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L58"
           target="_blank"
         >
           Implementation
@@ -134,7 +134,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L63"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L63"
           target="_blank"
         >
           Implementation
@@ -156,7 +156,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L68"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L68"
           target="_blank"
         >
           Implementation
@@ -178,7 +178,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L73"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L73"
           target="_blank"
         >
           Implementation
@@ -200,7 +200,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L78"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L78"
           target="_blank"
         >
           Implementation
@@ -222,7 +222,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L83"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L83"
           target="_blank"
         >
           Implementation
@@ -244,7 +244,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L88"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L88"
           target="_blank"
         >
           Implementation
@@ -266,7 +266,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L93"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L93"
           target="_blank"
         >
           Implementation
@@ -288,7 +288,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L98"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L98"
           target="_blank"
         >
           Implementation
@@ -310,7 +310,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L103"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L103"
           target="_blank"
         >
           Implementation
@@ -332,7 +332,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L108"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L108"
           target="_blank"
         >
           Implementation
@@ -354,7 +354,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L113"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L113"
           target="_blank"
         >
           Implementation
@@ -376,7 +376,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L117"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L117"
           target="_blank"
         >
           Implementation
@@ -398,7 +398,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L121"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L121"
           target="_blank"
         >
           Implementation
@@ -420,7 +420,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L125"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L125"
           target="_blank"
         >
           Implementation
@@ -442,7 +442,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L129"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L129"
           target="_blank"
         >
           Implementation
@@ -464,7 +464,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L133"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L133"
           target="_blank"
         >
           Implementation
@@ -486,7 +486,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L137"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L137"
           target="_blank"
         >
           Implementation
@@ -508,7 +508,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L141"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L141"
           target="_blank"
         >
           Implementation
@@ -530,7 +530,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L145"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L149"
           target="_blank"
         >
           Implementation
@@ -552,7 +552,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L165"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L169"
           target="_blank"
         >
           Implementation
@@ -586,7 +586,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwner.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L0"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwnerPublic.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwnerPublic.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwnerPublic.go#L34"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwnerPublic.go#L34"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwnerPublic.go#L25"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwnerPublic.go#L25"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwnerPublic.go#L20"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwnerPublic.go#L20"
           target="_blank"
         >
           Implementation
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwnerPublic.go#L39"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwnerPublic.go#L39"
           target="_blank"
         >
           Implementation
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwnerPublic.go#L44"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwnerPublic.go#L44"
           target="_blank"
         >
           Implementation
@@ -144,7 +144,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbOwnerPublic.go#L30"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwnerPublic.go#L30"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbRetryableTx.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbRetryableTx.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L49"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbRetryableTx.go#L49"
           target="_blank"
         >
           Implementation
@@ -47,7 +47,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L134"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbRetryableTx.go#L134"
           target="_blank"
         >
           Implementation
@@ -69,7 +69,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L139"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbRetryableTx.go#L139"
           target="_blank"
         >
           Implementation
@@ -91,7 +91,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L156"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbRetryableTx.go#L156"
           target="_blank"
         >
           Implementation
@@ -113,7 +113,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L184"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbRetryableTx.go#L184"
           target="_blank"
         >
           Implementation
@@ -135,7 +135,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L197"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbRetryableTx.go#L197"
           target="_blank"
         >
           Implementation
@@ -157,7 +157,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L225"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbRetryableTx.go#L225"
           target="_blank"
         >
           Implementation
@@ -179,7 +179,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L232"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbRetryableTx.go#L232"
           target="_blank"
         >
           Implementation
@@ -216,7 +216,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbRetryableTx.go#L0"
           target="_blank"
         >
           Implementation
@@ -238,7 +238,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L179"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbRetryableTx.go#L179"
           target="_blank"
         >
           Implementation
@@ -260,7 +260,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L116"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbRetryableTx.go#L116"
           target="_blank"
         >
           Implementation
@@ -282,7 +282,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L222"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbRetryableTx.go#L222"
           target="_blank"
         >
           Implementation
@@ -304,7 +304,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbRetryableTx.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbRetryableTx.go#L0"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbStatistics.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbStatistics.md
@@ -10,11 +10,11 @@
   <tbody>
     <tr>
       <td>
-        <code>burnArbGas(uint256 gasAmount)</code>
+        <code>getStats()</code>
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbosTest.sol#L13"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbStatistics.sol#L18"
           target="_blank"
         >
           Interface
@@ -22,13 +22,16 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbosTest.go#L16"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbStatistics.go#L18"
           target="_blank"
         >
           Implementation
         </a>
       </td>
-      <td>BurnArbGas unproductively burns the amount of L2 ArbGas</td>
+      <td>
+        GetStats returns the current block number and some statistics about the rollup's pre-Nitro
+        state
+      </td>
     </tr>
   </tbody>
 </table>

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbSys.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbSys.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L33"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbSys.go#L33"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L38"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbSys.go#L38"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L59"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbSys.go#L59"
           target="_blank"
         >
           Implementation
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L64"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbSys.go#L64"
           target="_blank"
         >
           Implementation
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L70"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbSys.go#L70"
           target="_blank"
         >
           Implementation
@@ -132,7 +132,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L75"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbSys.go#L75"
           target="_blank"
         >
           Implementation
@@ -154,7 +154,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L80"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbSys.go#L80"
           target="_blank"
         >
           Implementation
@@ -176,7 +176,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L85"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbSys.go#L85"
           target="_blank"
         >
           Implementation
@@ -198,7 +198,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L95"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbSys.go#L95"
           target="_blank"
         >
           Implementation
@@ -222,7 +222,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L207"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbSys.go#L207"
           target="_blank"
         >
           Implementation
@@ -244,7 +244,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L111"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbSys.go#L111"
           target="_blank"
         >
           Implementation
@@ -266,7 +266,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L191"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbSys.go#L191"
           target="_blank"
         >
           Implementation
@@ -303,7 +303,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L170"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbSys.go#L170"
           target="_blank"
         >
           Implementation
@@ -325,7 +325,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbSys.go#L0"
           target="_blank"
         >
           Implementation
@@ -349,7 +349,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbSys.go#L154"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbSys.go#L154"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbosTest.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbosTest.md
@@ -10,11 +10,11 @@
   <tbody>
     <tr>
       <td>
-        <code>getStats()</code>
+        <code>burnArbGas(uint256 gasAmount)</code>
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbStatistics.sol#L18"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbosTest.sol#L13"
           target="_blank"
         >
           Interface
@@ -22,16 +22,13 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.1.0/precompiles/ArbStatistics.go#L18"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbosTest.go#L16"
           target="_blank"
         >
           Implementation
         </a>
       </td>
-      <td>
-        GetStats returns the current block number and some statistics about the rollup's pre-Nitro
-        state
-      </td>
+      <td>BurnArbGas unproductively burns the amount of L2 ArbGas</td>
     </tr>
   </tbody>
 </table>

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/precompiles.mdx
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/precompiles.mdx
@@ -70,7 +70,7 @@ This section is divided into two tables. We first list precompiles we expect use
 
 ArbAddressTable ([Interface][arbaddresstable_link_interface] | [Implementation][arbaddresstable_link_implementation]) provides the ability to create short-hands for commonly used accounts.
 
-import ArbAddressTableRef from './partials/precompile-tables/ArbAddressTable.md';
+import ArbAddressTableRef from './partials/precompile-tables/_ArbAddressTable.md';
 
 <ArbAddressTableRef />
 
@@ -80,7 +80,7 @@ ArbAggregator ([Interface][arbaggregator_link_interface] | [Implementation][arba
 
 Compression ratios are measured in basis points. Methods that are checkmarked are access-controlled and will revert if not called by the aggregator, its fee collector, or a chain owner.
 
-import ArbAggregatorRef from './partials/precompile-tables/ArbAggregator.md';
+import ArbAggregatorRef from './partials/precompile-tables/_ArbAggregator.md';
 
 <ArbAggregatorRef />
 
@@ -96,7 +96,7 @@ This precompile has been disabled. It previously provided a registry of BLS publ
 
 ArbDebug ([Interface][arbdebug_link_interface] | [Implementation][arbdebug_link_implementation]) provides mechanisms useful for testing. The methods of `ArbDebug` are only available for chains with the `AllowDebugPrecompiles` chain parameter set. Otherwise, calls to this precompile will revert.
 
-import ArbDebugRef from './partials/precompile-tables/ArbDebug.md';
+import ArbDebugRef from './partials/precompile-tables/_ArbDebug.md';
 
 <ArbDebugRef />
 
@@ -104,7 +104,7 @@ import ArbDebugRef from './partials/precompile-tables/ArbDebug.md';
 
 ArbFunctionTable ([Interface][arbfunctiontable_link_interface] | [Implementation][arbfunctiontable_link_implementation]) provides aggregators the ability to manage function tables, to enable one form of transaction compression. The Nitro aggregator implementation does not use these, so these methods have been stubbed and their effects disabled. They are kept for backwards compatibility.
 
-import ArbFunctionTableRef from './partials/precompile-tables/ArbFunctionTable.md';
+import ArbFunctionTableRef from './partials/precompile-tables/_ArbFunctionTable.md';
 
 <ArbFunctionTableRef />
 
@@ -112,7 +112,7 @@ import ArbFunctionTableRef from './partials/precompile-tables/ArbFunctionTable.m
 
 ArbGasInfo ([Interface][arbgasinfo_link_interface] | [Implementation][arbgasinfo_link_implementation]) provides insight into the cost of using the chain. These methods have been adjusted to account for Nitro's heavy use of calldata compression. Of note to end-users, we no longer make a distinction between non-zero and zero-valued calldata bytes.
 
-import ArbGasInfoRef from './partials/precompile-tables/ArbGasInfo.md';
+import ArbGasInfoRef from './partials/precompile-tables/_ArbGasInfo.md';
 
 <ArbGasInfoRef />
 
@@ -120,7 +120,7 @@ import ArbGasInfoRef from './partials/precompile-tables/ArbGasInfo.md';
 
 ArbInfo ([Interface][arbinfo_link_interface] | [Implementation][arbinfo_link_implementation]) provides the ability to lookup basic info about accounts and contracts.
 
-import ArbInfoRef from './partials/precompile-tables/ArbInfo.md';
+import ArbInfoRef from './partials/precompile-tables/_ArbInfo.md';
 
 <ArbInfoRef />
 
@@ -128,7 +128,7 @@ import ArbInfoRef from './partials/precompile-tables/ArbInfo.md';
 
 ArbosTest ([Interface][arbostest_link_interface] | [Implementation][arbostest_link_implementation]) provides a method of burning arbitrary amounts of gas, which exists for historical reasons. In Classic, `ArbosTest` had additional methods only the zero address could call. These have been removed since users don't use them and calls to missing methods revert.
 
-import ArbosTestRef from './partials/precompile-tables/ArbosTest.md';
+import ArbosTestRef from './partials/precompile-tables/_ArbosTest.md';
 
 <ArbosTestRef />
 
@@ -142,7 +142,7 @@ Most of Arbitrum Classic's owner methods have been removed since they no longer 
 - ArbOS upgrades happen with the rest of the system rather than being independent
 - Exemptions to address aliasing are no longer offered. Exemptions were intended to support backward compatibility for contracts deployed before aliasing was introduced, but no exemptions were ever requested.
 
-import ArbOwnerRef from './partials/precompile-tables/ArbOwner.md';
+import ArbOwnerRef from './partials/precompile-tables/_ArbOwner.md';
 
 <ArbOwnerRef />
 
@@ -150,7 +150,7 @@ import ArbOwnerRef from './partials/precompile-tables/ArbOwner.md';
 
 ArbOwnerPublic ([Interface][arbownerpublic_link_interface] | [Implementation][arbownerpublic_link_implementation]) provides non-owners with info about the current chain owners.
 
-import ArbOwnerPublicRef from './partials/precompile-tables/ArbOwnerPublic.md';
+import ArbOwnerPublicRef from './partials/precompile-tables/_ArbOwnerPublic.md';
 
 <ArbOwnerPublicRef />
 
@@ -158,7 +158,7 @@ import ArbOwnerPublicRef from './partials/precompile-tables/ArbOwnerPublic.md';
 
 ArbRetryableTx ([Interface][arbretryabletx_link_interface] | [Implementation][arbretryabletx_link_implementation]) provides methods for managing retryables. The model has been adjusted for Nitro, most notably in terms of how retry transactions are scheduled. For more information on retryables, please see [the retryable documentation](arbos#Retryables).
 
-import ArbRetryableTxRef from './partials/precompile-tables/ArbRetryableTx.md';
+import ArbRetryableTxRef from './partials/precompile-tables/_ArbRetryableTx.md';
 
 <ArbRetryableTxRef />
 
@@ -166,7 +166,7 @@ import ArbRetryableTxRef from './partials/precompile-tables/ArbRetryableTx.md';
 
 ArbStatistics ([Interface][arbstatistics_link_interface] | [Implementation][arbstatistics_link_implementation]) provides statistics about the chain as of just before the Nitro upgrade. In Arbitrum Classic, this was how a user would get info such as the total number of accounts, but there are better ways to get that info in Nitro.
 
-import ArbStatisticsRef from './partials/precompile-tables/ArbStatistics.md';
+import ArbStatisticsRef from './partials/precompile-tables/_ArbStatistics.md';
 
 <ArbStatisticsRef />
 
@@ -174,6 +174,6 @@ import ArbStatisticsRef from './partials/precompile-tables/ArbStatistics.md';
 
 ArbSys ([Interface][arbsys_link_interface] | [Implementation][arbsys_link_implementation]) provides system-level functionality for interacting with L1 and understanding the call stack.
 
-import ArbSysRef from './partials/precompile-tables/ArbSys.md';
+import ArbSysRef from './partials/precompile-tables/_ArbSys.md';
 
 <ArbSysRef />

--- a/arbitrum-docs/node-running/how-tos/running-a-sequencer-coordinator-manager.mdx
+++ b/arbitrum-docs/node-running/how-tos/running-a-sequencer-coordinator-manager.mdx
@@ -7,7 +7,7 @@ content-type: how-to
 ---
 
 The Sequencer Coordinator Manager is a command-line tool that allows you to manage the priority list of sequencers, update their positions, add new sequencers to the list, and refresh the lists from the Redis server.
-The tool offers keyboard-only support. Any changes you make are stored locally until you choose to save and push them to the Redis server. 
+The tool offers keyboard-only support. Any changes you make are stored locally until you choose to save and push them to the Redis server.
 
 - Here is an example of how to start the Sequencer Coordinator Manager and connect to a local Redis server:
   ```shell

--- a/website/src/scripts/precompile-reference-generator.ts
+++ b/website/src/scripts/precompile-reference-generator.ts
@@ -249,7 +249,7 @@ const generatePrecompileReferenceTables = async (
     eventOverrides,
   );
 
-  fs.writeFileSync(`${partialTablesBasePath}/${precompileName}.md`, methodsTable + eventsTable);
+  fs.writeFileSync(`${partialTablesBasePath}/_${precompileName}.md`, methodsTable + eventsTable);
 };
 
 const main = async (precompilesInformation) => {


### PR DESCRIPTION
When using the search box to search content of the partial views of the precompiles, the actual partial views are part of the results. For example, you can search `setMinimumL2BaseFee`.
This PR fixes that so those partial files do not appear in the results.
This PR also include changes from running the format command.