### PR TITLE
Add warning for beta nitro versions

### DIFF
--- a/arbitrum-docs/node-running/how-tos/running-a-full-node.mdx
+++ b/arbitrum-docs/node-running/how-tos/running-a-full-node.mdx
@@ -28,6 +28,12 @@ The minimum storage requirements will change over time as the Nitro chain grows.
 
 ### Prerequisites
 
+:::caution Only use released versions
+
+Even though there are alpha and beta versions of the <a data-quicklook-from='arbitrum-nitro'>Arbitrum Nitro software</a>, only release versions should be used when running your node. Running alpha or beta versions is not supported, and might lead to unexpected behaviors.
+
+:::
+
 - Latest Docker Image: <code>@latestNitroNodeImage@</code>
 - Database snapshot (required for Arbitrum One, optional for other chains)
   - Use the parameter `--init.url` on first startup to initialize the Nitro database (you can find a list of snapshots [here](https://snapshot.arbitrum.foundation/index.html)). Example: <code>--init.url="@arbOneNitroPrunedSnapshot@"</code>.


### PR DESCRIPTION
Simple PR to add a warning to deter node runners from using an alpha or beta version of nitro.

[Preview](https://nitro-docs-git-add-warning-for-beta-nitro-0dfd96-offchain-labs.vercel.app/node-running/how-tos/running-a-full-node#prerequisites)