### PR TITLE
Modify Goerli warning and RPC endpoints/providers titles

### DIFF
--- a/arbitrum-docs/node-running/node-providers.mdx
+++ b/arbitrum-docs/node-running/node-providers.mdx
@@ -12,7 +12,7 @@ Complete [this form](https://docs.google.com/forms/d/e/1FAIpQLSdw0U-9LcLuih5TZ_Q
 
 :::
 
-## RPC endpoints
+## Arbitrum public RPC endpoints
 
 This section provides an overview of the available public RPC endpoints for different Arbitrum chains and necessary details to interact with them.
 
@@ -28,7 +28,7 @@ This section provides an overview of the available public RPC endpoints for diff
 
 ⚠️ Important note: Arbitrum public RPCs do not provide Websocket support.
 
-⚠️ Important note: Ethereum Goerli was deprecated in Q1 2023 but will be supported until Q1 2024. Once Arbitrum Sepolia becomes publicly available, we will phase out the usage of Arbitrum Goerli. Support for Arbitrum Goerli will cease prior to the conclusion of Ethereum Goerli.
+⚠️ Important note: Ethereum Goerli was deprecated in Q1 2023 but will be supported until Q1 2024. We are currently phasing out the usage of Arbitrum Goerli. Support for Arbitrum Goerli will cease prior to the conclusion of Ethereum Goerli.
 
 ⚠️ Important note: Stylus testnet will be deprecated once stylus comes out of beta and is enabled on the Sepolia testnet.
 
@@ -40,7 +40,7 @@ More Arbitrum chain RPC endpoints can be found in Chain Connect: [Arbitrum One](
 
 :::
 
-## RPC providers
+## Third-party RPC providers
 
 Alternatively, to interact with public Arbitrum chains, you can rely on many of the same popular node providers that you are already using on Ethereum:
 

--- a/arbitrum-docs/node-running/quickstart-running-a-node.md
+++ b/arbitrum-docs/node-running/quickstart-running-a-node.md
@@ -11,11 +11,15 @@ import PublicPreviewBannerPartial from '../partials/_public-preview-banner-parti
 
 <PublicPreviewBannerPartial />
 
+:::info
+
+There is no protocol level incentive to run an Arbitum full node. If you’re interested in accessing an Arbitrum chain, but you don’t want to set up your own node, see our [RPC endpoints and providers](/node-running/node-providers.mdx) to get RPC access to fully-managed nodes hosted by a third party provider.
+
+:::
+
 When it comes to interacting with the Arbitrum network, users have the option to run either a full node or an archive node. There are distinct advantages to running an Arbitrum full node. In this quickstart, we will explore the reasons why a user may prefer to run a full node instead of an archive node. By understanding the benefits and trade-offs of each type of node, users can make an informed decision based on their specific requirements and objectives.
 
 ### Considerations for running an Arbitrum full node
-
-⚠️ Note: There is no protocol level incentive to run an Arbitum full node. If you’re interested in accessing an Arbitrum chain, but you don’t want to set up your own node, see our [RPC endpoints and providers](/node-running/node-providers.mdx) to get RPC access to fully-managed nodes hosted by a third party provider.
 
 - Transaction validation and security: Running a full node allows users to independently validate transactions and verify the state of the Arbitrum blockchain. Users can have full confidence in the authenticity and integrity of the transactions they interact with.
 - Reduced trust requirements: By running a full node, users can interact with the Arbitrum network without relying on third-party services or infrastructure. This reduces the need to trust external entities and mitigates the risk of potential centralized failures or vulnerabilities.


### PR DESCRIPTION
Also, moved the no-protocol-incentives banner to the top of the Quickstart so it applies to all kind of nodes.

[Preview](https://nitro-docs-git-modify-goerli-warning-offchain-labs.vercel.app/node-running/node-providers)