### PR TITLE
Update rust-sdk-guide.md

### DIFF
--- a/arbitrum-docs/stylus/reference/rust-sdk-guide.md
+++ b/arbitrum-docs/stylus/reference/rust-sdk-guide.md
@@ -267,7 +267,7 @@ As in Solidity, methods may accept ETH as call value.
 #[external]
 impl Contract {
     #[payable]
-    pub fn credit(&mut self) -> Result<(), Vec<u8> {
+    pub fn credit(&mut self) -> Result<(), Vec<u8>> {
         self.erc20.add_balance(msg::sender(), msg::value())
     }
 }


### PR DESCRIPTION
Fix syntax errors

```
pub fn credit(&mut self) -> Result<(), Vec<u8> {
        self.erc20.add_balance(msg::sender(), msg::value())
    }
```