### PR TITLE
docs: add BOLD public testnet docs

### DIFF
--- a/arbitrum-docs/bold/bold-gentle-introduction.md
+++ b/arbitrum-docs/bold/bold-gentle-introduction.md
@@ -1,0 +1,25 @@
+---
+title: 'A gentle introduction to BOLD'
+sidebar_label: 'A gentle introduction to BOLD'
+description: 'An educational introduction that provides a high-level understanding of BOLD, a new dispute protocol to enable permissionless validation for Arbitrum chains.'
+author: dereklee
+sme: rauljordan
+target_audience: 'Users and researchers who want to learn about Arbitrum's next-generation dispute protocol that enables permissionless validation'
+sidebar_position: 1
+---
+
+# A gentle introduction: Bounded Liquidity Delay (BOLD)
+
+import PublicPreviewBannerPartial from './partials/_bold-public-preview-banner-partial.md';
+
+<PublicPreviewBannerPartial />
+
+
+
+### In a nutshell:
+
+
+### What is BOLD?
+
+
+### 

--- a/arbitrum-docs/bold/partials/_bold-public-preview-banner-partial.md
+++ b/arbitrum-docs/bold/partials/_bold-public-preview-banner-partial.md
@@ -1,0 +1,7 @@
+:::info ALPHA RELEASE, PUBLIC PREVIEW DOCS
+
+BOLD is currently tagged as an `alpha` release. The code has not been audited, and should **not be used in production scenarios**. This documentation is currently in [public preview](/stylus/concepts/public-preview-expectations).
+
+To provide feedback, click the _Request an update_ button at the top of this document, [join the Arbitrum Discord](https://discord.gg/arbitrum), or reach out to our team directly by completing [this form](http://bit.ly/3yy6EUK).
+
+:::

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -538,6 +538,28 @@ const sidebars = {
     },
     {
       type: 'category',
+      label: 'BOLD: Challenge Protocol V3',
+      collapsed: false,
+      items: [
+        {
+        type: 'doc',
+        id: 'bold/bold-gentle-introduction',
+        label: 'A gentle introduction',
+        },
+        {
+        type: 'link',
+        href: 'https://github.com/OffchainLabs/bold/blob/main/docs/research-specs/BOLDChallengeProtocol.pdf',
+        label: 'Deep dive: Whitepaper',
+        },
+        {
+        type: 'link',
+        href: 'https://github.com/OffchainLabs/bold',
+        label: 'Deeper dive: Specification on Github',
+        },
+      ],
+    },
+    {
+      type: 'category',
       label: 'Advanced concepts',
       collapsed: false,
       items: [


### PR DESCRIPTION
We will be launching a public testnet for BOLD at the end of Feb 2024. This PR adds:

- [X] A new folder structure accommodating BOLD documentation and assets
- [ ] A gentle introduction to bold
- [ ] How-to guide for running a BOLD validator
- [ ] How-to guide for monitoring BOLD challenges

To be merged alongside the public testnet launch.