### PR TITLE
Fix: Orbit chain params

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -601,6 +601,11 @@ const sidebars = {
         },
         {
           type: 'doc',
+          id: 'launch-orbit-chain/reference/additional-configuration-parameters',
+          label: `Additional configuration parameters`,
+        },
+        {
+          type: 'doc',
           id: 'launch-orbit-chain/reference/command-line-options',
           label: 'Command-line options',
         },


### PR DESCRIPTION
- moving from `autogenerated` to explicit sidebar accidentally removed this; this PR reintroduces 