### PR TITLE
feat: add precompile addresses to the reference section + small note in the Troubleshooting node page

### DIFF
--- a/arbitrum-docs/for-devs/dev-tools-and-resources/precompiles.mdx
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/precompiles.mdx
@@ -28,7 +28,7 @@ This section is divided into two tables. We first list precompiles we expect use
 | Precompile                            | Address | Solidity interface                           | Go implementation                                      | Purpose                                            |
 | ------------------------------------- | ------- | -------------------------------------------- | ------------------------------------------------------ | -------------------------------------------------- |
 | [ArbAddressTable](#arbaddresstable)   | `0x66`  | [Interface][arbaddresstable_link_interface]  | [Implementation][arbaddresstable_link_implementation]  | Supporting compression of addresses                |
-| ArbBLS                                | `0x67`  | -                                            | -                                                      | **Disabled** (Former registry of BLS public keys)  |
+| ArbBLS                                | -       | -                                            | -                                                      | **Disabled** (Former registry of BLS public keys)  |
 | [ArbDebug](#arbdebug)                 | `0xff`  | [Interface][arbdebug_link_interface]         | [Implementation][arbdebug_link_implementation]         | Testing tools                                      |
 | [ArbFunctionTable](#arbfunctiontable) | `0x68`  | [Interface][arbfunctiontable_link_interface] | [Implementation][arbfunctiontable_link_implementation] | No longer used                                     |
 | [ArbInfo](#arbinfo)                   | `0x65`  | [Interface][arbinfo_link_interface]          | [Implementation][arbinfo_link_implementation]          | Info about accounts                                |
@@ -70,6 +70,8 @@ This section is divided into two tables. We first list precompiles we expect use
 
 ArbAddressTable ([Interface][arbaddresstable_link_interface] | [Implementation][arbaddresstable_link_implementation]) provides the ability to create short-hands for commonly used accounts.
 
+Precompile address: `0x0000000000000000000000000000000000000066`
+
 import ArbAddressTableRef from './partials/precompile-tables/_ArbAddressTable.md';
 
 <ArbAddressTableRef />
@@ -79,6 +81,8 @@ import ArbAddressTableRef from './partials/precompile-tables/_ArbAddressTable.md
 ArbAggregator ([Interface][arbaggregator_link_interface] | [Implementation][arbaggregator_link_implementation]) provides aggregators and their users methods for configuring how they participate in L1 aggregation. Arbitrum One's default aggregator is the Sequencer, which a user will prefer unless `SetPreferredAggregator` is invoked to change it.
 
 Compression ratios are measured in basis points. Methods that are checkmarked are access-controlled and will revert if not called by the aggregator, its fee collector, or a chain owner.
+
+Precompile address: `0x000000000000000000000000000000000000006D`
 
 import ArbAggregatorRef from './partials/precompile-tables/_ArbAggregator.md';
 
@@ -96,6 +100,8 @@ This precompile has been disabled. It previously provided a registry of BLS publ
 
 ArbDebug ([Interface][arbdebug_link_interface] | [Implementation][arbdebug_link_implementation]) provides mechanisms useful for testing. The methods of `ArbDebug` are only available for chains with the `AllowDebugPrecompiles` chain parameter set. Otherwise, calls to this precompile will revert.
 
+Precompile address: `0x00000000000000000000000000000000000000ff`
+
 import ArbDebugRef from './partials/precompile-tables/_ArbDebug.md';
 
 <ArbDebugRef />
@@ -103,6 +109,8 @@ import ArbDebugRef from './partials/precompile-tables/_ArbDebug.md';
 ### ArbFunctionTable
 
 ArbFunctionTable ([Interface][arbfunctiontable_link_interface] | [Implementation][arbfunctiontable_link_implementation]) provides aggregators the ability to manage function tables, to enable one form of transaction compression. The Nitro aggregator implementation does not use these, so these methods have been stubbed and their effects disabled. They are kept for backwards compatibility.
+
+Precompile address: `0x0000000000000000000000000000000000000068`
 
 import ArbFunctionTableRef from './partials/precompile-tables/_ArbFunctionTable.md';
 
@@ -112,6 +120,8 @@ import ArbFunctionTableRef from './partials/precompile-tables/_ArbFunctionTable.
 
 ArbGasInfo ([Interface][arbgasinfo_link_interface] | [Implementation][arbgasinfo_link_implementation]) provides insight into the cost of using the chain. These methods have been adjusted to account for Nitro's heavy use of calldata compression. Of note to end-users, we no longer make a distinction between non-zero and zero-valued calldata bytes.
 
+Precompile address: `0x000000000000000000000000000000000000006C`
+
 import ArbGasInfoRef from './partials/precompile-tables/_ArbGasInfo.md';
 
 <ArbGasInfoRef />
@@ -120,6 +130,8 @@ import ArbGasInfoRef from './partials/precompile-tables/_ArbGasInfo.md';
 
 ArbInfo ([Interface][arbinfo_link_interface] | [Implementation][arbinfo_link_implementation]) provides the ability to lookup basic info about accounts and contracts.
 
+Precompile address: `0x0000000000000000000000000000000000000065`
+
 import ArbInfoRef from './partials/precompile-tables/_ArbInfo.md';
 
 <ArbInfoRef />
@@ -127,6 +139,8 @@ import ArbInfoRef from './partials/precompile-tables/_ArbInfo.md';
 ### ArbosTest
 
 ArbosTest ([Interface][arbostest_link_interface] | [Implementation][arbostest_link_implementation]) provides a method of burning arbitrary amounts of gas, which exists for historical reasons. In Classic, `ArbosTest` had additional methods only the zero address could call. These have been removed since users don't use them and calls to missing methods revert.
+
+Precompile address: `0x0000000000000000000000000000000000000069`
 
 import ArbosTestRef from './partials/precompile-tables/_ArbosTest.md';
 
@@ -142,6 +156,8 @@ Most of Arbitrum Classic's owner methods have been removed since they no longer 
 - ArbOS upgrades happen with the rest of the system rather than being independent
 - Exemptions to address aliasing are no longer offered. Exemptions were intended to support backward compatibility for contracts deployed before aliasing was introduced, but no exemptions were ever requested.
 
+Precompile address: `0x0000000000000000000000000000000000000070`
+
 import ArbOwnerRef from './partials/precompile-tables/_ArbOwner.md';
 
 <ArbOwnerRef />
@@ -149,6 +165,8 @@ import ArbOwnerRef from './partials/precompile-tables/_ArbOwner.md';
 ### ArbOwnerPublic
 
 ArbOwnerPublic ([Interface][arbownerpublic_link_interface] | [Implementation][arbownerpublic_link_implementation]) provides non-owners with info about the current chain owners.
+
+Precompile address: `0x000000000000000000000000000000000000006b`
 
 import ArbOwnerPublicRef from './partials/precompile-tables/_ArbOwnerPublic.md';
 
@@ -158,6 +176,8 @@ import ArbOwnerPublicRef from './partials/precompile-tables/_ArbOwnerPublic.md';
 
 ArbRetryableTx ([Interface][arbretryabletx_link_interface] | [Implementation][arbretryabletx_link_implementation]) provides methods for managing retryables. The model has been adjusted for Nitro, most notably in terms of how retry transactions are scheduled. For more information on retryables, please see [the retryable documentation](arbos#Retryables).
 
+Precompile address: `0x000000000000000000000000000000000000006E`
+
 import ArbRetryableTxRef from './partials/precompile-tables/_ArbRetryableTx.md';
 
 <ArbRetryableTxRef />
@@ -166,6 +186,8 @@ import ArbRetryableTxRef from './partials/precompile-tables/_ArbRetryableTx.md';
 
 ArbStatistics ([Interface][arbstatistics_link_interface] | [Implementation][arbstatistics_link_implementation]) provides statistics about the chain as of just before the Nitro upgrade. In Arbitrum Classic, this was how a user would get info such as the total number of accounts, but there are better ways to get that info in Nitro.
 
+Precompile address: `0x000000000000000000000000000000000000006F`
+
 import ArbStatisticsRef from './partials/precompile-tables/_ArbStatistics.md';
 
 <ArbStatisticsRef />
@@ -173,6 +195,8 @@ import ArbStatisticsRef from './partials/precompile-tables/_ArbStatistics.md';
 ### ArbSys
 
 ArbSys ([Interface][arbsys_link_interface] | [Implementation][arbsys_link_implementation]) provides system-level functionality for interacting with L1 and understanding the call stack.
+
+Precompile address: `0x0000000000000000000000000000000000000064`
 
 import ArbSysRef from './partials/precompile-tables/_ArbSys.md';
 

--- a/arbitrum-docs/for-devs/useful-addresses.mdx
+++ b/arbitrum-docs/for-devs/useful-addresses.mdx
@@ -98,7 +98,6 @@ The following precompiles are deployed on every L2 chain and always have the sam
 | ---------------- | ---------------------------------------------------------------------------- |
 | ArbAddressTable  | <AEL address="0x0000000000000000000000000000000000000066" chainID={42161} /> |
 | ArbAggregator    | <AEL address="0x000000000000000000000000000000000000006D" chainID={42161} /> |
-| ArbBLS           | <AEL address="0x0000000000000000000000000000000000000067" chainID={42161} /> |
 | ArbFunctionTable | <AEL address="0x0000000000000000000000000000000000000068" chainID={42161} /> |
 | ArbGasInfo       | <AEL address="0x000000000000000000000000000000000000006C" chainID={42161} /> |
 | ArbInfo          | <AEL address="0x0000000000000000000000000000000000000065" chainID={42161} /> |

--- a/arbitrum-docs/node-running/troubleshooting-running-nodes.md
+++ b/arbitrum-docs/node-running/troubleshooting-running-nodes.md
@@ -257,7 +257,9 @@ import { GenerateTroubleshootingReportWidget } from '@site/src/components/Genera
 <GenerateTroubleshootingReportWidget />
 
 <div className="troubleshooting-report-area">
-  <p>Node startup command</p>
+  <p>
+    Node startup command (make sure to remove any sensitive information like, i.e., private keys)
+  </p>
   <textarea
     id="vn-cmd"
     rows="3"


### PR DESCRIPTION
This PR adds all precompile addresses to the precompiles reference page. I find it extremely useful to have the addresses there while navigating through the interfaces or the implementation of the different functions, so I know where the precompile is located.

This PR also adds a small note about removing sensitive information from the `docker run` command when filling up the information in the Troubleshooting: Run a node page

[Preview](https://arbitrum-docs-git-precompiles-reference-an-bb2192-offchain-labs.vercel.app/for-devs/dev-tools-and-resources/precompiles)