### PR TITLE
Change Stylus testnet feed URL

### DIFF
--- a/arbitrum-docs/stylus/reference/testnet-information.md
+++ b/arbitrum-docs/stylus/reference/testnet-information.md
@@ -24,7 +24,7 @@ This table provides an overview of the available public RPC endpoints for the St
 
 | Name           | RPC URL                                | Chain ID | Block explorer                               | Underlying chain | Tech stack     | Sequencer feed URL                    | Sequencer endpoint<sup>⚠️</sup>                  |
 | -------------- | -------------------------------------- | -------- | -------------------------------------------- | ---------------- | -------------- | ------------------------------------- | ------------------------------------------------ |
-| Stylus testnet | https://stylus-testnet.arbitrum.io/rpc | 23011913 | https://stylus-testnet-explorer.arbitrum.io/ | Arbitrum Sepolia | Nitro (Rollup) | wss://stylus-sepolia.arbitrum.io/feed | https://stylus-testnet-sequencer.arbitrum.io/rpc |
+| Stylus testnet | https://stylus-testnet.arbitrum.io/rpc | 23011913 | https://stylus-testnet-explorer.arbitrum.io/ | Arbitrum Sepolia | Nitro (Rollup) | wss://stylus-testnet.arbitrum.io/feed | https://stylus-testnet-sequencer.arbitrum.io/rpc |
 
 :::caution
 


### PR DESCRIPTION
Simple update of the feed URL endpoint for Stylus

[Preview](https://nitro-docs-git-change-stylus-testnet-feed-url-offchain-labs.vercel.app/stylus/reference/testnet-information#rpc-endpoints)