### PR TITLE
fix the portal google form link

### DIFF
--- a/arbitrum-docs/for-devs/third-party-docs/contribute.md
+++ b/arbitrum-docs/for-devs/third-party-docs/contribute.md
@@ -14,7 +14,7 @@ These documents are usually authored by partner teams, but can be authored by an
 
 1.  **Eligibility**
     - Third-party docs are intended to support products listed in the [Arbitrum portal](https://portal.arbitrum.io/), or infrastructure and services that those products use.
-    - To submit your project to the Arbitrum portal, [apply using this Google form](https://docs.google.com/forms/d/e/1FAIpQLSezhBlPgKIKKWgXKUz4MmlJPdHyfmPQlxUtS48HlRoi0e14_Q/viewform).
+    - To submit your project to the Arbitrum portal, [apply using this Google form](https://docs.google.com/forms/d/e/1FAIpQLSc_v8j7sc4ffE6U-lJJyLMdBoIubf7OIhGtCqvK3cGPGoLr7w/viewform).
 2.  **Purpose**
     - The purpose of our `Third-party docs` sections is to **_meet Arbitrum developer (or user) demand for guidance that helps them use non-Arbitrum products with Arbitrum products_**.
     - It's _not_ meant to drive traffic to your product (although that may happen); it's meant to solve problems that our readers are actually facing, which are directly related to Arbitrum products.

--- a/arbitrum-docs/node-running/how-tos/running-a-daserver.mdx
+++ b/arbitrum-docs/node-running/how-tos/running-a-daserver.mdx
@@ -1,5 +1,5 @@
 ---
-title: "How to run a data availability server (DAS)"
+title: 'How to run a data availability server (DAS)'
 description: This how-to will help you run a data availability server.
 author: amsanghi
 sidebar_label: Run a Data Availability Server


### PR DESCRIPTION
The current link points to a Google form that no longer accepts requests.


<img width="841" alt="Screenshot 2024-01-18 at 12 41 33 PM" src="https://github.com/OffchainLabs/arbitrum-docs/assets/8293156/a2ed95bb-d08e-4c71-8d02-500e6bd593f7">
