### PR TITLE
Revert nitro version to 2.2.2

### DIFF
--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbAddressTable.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbAddressTable.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbAddressTable.go#L17"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbAddressTable.go#L17"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbAddressTable.go#L22"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbAddressTable.go#L22"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbAddressTable.go#L27"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbAddressTable.go#L27"
           target="_blank"
         >
           Implementation
@@ -90,7 +90,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbAddressTable.go#L40"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbAddressTable.go#L40"
           target="_blank"
         >
           Implementation
@@ -112,7 +112,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbAddressTable.go#L52"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbAddressTable.go#L52"
           target="_blank"
         >
           Implementation
@@ -134,7 +134,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbAddressTable.go#L67"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbAddressTable.go#L67"
           target="_blank"
         >
           Implementation
@@ -156,7 +156,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbAddressTable.go#L73"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbAddressTable.go#L73"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbAggregator.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbAggregator.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbAggregator.go#L24"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbAggregator.go#L24"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbAggregator.go#L30"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbAggregator.go#L30"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbAggregator.go#L35"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbAggregator.go#L35"
           target="_blank"
         >
           Implementation
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbAggregator.go#L39"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbAggregator.go#L39"
           target="_blank"
         >
           Implementation
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbAggregator.go#L62"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbAggregator.go#L62"
           target="_blank"
         >
           Implementation
@@ -132,7 +132,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbAggregator.go#L71"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbAggregator.go#L71"
           target="_blank"
         >
           Implementation
@@ -157,7 +157,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbAggregator.go#L93"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbAggregator.go#L93"
           target="_blank"
         >
           Implementation
@@ -179,7 +179,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbAggregator.go#L99"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbAggregator.go#L99"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbDebug.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbDebug.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbDebug.go#L55"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbDebug.go#L55"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbDebug.go#L27"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbDebug.go#L27"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbDebug.go#L45"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbDebug.go#L45"
           target="_blank"
         >
           Implementation
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbDebug.go#L50"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbDebug.go#L50"
           target="_blank"
         >
           Implementation
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbDebug.go#L59"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbDebug.go#L59"
           target="_blank"
         >
           Implementation
@@ -144,7 +144,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbDebug.go#L32"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbDebug.go#L32"
           target="_blank"
         >
           Implementation
@@ -168,7 +168,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbDebug.go#L37"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbDebug.go#L37"
           target="_blank"
         >
           Implementation
@@ -192,7 +192,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbDebug.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbDebug.go#L0"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbFunctionTable.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbFunctionTable.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbFunctionTable.go#L19"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbFunctionTable.go#L19"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbFunctionTable.go#L24"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbFunctionTable.go#L24"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbFunctionTable.go#L29"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbFunctionTable.go#L29"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbGasInfo.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbGasInfo.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbGasInfo.go#L26"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbGasInfo.go#L26"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbGasInfo.go#L91"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbGasInfo.go#L91"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbGasInfo.go#L96"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbGasInfo.go#L96"
           target="_blank"
         >
           Implementation
@@ -90,7 +90,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbGasInfo.go#L138"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbGasInfo.go#L138"
           target="_blank"
         >
           Implementation
@@ -112,7 +112,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbGasInfo.go#L143"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbGasInfo.go#L143"
           target="_blank"
         >
           Implementation
@@ -134,7 +134,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbGasInfo.go#L151"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbGasInfo.go#L151"
           target="_blank"
         >
           Implementation
@@ -156,7 +156,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbGasInfo.go#L156"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbGasInfo.go#L156"
           target="_blank"
         >
           Implementation
@@ -178,7 +178,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbGasInfo.go#L161"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbGasInfo.go#L161"
           target="_blank"
         >
           Implementation
@@ -202,7 +202,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbGasInfo.go#L166"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbGasInfo.go#L166"
           target="_blank"
         >
           Implementation
@@ -224,7 +224,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbGasInfo.go#L171"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbGasInfo.go#L171"
           target="_blank"
         >
           Implementation
@@ -246,7 +246,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbGasInfo.go#L176"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbGasInfo.go#L176"
           target="_blank"
         >
           Implementation
@@ -268,7 +268,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbGasInfo.go#L181"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbGasInfo.go#L181"
           target="_blank"
         >
           Implementation
@@ -290,7 +290,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbGasInfo.go#L186"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbGasInfo.go#L186"
           target="_blank"
         >
           Implementation
@@ -312,7 +312,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbGasInfo.go#L191"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbGasInfo.go#L191"
           target="_blank"
         >
           Implementation
@@ -334,7 +334,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbGasInfo.go#L196"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbGasInfo.go#L196"
           target="_blank"
         >
           Implementation
@@ -359,7 +359,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbGasInfo.go#L200"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbGasInfo.go#L200"
           target="_blank"
         >
           Implementation
@@ -381,7 +381,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbGasInfo.go#L236"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbGasInfo.go#L236"
           target="_blank"
         >
           Implementation
@@ -405,7 +405,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbGasInfo.go#L240"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbGasInfo.go#L240"
           target="_blank"
         >
           Implementation
@@ -427,7 +427,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbGasInfo.go#L244"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbGasInfo.go#L244"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbInfo.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbInfo.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbInfo.go#L17"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbInfo.go#L17"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbInfo.go#L25"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbInfo.go#L25"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwner.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwner.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L34"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L34"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L39"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L39"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L48"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L48"
           target="_blank"
         >
           Implementation
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L53"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L53"
           target="_blank"
         >
           Implementation
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L58"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L58"
           target="_blank"
         >
           Implementation
@@ -134,7 +134,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L63"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L63"
           target="_blank"
         >
           Implementation
@@ -156,7 +156,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L68"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L68"
           target="_blank"
         >
           Implementation
@@ -178,7 +178,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L73"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L73"
           target="_blank"
         >
           Implementation
@@ -200,7 +200,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L78"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L78"
           target="_blank"
         >
           Implementation
@@ -222,7 +222,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L83"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L83"
           target="_blank"
         >
           Implementation
@@ -244,7 +244,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L88"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L88"
           target="_blank"
         >
           Implementation
@@ -266,7 +266,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L93"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L93"
           target="_blank"
         >
           Implementation
@@ -288,7 +288,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L98"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L98"
           target="_blank"
         >
           Implementation
@@ -310,7 +310,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L103"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L103"
           target="_blank"
         >
           Implementation
@@ -332,7 +332,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L108"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L108"
           target="_blank"
         >
           Implementation
@@ -354,7 +354,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L113"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L113"
           target="_blank"
         >
           Implementation
@@ -376,7 +376,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L117"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L117"
           target="_blank"
         >
           Implementation
@@ -398,7 +398,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L121"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L121"
           target="_blank"
         >
           Implementation
@@ -420,7 +420,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L125"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L125"
           target="_blank"
         >
           Implementation
@@ -442,7 +442,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L129"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L129"
           target="_blank"
         >
           Implementation
@@ -464,7 +464,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L133"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L133"
           target="_blank"
         >
           Implementation
@@ -486,7 +486,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L137"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L137"
           target="_blank"
         >
           Implementation
@@ -508,7 +508,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L145"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L145"
           target="_blank"
         >
           Implementation
@@ -533,7 +533,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L141"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L141"
           target="_blank"
         >
           Implementation
@@ -555,7 +555,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L149"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L149"
           target="_blank"
         >
           Implementation
@@ -577,7 +577,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L169"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L169"
           target="_blank"
         >
           Implementation
@@ -611,7 +611,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwner.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwner.go#L0"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwnerPublic.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwnerPublic.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwnerPublic.go#L34"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwnerPublic.go#L34"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwnerPublic.go#L25"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwnerPublic.go#L25"
           target="_blank"
         >
           Implementation
@@ -68,7 +68,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwnerPublic.go#L20"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwnerPublic.go#L20"
           target="_blank"
         >
           Implementation
@@ -90,7 +90,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwnerPublic.go#L39"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwnerPublic.go#L39"
           target="_blank"
         >
           Implementation
@@ -112,7 +112,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwnerPublic.go#L44"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwnerPublic.go#L44"
           target="_blank"
         >
           Implementation
@@ -134,7 +134,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwnerPublic.go#L52"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwnerPublic.go#L52"
           target="_blank"
         >
           Implementation
@@ -171,7 +171,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbOwnerPublic.go#L30"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbOwnerPublic.go#L30"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbRetryableTx.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbRetryableTx.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbRetryableTx.go#L49"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbRetryableTx.go#L49"
           target="_blank"
         >
           Implementation
@@ -47,7 +47,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbRetryableTx.go#L134"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbRetryableTx.go#L134"
           target="_blank"
         >
           Implementation
@@ -69,7 +69,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbRetryableTx.go#L139"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbRetryableTx.go#L139"
           target="_blank"
         >
           Implementation
@@ -91,7 +91,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbRetryableTx.go#L156"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbRetryableTx.go#L156"
           target="_blank"
         >
           Implementation
@@ -113,7 +113,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbRetryableTx.go#L184"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbRetryableTx.go#L184"
           target="_blank"
         >
           Implementation
@@ -135,7 +135,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbRetryableTx.go#L197"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbRetryableTx.go#L197"
           target="_blank"
         >
           Implementation
@@ -157,7 +157,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbRetryableTx.go#L225"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbRetryableTx.go#L225"
           target="_blank"
         >
           Implementation
@@ -179,7 +179,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbRetryableTx.go#L232"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbRetryableTx.go#L232"
           target="_blank"
         >
           Implementation
@@ -216,7 +216,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbRetryableTx.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbRetryableTx.go#L0"
           target="_blank"
         >
           Implementation
@@ -238,7 +238,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbRetryableTx.go#L179"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbRetryableTx.go#L179"
           target="_blank"
         >
           Implementation
@@ -260,7 +260,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbRetryableTx.go#L116"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbRetryableTx.go#L116"
           target="_blank"
         >
           Implementation
@@ -282,7 +282,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbRetryableTx.go#L222"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbRetryableTx.go#L222"
           target="_blank"
         >
           Implementation
@@ -304,7 +304,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbRetryableTx.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbRetryableTx.go#L0"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbStatistics.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbStatistics.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbStatistics.go#L18"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbStatistics.go#L18"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbSys.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbSys.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbSys.go#L32"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbSys.go#L32"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbSys.go#L37"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbSys.go#L37"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbSys.go#L58"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbSys.go#L58"
           target="_blank"
         >
           Implementation
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbSys.go#L63"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbSys.go#L63"
           target="_blank"
         >
           Implementation
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbSys.go#L69"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbSys.go#L69"
           target="_blank"
         >
           Implementation
@@ -132,7 +132,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbSys.go#L74"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbSys.go#L74"
           target="_blank"
         >
           Implementation
@@ -154,7 +154,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbSys.go#L79"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbSys.go#L79"
           target="_blank"
         >
           Implementation
@@ -176,7 +176,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbSys.go#L84"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbSys.go#L84"
           target="_blank"
         >
           Implementation
@@ -198,7 +198,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbSys.go#L94"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbSys.go#L94"
           target="_blank"
         >
           Implementation
@@ -222,7 +222,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbSys.go#L206"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbSys.go#L206"
           target="_blank"
         >
           Implementation
@@ -244,7 +244,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbSys.go#L110"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbSys.go#L110"
           target="_blank"
         >
           Implementation
@@ -266,7 +266,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbSys.go#L190"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbSys.go#L190"
           target="_blank"
         >
           Implementation
@@ -303,7 +303,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbSys.go#L169"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbSys.go#L169"
           target="_blank"
         >
           Implementation
@@ -325,7 +325,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbSys.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbSys.go#L0"
           target="_blank"
         >
           Implementation
@@ -349,7 +349,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbSys.go#L153"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbSys.go#L153"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbosTest.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbosTest.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/precompiles/ArbosTest.go#L16"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/precompiles/ArbosTest.go#L16"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_NodeInterface.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_NodeInterface.md
@@ -25,7 +25,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/nodeInterface/NodeInterface.go#L142"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/nodeInterface/NodeInterface.go#L116"
           target="_blank"
         >
           Implementation
@@ -47,7 +47,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/nodeInterface/NodeInterface.go#L190"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/nodeInterface/NodeInterface.go#L164"
           target="_blank"
         >
           Implementation
@@ -69,7 +69,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/nodeInterface/NodeInterface.go#L64"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/nodeInterface/NodeInterface.go#L61"
           target="_blank"
         >
           Implementation
@@ -91,7 +91,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/nodeInterface/NodeInterface.go#L72"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/nodeInterface/NodeInterface.go#L69"
           target="_blank"
         >
           Implementation
@@ -115,7 +115,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/nodeInterface/NodeInterface.go#L511"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/nodeInterface/NodeInterface.go#L485"
           target="_blank"
         >
           Implementation
@@ -137,7 +137,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/nodeInterface/NodeInterface.go#L473"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/nodeInterface/NodeInterface.go#L447"
           target="_blank"
         >
           Implementation
@@ -159,7 +159,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/nodeInterface/NodeInterface.go#L588"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/nodeInterface/NodeInterface.go#L562"
           target="_blank"
         >
           Implementation
@@ -181,7 +181,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/nodeInterface/NodeInterface.go#L59"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/nodeInterface/NodeInterface.go#L56"
           target="_blank"
         >
           Implementation
@@ -203,7 +203,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/nodeInterface/NodeInterface.go#L633"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/nodeInterface/NodeInterface.go#L607"
           target="_blank"
         >
           Implementation
@@ -225,7 +225,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v2.2.4/nodeInterface/NodeInterface.go#L657"
+          href="https://github.com/OffchainLabs/nitro/blob/v2.2.2/nodeInterface/NodeInterface.go#L631"
           target="_blank"
         >
           Implementation

--- a/website/src/resources/globalVars.js
+++ b/website/src/resources/globalVars.js
@@ -12,7 +12,7 @@ const sepoliaForceIncludePeriodBlocks = 5760;
 
 const globalVars = {
   // Node docker images
-  latestNitroNodeImage: 'offchainlabs/nitro-node:v2.2.4-8517340',
+  latestNitroNodeImage: 'offchainlabs/nitro-node:v2.2.2-8f33fea',
   latestClassicNodeImage: 'offchainlabs/arb-node:v1.4.5-e97c1a4',
 
   // Node snapshots (taken around April 20th, 2013)
@@ -29,7 +29,7 @@ const globalVars = {
 
   // Nitro Github references
   nitroRepositorySlug: 'nitro',
-  nitroVersionTag: 'v2.2.4',
+  nitroVersionTag: 'v2.2.2',
   nitroPathToPrecompiles: 'precompiles',
 
   nitroContractsRepositorySlug: 'nitro-contracts',


### PR DESCRIPTION
This PR reverts the recommended nitro version to 2.2.2