### PR TITLE
update RPC and Blockscout ports when using orbit-setup-script

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ yarn start
 
 ### Update submodules
 
-SDK repo:
+Sdk repo:
 
 ```
 git submodule update --remote arbitrum-sdk

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ yarn start
 
 ### Update submodules
 
-Sdk repo:
+SDK repo:
 
 ```
 git submodule update --remote arbitrum-sdk

--- a/arbitrum-docs/launch-orbit-chain/how-tos/customize-precompile.mdx
+++ b/arbitrum-docs/launch-orbit-chain/how-tos/customize-precompile.mdx
@@ -65,7 +65,7 @@ Once your node is running, you can call `ArbSys.sol` either directly using `curl
 ### Call your function directly using `curl`
 
 ```shell
-curl Your_IP_Address:8547\
+curl http://localhost:8449 \
 -X POST \
 -H "Content-Type: application/json" \
 --data '{"method":"eth_call","params":[{"from":null,"to":"0x0000000000000000000000000000000000000064","data":"0x0c49c36c"}, "latest"],"id":1,"jsonrpc":"2.0"}'
@@ -140,7 +140,7 @@ Once your node is running, you can call `ArbHi.sol` either directly using `curl`
 ### Call your function directly using `curl`
 
 ```shell
-curl Your_IP_Address:8547 \
+curl http://localhost:8449 \
 -X POST \
 -H "Content-Type: application/json" \
 --data '{"method":"eth_call","params":[{"from":null,"to":"0x000000000000000000000000000000000000011a","data":"0x0c49c36c"}, "latest"],"id":1,"jsonrpc":"2.0"}'

--- a/arbitrum-docs/launch-orbit-chain/how-tos/customize-precompile.mdx
+++ b/arbitrum-docs/launch-orbit-chain/how-tos/customize-precompile.mdx
@@ -98,7 +98,7 @@ First, navigate to the [precompiles implementation][precompile_impl_dir_link] di
 ```go
 package precompiles
 
-// ArbGasInfo provides insight into the cost of using the rollup.
+// ArbHi provides a friendly greeting to anyone who calls it.
 type ArbHi struct {
 	Address addr // 0x11a, for example
 }
@@ -474,7 +474,7 @@ This time, we'll add two new methods to read and write the ArbOS state:
 ```
 package precompiles
 
-// ArbGasInfo provides insight into the cost of using the rollup.
+// ArbHi provides a friendly greeting to anyone who calls it.
 type ArbHi struct {
 	Address addr // 0x11a, for example
 }

--- a/arbitrum-docs/launch-orbit-chain/orbit-quickstart.md
+++ b/arbitrum-docs/launch-orbit-chain/orbit-quickstart.md
@@ -169,7 +169,7 @@ You should see two JSON code blocks appear labeled `Rollup Config` and `L3 Confi
 
 Run Docker, then run `docker-compose up -d` from the root of the `orbit-setup-script` repository.
 
-A Nitro node and BlockScout explorer instance will be started. Visit [http://localhost:4000/](http://localhost:4000/) to access your BlockScout explorer instance - this will allow you to view your chain's transactions and blocks, which can be useful for debugging.
+A Nitro node and BlockScout explorer instance will be started. Visit [http://localhost/](http://localhost/) to access your BlockScout explorer instance - this will allow you to view your chain's transactions and blocks, which can be useful for debugging.
 
 ## Step 11: Finish setting up your chain
 


### PR DESCRIPTION
1. Change the Blockscout port from 4000 to 80 after the pull request that added Blockscout integration to `orbit-setup-script` changed the default port from 4000 to 80: https://github.com/OffchainLabs/orbit-setup-script/pull/42
2. Change the L3 RPC URL port from 8547 to 8449, because running `docker-compose up -d` in `orbit-setup-script` has always used port 8449