### PR TITLE
Add NodeInterface pages

### DIFF
--- a/arbitrum-docs/arbos/gas.mdx
+++ b/arbitrum-docs/arbos/gas.mdx
@@ -27,21 +27,6 @@ When a transaction schedules another, the subsequent transaction's execution [wi
 
 Because a call to [`redeem`](/for-devs/dev-tools-and-resources/precompiles.mdx#arbretryabletx) donates all of the call's gas, doing multiple requires limiting the amount of gas provided to each subcall. Otherwise the first will take all of the gas and force the second to necessarily fail irrespective of the estimation's gas limit.
 
-Gas estimation for Retryable submissions is possible via [`NodeInterface.sol`][node_interface_link] and similarly requires the auto-redeem attempt succeed.
+Gas estimation for Retryable submissions is possible via the [NodeInterface](/for-devs/dev-tools-and-resources/nodeinterface.mdx) and similarly requires the auto-redeem attempt succeed.
 
 [estimation_inclusion_link]: https://github.com/OffchainLabs/go-ethereum/blob/d52739e6d54f2ea06146fdc44947af3488b89082/internal/ethapi/api.go#L999
-[node_interface_link]: https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/node-interface/NodeInterface.sol
-
-## NodeInterface.sol
-
-To avoid creating new RPC methods for client-side tooling, nitro Geth's [`InterceptRPCMessage`][interceptrpcmessage_link] hook provides an opportunity to swap out the message its handling before deriving a transaction from it. The node [uses this hook][use_hook_link] to detect messages sent to the address `0xc8`, the location of the fictional `NodeInterface` contract specified in [`NodeInterface.sol`][node_interface_link].
-
-`NodeInterface` isn't deployed on L2 and only exists in the RPC, but it contains methods callable via `0xc8`. Doing so requires setting the `To` field to `0xc8` and supplying calldata for the method. Below is the list of methods.
-
-| Method                                                           | Info                                                |
-| :--------------------------------------------------------------- | :-------------------------------------------------- |
-| [`estimateRetryableTicket`][estimateretryableticket_link] &nbsp; | Estimates the gas needed for a retryable submission |
-
-[interceptrpcmessage_link]: https://github.com/OffchainLabs/go-ethereum/blob/d52739e6d54f2ea06146fdc44947af3488b89082/internal/ethapi/api.go#L965
-[use_hook_link]: https://github.com/OffchainLabs/nitro/blob/v2.0.14/nodeInterface/NodeInterface.go#L32
-[estimateretryableticket_link]: https://github.com/OffchainLabs/nitro/blob/v2.0.14/contracts/src/node-interface/NodeInterface.sol#L25

--- a/arbitrum-docs/arbos/gas.mdx
+++ b/arbitrum-docs/arbos/gas.mdx
@@ -27,6 +27,6 @@ When a transaction schedules another, the subsequent transaction's execution [wi
 
 Because a call to [`redeem`](/for-devs/dev-tools-and-resources/precompiles.mdx#arbretryabletx) donates all of the call's gas, doing multiple requires limiting the amount of gas provided to each subcall. Otherwise the first will take all of the gas and force the second to necessarily fail irrespective of the estimation's gas limit.
 
-Gas estimation for Retryable submissions is possible via the [NodeInterface](/for-devs/dev-tools-and-resources/nodeinterface.mdx) and similarly requires the auto-redeem attempt succeed.
+Gas estimation for Retryable submissions is possible via the [NodeInterface](/for-devs/dev-tools-and-resources/nodeinterface.mdx) and similarly requires the auto-redeem attempt to succeed.
 
 [estimation_inclusion_link]: https://github.com/OffchainLabs/go-ethereum/blob/d52739e6d54f2ea06146fdc44947af3488b89082/internal/ethapi/api.go#L999

--- a/arbitrum-docs/arbos/geth.mdx
+++ b/arbitrum-docs/arbos/geth.mdx
@@ -203,11 +203,11 @@ A [geth message][geth_message_link] may be processed for various purposes. For e
 
 A message [derived from a transaction][asmessage_link] will carry that transaction in a field accessible via its [`UnderlyingTransaction`][underlying_link] method. While this is related to the way a given message is used, they are not one-to-one. The table below shows the various run modes and whether each could have an underlying transaction.
 
-| Run Mode                                 | Scope                   | Carries an Underlying Tx?                                                       |
-| :--------------------------------------- | :---------------------- | :------------------------------------------------------------------------------ |
-| [`MessageCommitMode`][mc0]               | state transition &nbsp; | always                                                                          |
-| [`MessageGasEstimationMode`][mc1] &nbsp; | gas estimation          | when created via [`NodeInterface.sol`](gas#NodeInterface.sol) or when scheduled |
-| [`MessageEthcallMode`][mc2]              | eth_calls               | never                                                                           |
+| Run Mode                                 | Scope                   | Carries an Underlying Tx?                                                                               |
+| :--------------------------------------- | :---------------------- | :------------------------------------------------------------------------------------------------------ |
+| [`MessageCommitMode`][mc0]               | state transition &nbsp; | always                                                                                                  |
+| [`MessageGasEstimationMode`][mc1] &nbsp; | gas estimation          | when created via [NodeInterface](/for-devs/dev-tools-and-resources/nodeinterface.mdx) or when scheduled |
+| [`MessageEthcallMode`][mc2]              | eth_calls               | never                                                                                                   |
 
 [mc0]: https://github.com/OffchainLabs/go-ethereum/blob/7503143fd13f73e46a966ea2c42a058af96f7fcf/core/types/transaction.go#L654
 [mc1]: https://github.com/OffchainLabs/go-ethereum/blob/7503143fd13f73e46a966ea2c42a058af96f7fcf/core/types/transaction.go#L655

--- a/arbitrum-docs/arbos/l1-pricing.mdx
+++ b/arbitrum-docs/arbos/l1-pricing.mdx
@@ -51,6 +51,6 @@ A second term is added to the L1 Gas Basefee, based on the derivative of the sur
 
 ## Getting L1 Fee Info
 
-The L1 gas basefee can be queried via [`ArbGasInfo.getL1BaseFeeEstimate`](/for-devs/dev-tools-and-resources/precompiles.mdx#arbgasinfo). To estimate the L1 fee a transaction will use, the [`NodeInterface.gasEstimateComponents`](gas.mdx) or [`NodeInterface.gasEstimateL1Component`](gas.mdx) method can be used.
+The L1 gas basefee can be queried via [`ArbGasInfo.getL1BaseFeeEstimate`](/for-devs/dev-tools-and-resources/precompiles.mdx#arbgasinfo). To estimate the L1 fee a transaction will use, the [NodeInterface.gasEstimateComponents()](/for-devs/dev-tools-and-resources/nodeinterface.mdx) or [NodeInterface.gasEstimateL1Component()](/for-devs/dev-tools-and-resources/nodeinterface.mdx) method can be used.
 
 Arbitrum transaction receipts include a `gasUsedForL1` field, showing the amount of gas used on L1 in units of L2 gas.

--- a/arbitrum-docs/arbos/l1-pricing.mdx
+++ b/arbitrum-docs/arbos/l1-pricing.mdx
@@ -41,7 +41,7 @@ The pricer computes an allocation fraction `F = (updateTime-lastUpdateTime) / (c
 
 Now the pricer pays out the allocated funds to cover the rewards due and the amounts due to batch posters, reducing the balance due to each party as a result. If the allocated funds aren't sufficient to cover everything that is due, some amount due will remain. If all of the amount due can be covered with the allocated funds, any remaining allocated funds are returned to the `L1PricerFundsPool`.
 
-## Adjusting the L1 Gas Basefee
+## Adjusting the L1 gas basefee
 
 After allocating funds and paying what is owed, the L1 Pricer adjusts the L1 Gas Basefee. The goal of this process is to find a value that will cause the amount collected to equal the amount owed over time.
 
@@ -49,7 +49,7 @@ The algorithm first computes the surplus (funds in the `L1PricerFundsPool`, minu
 
 A second term is added to the L1 Gas Basefee, based on the derivative of the surplus (surplus at present, minus the surplus after the previous batch posting report was processed). This term, which is multiplied by a smoothing factor to reduce fluctuations, will reduce the Basefee if the surplus is increasing, and increase the Basefee if the surplus is shrinking.
 
-## Getting L1 Fee Info
+## Getting L1 fee info
 
 The L1 gas basefee can be queried via [`ArbGasInfo.getL1BaseFeeEstimate`](/for-devs/dev-tools-and-resources/precompiles.mdx#arbgasinfo). To estimate the L1 fee a transaction will use, the [NodeInterface.gasEstimateComponents()](/for-devs/dev-tools-and-resources/nodeinterface.mdx) or [NodeInterface.gasEstimateL1Component()](/for-devs/dev-tools-and-resources/nodeinterface.mdx) method can be used.
 

--- a/arbitrum-docs/devs-how-tos/how-to-estimate-gas.mdx
+++ b/arbitrum-docs/devs-how-tos/how-to-estimate-gas.mdx
@@ -64,7 +64,7 @@ TXFEES = P * (L2G + ((L1P * L1S) / P))
 
 ## Where do we get all this information from?
 
-We'll use one resource available in Arbitrum: the [NodeInterface](/arbos/gas.mdx#nodeinterfacesol).
+We'll use one resource available in Arbitrum: the [NodeInterface](/for-devs/dev-tools-and-resources/nodeinterface.mdx).
 
 - P (L2 Gas Price) ⇒ Price to pay for each gas unit. It starts at @arbOneGasFloorGwei@ gwei on Arbitrum One (@novaGasFloorGwei@ gwei on Arbitrum Nova) and can increase depending on the demand for network resources.
   - Call `NodeInterface.GasEstimateComponents()` and get the third element, `baseFee`.

--- a/arbitrum-docs/for-devs/concepts/differences-between-arbitrum-ethereum/overview.mdx
+++ b/arbitrum-docs/for-devs/concepts/differences-between-arbitrum-ethereum/overview.mdx
@@ -41,4 +41,4 @@ Besides supporting all precompiles available in Ethereum, Arbitrum provides L2-s
 
 ## NodeInterface
 
-Arbitrum Nitro software includes a special `NodeInterface` contract available at address `0xc8` that is only accessible via RPCs (it's not actually deployed on-chain, and thus can't be called by smart contracts). Find more information about this interface in [NodeInterface](/for-devs/concepts/nodeinterface.mdx).
+The Arbitrum Nitro software includes a special `NodeInterface` contract available at address `0xc8` that is only accessible via RPCs (it's not actually deployed on-chain, and thus can't be called by smart contracts). Find more information about this interface in [NodeInterface](/for-devs/concepts/nodeinterface.mdx).

--- a/arbitrum-docs/for-devs/concepts/differences-between-arbitrum-ethereum/overview.mdx
+++ b/arbitrum-docs/for-devs/concepts/differences-between-arbitrum-ethereum/overview.mdx
@@ -41,4 +41,4 @@ Besides supporting all precompiles available in Ethereum, Arbitrum provides L2-s
 
 ## NodeInterface
 
-Arbitrum Nitro software includes a special `NodeInterface` contract available at address `0xc8` that is only accessible via RPCs (it's not actually deployed on-chain, and thus can't be called by smart contracts). Find more information about this interface in [NodeInterface.sol](/arbos/gas.mdx#nodeinterfacesol).
+Arbitrum Nitro software includes a special `NodeInterface` contract available at address `0xc8` that is only accessible via RPCs (it's not actually deployed on-chain, and thus can't be called by smart contracts). Find more information about this interface in [NodeInterface](/for-devs/concepts/nodeinterface.mdx).

--- a/arbitrum-docs/for-devs/concepts/nodeinterface.mdx
+++ b/arbitrum-docs/for-devs/concepts/nodeinterface.mdx
@@ -1,0 +1,15 @@
+---
+title: 'NodeInterface: A conceptual overview'
+sidebar_label: NodeInterface
+description: A high level description of what the NodeInterface is and how it works
+reader-audience: developers who want to build on Ethereum/Arbitrum
+content-type: concept
+---
+
+import PublicPreviewBannerPartial from '../../partials/_public-preview-banner-partial.md';
+
+<PublicPreviewBannerPartial />
+
+Arbitrum Nitro software includes a special `NodeInterface` contract available at address `0xc8` that is only accessible via RPCs (it's not actually deployed on-chain, and thus can't be called by smart contracts). The way it works is that nodes use Geth's [`InterceptRPCMessage`](https://github.com/OffchainLabs/go-ethereum/blob/@goEthereumCommit@/internal/ethapi/api.go#L1034) hook to detect messages sent to the address `0xc8` and swaps out the message its handling before deriving a transaction from it.
+
+The [reference page](/for-devs/dev-tools-and-resources/nodeinterface.mdx) contains information about all methods available in the NodeInterface.

--- a/arbitrum-docs/for-devs/concepts/nodeinterface.mdx
+++ b/arbitrum-docs/for-devs/concepts/nodeinterface.mdx
@@ -10,6 +10,6 @@ import PublicPreviewBannerPartial from '../../partials/_public-preview-banner-pa
 
 <PublicPreviewBannerPartial />
 
-The Arbitrum Nitro software includes a special `NodeInterface` contract available at address `0xc8` that is only accessible via RPCs (it's not actually deployed on-chain, and thus can't be called by smart contracts). The way it works is that the node uses geth's [`InterceptRPCMessage`](https://github.com/OffchainLabs/go-ethereum/blob/@goEthereumCommit@/internal/ethapi/api.go#L1034) hook to detect messages sent to the address `0xc8`, and swaps out the message it's handling before deriving a transaction from it.
+The Arbitrum Nitro software includes a special `NodeInterface` contract available at address `0xc8` that is only accessible via RPCs (it's not actually deployed on-chain, and thus can't be called by smart contracts). The way it works is that the node uses Geth's [`InterceptRPCMessage`](https://github.com/OffchainLabs/go-ethereum/blob/@goEthereumCommit@/internal/ethapi/api.go#L1034) hook to detect messages sent to the address `0xc8`, and swaps out the message it's handling before deriving a transaction from it.
 
 The [reference page](/for-devs/dev-tools-and-resources/nodeinterface.mdx) contains information about all methods available in the NodeInterface.

--- a/arbitrum-docs/for-devs/concepts/nodeinterface.mdx
+++ b/arbitrum-docs/for-devs/concepts/nodeinterface.mdx
@@ -10,6 +10,6 @@ import PublicPreviewBannerPartial from '../../partials/_public-preview-banner-pa
 
 <PublicPreviewBannerPartial />
 
-Arbitrum Nitro software includes a special `NodeInterface` contract available at address `0xc8` that is only accessible via RPCs (it's not actually deployed on-chain, and thus can't be called by smart contracts). The way it works is that nodes use Geth's [`InterceptRPCMessage`](https://github.com/OffchainLabs/go-ethereum/blob/@goEthereumCommit@/internal/ethapi/api.go#L1034) hook to detect messages sent to the address `0xc8` and swaps out the message its handling before deriving a transaction from it.
+The Arbitrum Nitro software includes a special `NodeInterface` contract available at address `0xc8` that is only accessible via RPCs (it's not actually deployed on-chain, and thus can't be called by smart contracts). The way it works is that the node uses geth's [`InterceptRPCMessage`](https://github.com/OffchainLabs/go-ethereum/blob/@goEthereumCommit@/internal/ethapi/api.go#L1034) hook to detect messages sent to the address `0xc8`, and swaps out the message it's handling before deriving a transaction from it.
 
 The [reference page](/for-devs/dev-tools-and-resources/nodeinterface.mdx) contains information about all methods available in the NodeInterface.

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/nodeinterface.mdx
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/nodeinterface.mdx
@@ -1,0 +1,15 @@
+---
+title: 'NodeInterface reference'
+sidebar_label: NodeInterface reference
+description: A reference page of the NodeInterface available on Arbitrum chains
+reader-audience: developers who want to build on Ethereum/Arbitrum
+content-type: reference
+---
+
+Arbitrum Nitro software includes a special `NodeInterface` contract available at address `0xc8` that is only accessible via RPCs (it's not actually deployed on-chain, and thus can't be called by smart contracts). This reference page documents the specific calls available in the NodeInterface. For a more conceptual description of what it is and how it works, please refer to the [NodeInterface conceptual page](/for-devs/concepts/nodeinterface.mdx).
+
+## NodeInterface methods
+
+import NodeInterfaceRef from './partials/precompile-tables/_NodeInterface.md';
+
+<NodeInterfaceRef />

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/nodeinterface.mdx
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/nodeinterface.mdx
@@ -6,7 +6,7 @@ reader-audience: developers who want to build on Ethereum/Arbitrum
 content-type: reference
 ---
 
-Arbitrum Nitro software includes a special `NodeInterface` contract available at address `0xc8` that is only accessible via RPCs (it's not actually deployed on-chain, and thus can't be called by smart contracts). This reference page documents the specific calls available in the NodeInterface. For a more conceptual description of what it is and how it works, please refer to the [NodeInterface conceptual page](/for-devs/concepts/nodeinterface.mdx).
+The Arbitrum Nitro software includes a special `NodeInterface` contract available at address `0xc8` that is only accessible via RPCs (it's not actually deployed on-chain, and thus can't be called by smart contracts). This reference page documents the specific calls available in the NodeInterface. For a more conceptual description of what it is and how it works, please refer to the [NodeInterface conceptual page](/for-devs/concepts/nodeinterface.mdx).
 
 ## NodeInterface methods
 

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbAddressTable.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbAddressTable.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAddressTable.sol#L17"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbAddressTable.sol#L17"
           target="_blank"
         >
           Interface
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAddressTable.sol#L24"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbAddressTable.sol#L24"
           target="_blank"
         >
           Interface
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAddressTable.sol#L32"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbAddressTable.sol#L32"
           target="_blank"
         >
           Interface
@@ -82,7 +82,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAddressTable.sol#L41"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbAddressTable.sol#L41"
           target="_blank"
         >
           Interface
@@ -104,7 +104,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAddressTable.sol#L47"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbAddressTable.sol#L47"
           target="_blank"
         >
           Interface
@@ -126,7 +126,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAddressTable.sol#L54"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbAddressTable.sol#L54"
           target="_blank"
         >
           Interface
@@ -148,7 +148,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAddressTable.sol#L59"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbAddressTable.sol#L59"
           target="_blank"
         >
           Interface

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbAggregator.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbAggregator.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAggregator.sol#L14"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbAggregator.sol#L14"
           target="_blank"
         >
           Interface
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAggregator.sol#L18"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbAggregator.sol#L18"
           target="_blank"
         >
           Interface
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAggregator.sol#L22"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbAggregator.sol#L22"
           target="_blank"
         >
           Interface
@@ -80,7 +80,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAggregator.sol#L27"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbAggregator.sol#L27"
           target="_blank"
         >
           Interface
@@ -102,7 +102,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAggregator.sol#L32"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbAggregator.sol#L32"
           target="_blank"
         >
           Interface
@@ -124,7 +124,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAggregator.sol#L38"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbAggregator.sol#L38"
           target="_blank"
         >
           Interface
@@ -149,7 +149,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAggregator.sol#L43"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbAggregator.sol#L43"
           target="_blank"
         >
           Interface
@@ -171,7 +171,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbAggregator.sol#L51"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbAggregator.sol#L51"
           target="_blank"
         >
           Interface

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbDebug.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbDebug.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbDebug.sol#L13"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbDebug.sol#L13"
           target="_blank"
         >
           Interface
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbDebug.sol#L16"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbDebug.sol#L16"
           target="_blank"
         >
           Interface
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbDebug.sol#L19"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbDebug.sol#L19"
           target="_blank"
         >
           Interface
@@ -80,7 +80,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbDebug.sol#L38"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbDebug.sol#L38"
           target="_blank"
         >
           Interface
@@ -102,7 +102,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbDebug.sol#L40"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbDebug.sol#L40"
           target="_blank"
         >
           Interface
@@ -136,7 +136,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbDebug.sol#L22"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbDebug.sol#L22"
           target="_blank"
         >
           Interface
@@ -160,7 +160,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbDebug.sol#L23"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbDebug.sol#L23"
           target="_blank"
         >
           Interface
@@ -184,7 +184,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbDebug.sol#L30"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbDebug.sol#L30"
           target="_blank"
         >
           Interface

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbFunctionTable.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbFunctionTable.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbFunctionTable.sol#L15"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbFunctionTable.sol#L15"
           target="_blank"
         >
           Interface
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbFunctionTable.sol#L18"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbFunctionTable.sol#L18"
           target="_blank"
         >
           Interface
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbFunctionTable.sol#L21"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbFunctionTable.sol#L21"
           target="_blank"
         >
           Interface

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbGasInfo.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbGasInfo.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L22"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbGasInfo.sol#L22"
           target="_blank"
         >
           Interface
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L44"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbGasInfo.sol#L44"
           target="_blank"
         >
           Interface
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L58"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbGasInfo.sol#L58"
           target="_blank"
         >
           Interface
@@ -82,7 +82,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L69"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbGasInfo.sol#L69"
           target="_blank"
         >
           Interface
@@ -104,7 +104,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L80"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbGasInfo.sol#L80"
           target="_blank"
         >
           Interface
@@ -126,7 +126,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L90"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbGasInfo.sol#L90"
           target="_blank"
         >
           Interface
@@ -148,7 +148,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L93"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbGasInfo.sol#L93"
           target="_blank"
         >
           Interface
@@ -170,7 +170,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L96"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbGasInfo.sol#L96"
           target="_blank"
         >
           Interface
@@ -194,7 +194,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L100"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbGasInfo.sol#L100"
           target="_blank"
         >
           Interface
@@ -216,7 +216,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L104"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbGasInfo.sol#L104"
           target="_blank"
         >
           Interface
@@ -238,7 +238,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L107"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbGasInfo.sol#L107"
           target="_blank"
         >
           Interface
@@ -260,7 +260,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L110"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbGasInfo.sol#L110"
           target="_blank"
         >
           Interface
@@ -282,7 +282,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L113"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbGasInfo.sol#L113"
           target="_blank"
         >
           Interface
@@ -304,7 +304,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L116"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbGasInfo.sol#L116"
           target="_blank"
         >
           Interface
@@ -326,7 +326,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L119"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbGasInfo.sol#L119"
           target="_blank"
         >
           Interface
@@ -351,7 +351,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L122"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbGasInfo.sol#L122"
           target="_blank"
         >
           Interface
@@ -373,7 +373,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L125"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbGasInfo.sol#L125"
           target="_blank"
         >
           Interface
@@ -397,7 +397,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L128"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbGasInfo.sol#L128"
           target="_blank"
         >
           Interface
@@ -419,7 +419,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbGasInfo.sol#L131"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbGasInfo.sol#L131"
           target="_blank"
         >
           Interface

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbInfo.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbInfo.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbInfo.sol#L11"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbInfo.sol#L11"
           target="_blank"
         >
           Interface
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbInfo.sol#L14"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbInfo.sol#L14"
           target="_blank"
         >
           Interface

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwner.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwner.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L16"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L16"
           target="_blank"
         >
           Interface
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L19"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L19"
           target="_blank"
         >
           Interface
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L22"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L22"
           target="_blank"
         >
           Interface
@@ -80,7 +80,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L25"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L25"
           target="_blank"
         >
           Interface
@@ -102,7 +102,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L28"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L28"
           target="_blank"
         >
           Interface
@@ -126,7 +126,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L31"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L31"
           target="_blank"
         >
           Interface
@@ -148,7 +148,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L34"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L34"
           target="_blank"
         >
           Interface
@@ -170,7 +170,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L37"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L37"
           target="_blank"
         >
           Interface
@@ -192,7 +192,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L40"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L40"
           target="_blank"
         >
           Interface
@@ -214,7 +214,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L43"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L43"
           target="_blank"
         >
           Interface
@@ -236,7 +236,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L46"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L46"
           target="_blank"
         >
           Interface
@@ -258,7 +258,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L49"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L49"
           target="_blank"
         >
           Interface
@@ -280,7 +280,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L52"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L52"
           target="_blank"
         >
           Interface
@@ -302,7 +302,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L55"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L55"
           target="_blank"
         >
           Interface
@@ -324,7 +324,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L58"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L58"
           target="_blank"
         >
           Interface
@@ -346,7 +346,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L61"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L61"
           target="_blank"
         >
           Interface
@@ -368,7 +368,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L64"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L64"
           target="_blank"
         >
           Interface
@@ -390,7 +390,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L67"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L67"
           target="_blank"
         >
           Interface
@@ -412,7 +412,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L70"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L70"
           target="_blank"
         >
           Interface
@@ -434,7 +434,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L73"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L73"
           target="_blank"
         >
           Interface
@@ -456,7 +456,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L76"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L76"
           target="_blank"
         >
           Interface
@@ -478,7 +478,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L79"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L79"
           target="_blank"
         >
           Interface
@@ -496,11 +496,33 @@
     </tr>
     <tr>
       <td>
+        <code>setBrotliCompressionLevel(uint64 level)</code>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L85"
+          target="_blank"
+        >
+          Interface
+        </a>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwner.go#L145"
+          target="_blank"
+        >
+          Implementation
+        </a>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>
         <code>setAmortizedCostCapBips(uint64 cap)</code>
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L82"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L88"
           target="_blank"
         >
           Interface
@@ -522,7 +544,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L85"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L91"
           target="_blank"
         >
           Interface
@@ -544,7 +566,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L88"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L94"
           target="_blank"
         >
           Interface
@@ -578,7 +600,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwner.sol#L91"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwner.sol#L97"
           target="_blank"
         >
           Interface

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwnerPublic.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwnerPublic.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwnerPublic.sol#L11"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwnerPublic.sol#L11"
           target="_blank"
         >
           Interface
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwnerPublic.sol#L18"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwnerPublic.sol#L18"
           target="_blank"
         >
           Interface
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwnerPublic.sol#L21"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwnerPublic.sol#L21"
           target="_blank"
         >
           Interface
@@ -80,7 +80,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwnerPublic.sol#L24"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwnerPublic.sol#L24"
           target="_blank"
         >
           Interface
@@ -102,7 +102,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwnerPublic.sol#L27"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwnerPublic.sol#L27"
           target="_blank"
         >
           Interface
@@ -117,6 +117,31 @@
         </a>
       </td>
       <td>GetInfraFeeAccount gets the infrastructure fee collector</td>
+    </tr>
+    <tr>
+      <td>
+        <code>getBrotliCompressionLevel()</code>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwnerPublic.sol#L30"
+          target="_blank"
+        >
+          Interface
+        </a>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/precompiles/ArbOwnerPublic.go#L52"
+          target="_blank"
+        >
+          Implementation
+        </a>
+      </td>
+      <td>
+        GetBrotliCompressionLevel gets the current brotli compression level used for fast
+        compression
+      </td>
     </tr>
   </tbody>
 </table>
@@ -136,7 +161,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbOwnerPublic.sol#L29"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbOwnerPublic.sol#L32"
           target="_blank"
         >
           Interface

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbRetryableTx.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbRetryableTx.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L18"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbRetryableTx.sol#L18"
           target="_blank"
         >
           Interface
@@ -39,7 +39,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L24"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbRetryableTx.sol#L24"
           target="_blank"
         >
           Interface
@@ -61,7 +61,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L31"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbRetryableTx.sol#L31"
           target="_blank"
         >
           Interface
@@ -83,7 +83,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L41"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbRetryableTx.sol#L41"
           target="_blank"
         >
           Interface
@@ -105,7 +105,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L49"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbRetryableTx.sol#L49"
           target="_blank"
         >
           Interface
@@ -127,7 +127,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L56"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbRetryableTx.sol#L56"
           target="_blank"
         >
           Interface
@@ -149,7 +149,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L63"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbRetryableTx.sol#L63"
           target="_blank"
         >
           Interface
@@ -171,7 +171,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L69"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbRetryableTx.sol#L69"
           target="_blank"
         >
           Interface
@@ -208,7 +208,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L83"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbRetryableTx.sol#L83"
           target="_blank"
         >
           Interface
@@ -230,7 +230,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L84"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbRetryableTx.sol#L84"
           target="_blank"
         >
           Interface
@@ -252,7 +252,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L85"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbRetryableTx.sol#L85"
           target="_blank"
         >
           Interface
@@ -274,7 +274,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L94"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbRetryableTx.sol#L94"
           target="_blank"
         >
           Interface
@@ -296,7 +296,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbRetryableTx.sol#L97"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbRetryableTx.sol#L97"
           target="_blank"
         >
           Interface

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbStatistics.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbStatistics.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbStatistics.sol#L18"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbStatistics.sol#L18"
           target="_blank"
         >
           Interface

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbSys.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbSys.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L17"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbSys.sol#L17"
           target="_blank"
         >
           Interface
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L23"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbSys.sol#L23"
           target="_blank"
         >
           Interface
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L29"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbSys.sol#L29"
           target="_blank"
         >
           Interface
@@ -80,7 +80,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L35"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbSys.sol#L35"
           target="_blank"
         >
           Interface
@@ -102,7 +102,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L41"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbSys.sol#L41"
           target="_blank"
         >
           Interface
@@ -124,7 +124,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L48"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbSys.sol#L48"
           target="_blank"
         >
           Interface
@@ -146,7 +146,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L56"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbSys.sol#L56"
           target="_blank"
         >
           Interface
@@ -168,7 +168,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L65"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbSys.sol#L65"
           target="_blank"
         >
           Interface
@@ -190,7 +190,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L71"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbSys.sol#L71"
           target="_blank"
         >
           Interface
@@ -214,7 +214,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L79"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbSys.sol#L79"
           target="_blank"
         >
           Interface
@@ -236,7 +236,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L89"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbSys.sol#L89"
           target="_blank"
         >
           Interface
@@ -258,7 +258,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L100"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbSys.sol#L100"
           target="_blank"
         >
           Interface
@@ -295,7 +295,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L113"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbSys.sol#L113"
           target="_blank"
         >
           Interface
@@ -317,7 +317,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L126"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbSys.sol#L126"
           target="_blank"
         >
           Interface
@@ -341,7 +341,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbSys.sol#L145"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbSys.sol#L145"
           target="_blank"
         >
           Interface

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbosTest.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbosTest.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/9edc1b943ed0255f050f91f265d96bc1ad9de1a2/src/precompiles/ArbosTest.sol#L13"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/precompiles/ArbosTest.sol#L13"
           target="_blank"
         >
           Interface

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_NodeInterface.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_NodeInterface.md
@@ -1,0 +1,237 @@
+<table>
+  <thead>
+    <tr>
+      <th>Method</th>
+      <th>Solidity interface</th>
+      <th>Go implementation</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>
+          estimateRetryableTicket(address sender, uint256 deposit, address to, uint256 l2CallValue,
+          address excessFeeRefundAddress, address callValueRefundAddress, bytes calldata data)
+        </code>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/node-interface/NodeInterface.sol#L25"
+          target="_blank"
+        >
+          Interface
+        </a>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/nodeInterface/NodeInterface.go#L113"
+          target="_blank"
+        >
+          Implementation
+        </a>
+      </td>
+      <td>Estimates the gas needed for a retryable submission</td>
+    </tr>
+    <tr>
+      <td>
+        <code>constructOutboxProof(uint64 size, uint64 leaf)</code>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/node-interface/NodeInterface.sol#L44"
+          target="_blank"
+        >
+          Interface
+        </a>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/nodeInterface/NodeInterface.go#L161"
+          target="_blank"
+        >
+          Implementation
+        </a>
+      </td>
+      <td>Constructs an outbox proof of an l2->l1 send's existence in the outbox accumulator</td>
+    </tr>
+    <tr>
+      <td>
+        <code>findBatchContainingBlock(uint64 blockNum)</code>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/node-interface/NodeInterface.sol#L60"
+          target="_blank"
+        >
+          Interface
+        </a>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/nodeInterface/NodeInterface.go#L61"
+          target="_blank"
+        >
+          Implementation
+        </a>
+      </td>
+      <td>Finds the L1 batch containing a requested L2 block, reverting if none does</td>
+    </tr>
+    <tr>
+      <td>
+        <code>getL1Confirmations(bytes32 blockHash)</code>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/node-interface/NodeInterface.sol#L71"
+          target="_blank"
+        >
+          Interface
+        </a>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/nodeInterface/NodeInterface.go#L69"
+          target="_blank"
+        >
+          Implementation
+        </a>
+      </td>
+      <td>
+        Gets the number of L1 confirmations of the sequencer batch producing the requested L2 block
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>gasEstimateComponents(address to, bool contractCreation, bytes calldata data)</code>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/node-interface/NodeInterface.sol#L84"
+          target="_blank"
+        >
+          Interface
+        </a>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/nodeInterface/NodeInterface.go#L482"
+          target="_blank"
+        >
+          Implementation
+        </a>
+      </td>
+      <td>Same as native gas estimation, but with additional info on the l1 costs</td>
+    </tr>
+    <tr>
+      <td>
+        <code>gasEstimateL1Component(address to, bool contractCreation, bytes calldata data)</code>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/node-interface/NodeInterface.sol#L112"
+          target="_blank"
+        >
+          Interface
+        </a>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/nodeInterface/NodeInterface.go#L444"
+          target="_blank"
+        >
+          Implementation
+        </a>
+      </td>
+      <td>Estimates a transaction's l1 costs</td>
+    </tr>
+    <tr>
+      <td>
+        <code>legacyLookupMessageBatchProof(uint256 batchNum, uint64 index)</code>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/node-interface/NodeInterface.sol#L139"
+          target="_blank"
+        >
+          Interface
+        </a>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/nodeInterface/NodeInterface.go#L559"
+          target="_blank"
+        >
+          Implementation
+        </a>
+      </td>
+      <td>Returns the proof necessary to redeem a message</td>
+    </tr>
+    <tr>
+      <td>
+        <code>nitroGenesisBlock()</code>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/node-interface/NodeInterface.sol#L157"
+          target="_blank"
+        >
+          Interface
+        </a>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/nodeInterface/NodeInterface.go#L56"
+          target="_blank"
+        >
+          Implementation
+        </a>
+      </td>
+      <td>Returns the first block produced using the Nitro codebase</td>
+    </tr>
+    <tr>
+      <td>
+        <code>blockL1Num(uint64 l2BlockNum)</code>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/node-interface/NodeInterface.sol#L161"
+          target="_blank"
+        >
+          Interface
+        </a>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/nodeInterface/NodeInterface.go#L604"
+          target="_blank"
+        >
+          Implementation
+        </a>
+      </td>
+      <td>Returns the L1 block number of the L2 block</td>
+    </tr>
+    <tr>
+      <td>
+        <code>l2BlockRangeForL1(uint64 blockNum)</code>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/b16bf0b737468382854dac28346fec8b65b55989/src/node-interface/NodeInterface.sol#L170"
+          target="_blank"
+        >
+          Interface
+        </a>
+      </td>
+      <td>
+        <a
+          href="https://github.com/OffchainLabs/nitro/blob/v2.1.1/nodeInterface/NodeInterface.go#L628"
+          target="_blank"
+        >
+          Implementation
+        </a>
+      </td>
+      <td>Finds the L2 block number range that has the given L1 block number</td>
+    </tr>
+  </tbody>
+</table>

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -82,6 +82,11 @@ const sidebars = {
             },
             {
               type: 'doc',
+              label: 'NodeInterface',
+              id: 'for-devs/concepts/nodeinterface',
+            },
+            {
+              type: 'doc',
               label: 'Oracles',
               id: 'for-devs/concepts/oracles',
             },
@@ -288,6 +293,11 @@ const sidebars = {
           type: 'doc',
           label: 'Precompiles',
           id: 'for-devs/dev-tools-and-resources/precompiles',
+        },
+        {
+          type: 'doc',
+          label: 'NodeInterface',
+          id: 'for-devs/dev-tools-and-resources/nodeinterface',
         },
         {
           type: 'doc',

--- a/website/src/resources/globalVars.js
+++ b/website/src/resources/globalVars.js
@@ -33,8 +33,10 @@ const globalVars = {
   nitroPathToPrecompiles: 'precompiles',
 
   nitroContractsRepositorySlug: 'nitro-contracts',
-  nitroContractsCommit: '9edc1b943ed0255f050f91f265d96bc1ad9de1a2',
+  nitroContractsCommit: 'b16bf0b737468382854dac28346fec8b65b55989',
   nitroContractsPathToPrecompilesInterface: 'src/precompiles',
+
+  goEthereumCommit: 'e8c8827c0b9e22e60829da1945cba9c451cda85a',
 
   // gas floor
   arbOneGasFloorGwei: '0.1',

--- a/website/src/resources/precompilesInformation.js
+++ b/website/src/resources/precompilesInformation.js
@@ -144,4 +144,48 @@ const precompilesInformation = {
   },
 };
 
-module.exports = precompilesInformation;
+const nodeInterfaceInformation = {
+  methodOverrides: {
+    estimateretryableticket: {
+      signature:
+        'estimateRetryableTicket(address sender, uint256 deposit, address to, uint256 l2CallValue, address excessFeeRefundAddress, address callValueRefundAddress, bytes calldata data)',
+      description: 'Estimates the gas needed for a retryable submission',
+    },
+    constructoutboxproof: {
+      description:
+        "Constructs an outbox proof of an l2->l1 send's existence in the outbox accumulator",
+    },
+    findbatchcontainingblock: {
+      description: 'Finds the L1 batch containing a requested L2 block, reverting if none does',
+    },
+    getl1confirmations: {
+      description:
+        'Gets the number of L1 confirmations of the sequencer batch producing the requested L2 block',
+    },
+    gasestimatecomponents: {
+      signature: 'gasEstimateComponents(address to, bool contractCreation, bytes calldata data)',
+      description: 'Same as native gas estimation, but with additional info on the l1 costs',
+    },
+    gasestimatel1component: {
+      signature: 'gasEstimateL1Component(address to, bool contractCreation, bytes calldata data)',
+      description: "Estimates a transaction's l1 costs",
+    },
+    legacylookupmessagebatchproof: {
+      description: 'Returns the proof necessary to redeem a message',
+    },
+    nitrogenesisblock: {
+      description: 'Returns the first block produced using the Nitro codebase',
+    },
+    blockl1num: {
+      description: 'Returns the L1 block number of the L2 block',
+    },
+    l2blockrangeforl1: {
+      description: 'Finds the L2 block number range that has the given L1 block number',
+    },
+  },
+};
+
+module.exports = {
+  precompilesInformation,
+  nodeInterfaceInformation,
+};

--- a/website/src/scripts/precompile-reference-generator.ts
+++ b/website/src/scripts/precompile-reference-generator.ts
@@ -1,5 +1,8 @@
 import globalVars from '../resources/globalVars.js';
-import precompilesInformation from '../resources/precompilesInformation.js';
+import {
+  precompilesInformation,
+  nodeInterfaceInformation,
+} from '../resources/precompilesInformation.js';
 import fs from 'fs';
 
 type PrecompileMethodInfo = {
@@ -29,12 +32,15 @@ const partialTablesBasePath =
   '../arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables';
 const interfaceBaseUrl = `https://github.com/OffchainLabs/${globalVars.nitroContractsRepositorySlug}/blob/${globalVars.nitroContractsCommit}/${globalVars.nitroContractsPathToPrecompilesInterface}/`;
 const implementationBaseUrl = `https://github.com/OffchainLabs/${globalVars.nitroRepositorySlug}/blob/${globalVars.nitroVersionTag}/${globalVars.nitroPathToPrecompiles}/`;
+const nodeInterfaceInterfaceBaseUrl = `https://github.com/OffchainLabs/${globalVars.nitroContractsRepositorySlug}/blob/${globalVars.nitroContractsCommit}/src/node-interface/`;
+const nodeInterfaceImplementationBaseUrl = `https://github.com/OffchainLabs/${globalVars.nitroRepositorySlug}/blob/${globalVars.nitroVersionTag}/nodeInterface/`;
 const defaultDeprecationNotice = `<p>Note: methods marked with ⚠️ are deprecated and their use is not supported.</p>`;
 
 const renderMethodsInTable = (
   interfaceCode: string,
   implementationCode: string,
-  precompileName: string,
+  interfaceUrl: string,
+  implementationUrl: string,
   methodOverrides?: PrecompileMethodOverrides,
 ) => {
   // Initialization of list of methods
@@ -114,10 +120,10 @@ const renderMethodsInTable = (
 
           return `<tr>
             <td>${methodInfo.deprecated ? `⚠️` : ''}<code>${methodInfo.signature}</code></td>
-            <td><a href="${interfaceBaseUrl}${precompileName}.sol#L${
+            <td><a href="${interfaceUrl}#L${
             methodInfo.interfaceLine
           }" target="_blank">Interface</a></td>
-            <td><a href="${implementationBaseUrl}${precompileName}.go#L${
+            <td><a href="${implementationUrl}#L${
             methodInfo.implementationLine
           }" target="_blank">Implementation</a></td>
             <td>${methodInfo.description}</td>
@@ -135,7 +141,8 @@ const renderMethodsInTable = (
 const renderEventsInTable = (
   interfaceCode: string,
   implementationCode: string,
-  precompileName: string,
+  interfaceUrl: string,
+  implementationUrl: string,
   eventOverrides?: PrecompileEventOverrides,
 ) => {
   // Initialization of list of events
@@ -203,8 +210,8 @@ const renderEventsInTable = (
           .map((eventInfo: PrecompileEventInfo) => {
             return `<tr>
               <td><code>${eventInfo.name}</code></td>
-              <td><a href="${interfaceBaseUrl}${precompileName}.sol#L${eventInfo.interfaceLine}" target="_blank">Interface</a></td>
-              <td><a href="${implementationBaseUrl}${precompileName}.go#L${eventInfo.implementationLine}" target="_blank">Implementation</a></td>
+              <td><a href="${interfaceUrl}#L${eventInfo.interfaceLine}" target="_blank">Interface</a></td>
+              <td><a href="${implementationUrl}#L${eventInfo.implementationLine}" target="_blank">Implementation</a></td>
               <td>${eventInfo.description}</td>
             </tr>`;
           })
@@ -239,20 +246,49 @@ const generatePrecompileReferenceTables = async (
   const methodsTable = renderMethodsInTable(
     interfaceCode,
     implementationCode,
-    precompileName,
+    interfaceBaseUrl + precompileName + '.sol',
+    implementationBaseUrl + precompileName + '.go',
     methodOverrides,
   );
   const eventsTable = renderEventsInTable(
     interfaceCode,
     implementationCode,
-    precompileName,
+    interfaceBaseUrl + precompileName + '.sol',
+    implementationBaseUrl + precompileName + '.go',
     eventOverrides,
   );
 
   fs.writeFileSync(`${partialTablesBasePath}/_${precompileName}.md`, methodsTable + eventsTable);
 };
 
-const main = async (precompilesInformation) => {
+const generateNodeInterfaceReferenceTables = async (
+  methodOverrides?: PrecompileMethodOverrides,
+) => {
+  const interfaceCodeRawResponse = await fetch(
+    `${nodeInterfaceInterfaceBaseUrl
+      .replace('github.com', 'raw.githubusercontent.com')
+      .replace('blob/', '')}NodeInterface.sol`,
+  );
+  const interfaceCode = await interfaceCodeRawResponse.text();
+  const implementationCodeRawResponse = await fetch(
+    `${nodeInterfaceImplementationBaseUrl
+      .replace('github.com', 'raw.githubusercontent.com')
+      .replace('blob/', '')}NodeInterface.go`,
+  );
+  const implementationCode = await implementationCodeRawResponse.text();
+
+  const methodsTable = renderMethodsInTable(
+    interfaceCode,
+    implementationCode,
+    nodeInterfaceInterfaceBaseUrl + 'NodeInterface.sol',
+    nodeInterfaceImplementationBaseUrl + 'NodeInterface.go',
+    methodOverrides,
+  );
+
+  fs.writeFileSync(`${partialTablesBasePath}/_NodeInterface.md`, methodsTable);
+};
+
+const main = async (precompilesInformation, nodeInterfaceInformation) => {
   await Promise.all(
     Object.keys(precompilesInformation).map(async (precompileName) => {
       const methodOverrides = precompilesInformation[precompileName].methodOverrides ?? undefined;
@@ -260,9 +296,10 @@ const main = async (precompilesInformation) => {
       await generatePrecompileReferenceTables(precompileName, methodOverrides, eventOverrides);
     }),
   );
+  await generateNodeInterfaceReferenceTables(nodeInterfaceInformation.methodOverrides ?? undefined);
 };
 
-main(precompilesInformation)
+main(precompilesInformation, nodeInterfaceInformation)
   .then(() => process.exit(0))
   .catch((err) => {
     console.error(err);


### PR DESCRIPTION
This PR improves the information available about the NodeInterface. It creates a concept page and a reference page, autogenerating the table that contains the methods available in the NodeInterface. It also changes all previous links going to the short section in the L2 gas page to the new concept or reference page.

[Concept page](https://nitro-docs-git-create-nodeinterface-pages-offchain-labs.vercel.app/for-devs/concepts/nodeinterface)
[Reference page](https://nitro-docs-git-create-nodeinterface-pages-offchain-labs.vercel.app/for-devs/dev-tools-and-resources/nodeinterface)