### PR TITLE
docs: 1 char typo grammar update

### DIFF
--- a/arbitrum-docs/why-nitro.mdx
+++ b/arbitrum-docs/why-nitro.mdx
@@ -12,7 +12,7 @@ Viewed from a distance, the Classic and Nitro systems do similar things: both se
 
 In Arbitrum Classic, this was achieved via a custom-made virtual machine, which we call the Arbitrum Virtual Machine (AVM). The implementation of Arbitrum’s L2 state machine—known as [“ArbOS”](./arbos/arbos.mdx) — is effectively a program that is compiled and uploaded to the AVM; ArbOS includes (among other things) the ability to emulate EVM execution.
 
-In Nitro, instead of using the AVM for low-level instructions, we use WebAssembly (Wasm). Since Go code can be compiled down to Wasm, we can implement the ArbOS program in Go, and includes within it (as a sub-module) [Geth itself](./arbos/geth.mdx), the most widely used Ethereum implementation.
+In Nitro, instead of using the AVM for low-level instructions, we use WebAssembly (Wasm). Since Go code can be compiled down to Wasm, we can implement the ArbOS program in Go, and include within it (as a sub-module) [Geth itself](./arbos/geth.mdx), the most widely used Ethereum implementation.
 
 This architecture—in which Geth’s EVM implementation can be used directly—is Nitro’s defining feature, and is principally what we’re talking about when we talk about “Nitro.” Most of Nitro’s benefits are a direct or indirect consequence of this design choice. We can summarize these benefits as follows: lower fees, better Ethereum compatibility, and simplicity.
 


### PR DESCRIPTION
I was reading the docs for Nitro and stumbled for a second on the reference to "includes" in plural. I think "include" is what you actually meant here.

Apologizes for the 1 character change but it tripped me up for a moment and I thought it might someone else too :)