### PR TITLE
Docs landing page redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -132,7 +132,7 @@
         },
         {
             "source": "/docs/developer_quickstart",
-            "destination": "/",
+            "destination": "/welcome/get-started",
             "permanent": false
         },
         {
@@ -302,7 +302,7 @@
         },
         {
             "source": "/faqs/the-merge",
-            "destination": "/",
+            "destination": "/welcome/get-started",
             "permanent": false
         },
         {

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,11 @@
 {
     "redirects": [
         {
+            "source": "/",
+            "destination": "/welcome/get-started",
+            "permanent": false
+        },
+        {
             "source": "/(arb-specific-things/?)",
             "destination": "/for-devs/concepts/differences-between-arbitrum-ethereum/overview",
             "permanent": false


### PR DESCRIPTION
Redirects from the landing **page** to a landing **doc** per feedback.

Note that routing errors still route to the landing page, which I think is fine; the need we're meeting here is "visible sidebar when landing on docs".