### PR TITLE
Change example method of generating BLS keys to docker

### DIFF
--- a/arbitrum-docs/node-running/how-tos/data-availability-committee/deploy-a-das.mdx
+++ b/arbitrum-docs/node-running/how-tos/data-availability-committee/deploy-a-das.mdx
@@ -102,7 +102,7 @@ The BLS keypair must be generated using the `datool keygen` utility. Later, it
 
 When running the key generator, we'll specify the `--dir` parameter with the absolute path to the directory inside the volume to store the keys in. 
 
-Here's an example of how to use the `datool keygen` utility inside docker and store the key that will be used by the DAS in the next step.
+Here's an example of how to use the `datool keygen` utility inside Docker and store the key that will be used by the DAS in the next step.
 
 ```bash
 docker run -v $(pwd)/bls_keys:/data/keys --entrypoint datool \

--- a/arbitrum-docs/node-running/how-tos/data-availability-committee/deploy-a-das.mdx
+++ b/arbitrum-docs/node-running/how-tos/data-availability-committee/deploy-a-das.mdx
@@ -96,7 +96,7 @@ Depending on the storage backend you use for your DAS, you'll need to configure 
 
 ### Step 1: Generate the BLS keypair
 
-Next, we'll generate a BLS keypair. The private key will be used to sign the <a data-quicklook-from="data-availability-certificate">Data Availability Certificates (DACert)</a> when receiving requests to store data, and the public key will be used to prove that the DACert was signed by the DAS. The bls private key is sensitive and care must be taken to ensure it is generated and stored in a safe environment.
+Next, we'll generate a BLS keypair. The private key will be used to sign the <a data-quicklook-from="data-availability-certificate">Data Availability Certificates (DACert)</a> when receiving requests to store data, and the public key will be used to prove that the DACert was signed by the DAS. The BLS private key is sensitive and care must be taken to ensure it is generated and stored in a safe environment.
 
 The BLS keypair must be generated using the `datool keygen` utility. Later, it will be passed to the DAS by file or command line.
 

--- a/arbitrum-docs/node-running/how-tos/data-availability-committee/deploy-a-das.mdx
+++ b/arbitrum-docs/node-running/how-tos/data-availability-committee/deploy-a-das.mdx
@@ -105,7 +105,8 @@ When running the key generator, we'll specify the `--dir` parameter with the abs
 Here's an example of how to use the `datool keygen` utility inside docker and store the key that will be used by the DAS in the next step.
 
 ```bash
-docker run -v $(pwd)/bls_keys:/data/keys --entrypoint /usr/local/bin/datool offchainlabs/nitro-node:v2.2.4-8517340 keygen --dir /data/keys
+docker run -v $(pwd)/bls_keys:/data/keys --entrypoint /usr/local/bin/datool \
+offchainlabs/nitro-node:v2.2.4-8517340 keygen --dir /data/keys
 ```
 
 ### Step 2: Deploy the DAS

--- a/arbitrum-docs/node-running/how-tos/data-availability-committee/deploy-a-das.mdx
+++ b/arbitrum-docs/node-running/how-tos/data-availability-committee/deploy-a-das.mdx
@@ -105,7 +105,7 @@ When running the key generator, we'll specify the `--dir` parameter with the abs
 Here's an example of how to use the `datool keygen` utility inside docker and store the key that will be used by the DAS in the next step.
 
 ```bash
-docker run -v $(pwd)/bls_keys:/data/keys --entrypoint /usr/local/bin/datool \
+docker run -v $(pwd)/bls_keys:/data/keys --entrypoint datool \
 offchainlabs/nitro-node:v2.2.4-8517340 keygen --dir /data/keys
 ```
 

--- a/arbitrum-docs/node-running/how-tos/data-availability-committee/deploy-a-das.mdx
+++ b/arbitrum-docs/node-running/how-tos/data-availability-committee/deploy-a-das.mdx
@@ -94,81 +94,21 @@ In terms of hardware requirements, these are the minimum specs that your infrast
 Depending on the storage backend you use for your DAS, you'll need to configure the appropriate infrastructure: for example, an S3 bucket if you choose S3, or a local volume if you choose any of the local backend options. When using a local volume, it is recommended to use …
 -->
 
-### Step 1: Set up a persistent volume
+### Step 1: Generate the BLS keypair
 
-First, we'll set up a volume to store the DAS database and the BLS keypair that we generate in the next step.
-
-In k8s, we can use a configuration like this:
-
-```yaml
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-name: das-server
-spec:
-accessModes:
-  - ReadWriteOnce
-resources:
-  requests:
-  storage: 200Gi
-storageClassName: gp2
-```
-
-### Step 2: Generate the BLS keypair
-
-Next, we'll generate a BLS keypair. The private key will be used to sign the <a data-quicklook-from="data-availability-certificate">Data Availability Certificates (DACert)</a> when receiving requests to store data, and the public key will be used to prove that the DACert was signed by the DAS.
+Next, we'll generate a BLS keypair. The private key will be used to sign the <a data-quicklook-from="data-availability-certificate">Data Availability Certificates (DACert)</a> when receiving requests to store data, and the public key will be used to prove that the DACert was signed by the DAS. The bls private key is sensitive and care must be taken to ensure it is generated and stored in a safe environment.
 
 The BLS keypair must be generated using the `datool keygen` utility. Later, it will be passed to the DAS by file or command line.
 
-When running the key generator, we'll specify the `--dir` parameter with the absolute path to the directory inside the volume to store the keys in. That directory will need to exist before running the tool.
+When running the key generator, we'll specify the `--dir` parameter with the absolute path to the directory inside the volume to store the keys in. 
 
-Here's an example of how to use a k8s deployment to run the `datool keygen` utility and store the key on the volume that we created in the previous step (and that will be used by the DAS in the next step). Note that after this deployment has run once, the deployment can be torn down and deleted:
+Here's an example of how to use the `datool keygen` utility inside docker and store the key that will be used by the DAS in the next step.
 
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-name: das-server
-spec:
-replicas: 1
-selector:
-    matchLabels:
-    app: das-server
-template:
-    metadata:
-    labels:
-        app: das-server
-    spec:
-    containers:
-    - command:
-        - bash
-        - -c
-        - |
-        mkdir -p /home/user/data/keys
-        /usr/local/bin/datool keygen --dir /home/user/data/keys
-        sleep infinity
-        image: @latestNitroNodeImage@
-        imagePullPolicy: Always
-        resources:
-        limits:
-            cpu: "4"
-            memory: 10Gi
-        requests:
-            cpu: "4"
-            memory: 10Gi
-        ports:
-        - containerPort: 9876
-        protocol: TCP
-        volumeMounts:
-        - mountPath: /home/user/data/
-        name: data
-    volumes:
-    - name: data
-        persistentVolumeClaim:
-        claimName: das-server
+```bash
+docker run -v $(pwd)/bls_keys:/data/keys --entrypoint /usr/local/bin/datool offchainlabs/nitro-node:v2.2.4-8517340 keygen --dir /data/keys
 ```
 
-### Step 3: Deploy the DAS
+### Step 2: Deploy the DAS
 
 To run the DAS, we'll use the `daserver` tool and we'll configure the following parameters:
 


### PR DESCRIPTION
Using kubernetes as the base example to generate the BLS keys seems overly complex and not useful to teams not running kubernetes.

This streamlines the process a bit and should reduce confusion on generating the keys.