### PR TITLE
docs: make explicit the requirements for historical blob data to sync nitro nodes

### DIFF
--- a/arbitrum-docs/node-running/how-tos/running-a-full-node.mdx
+++ b/arbitrum-docs/node-running/how-tos/running-a-full-node.mdx
@@ -47,7 +47,8 @@ Even though there are alpha and beta versions of the <a data-quicklook-from='arb
 - L1 RPC URL
   - Use the parameter `--parent-chain.connection.url=<Layer 1 Ethereum RPC URL>` for execution layer.
   - If the chain is running [ArbOS 20](/node-running/reference/arbos-software-releases/arbos20.mdx), additionally use the parameter `--parent-chain.blob-client.beacon-url=<Layer 1 Ethereum Beacon RPC URL>` for consensus layer. You can find a list of beacon chain RPC providers [here](/node-running/reference/ethereum-beacon-rpc-providers.mdx).
-  - It must provide a standard layer 1 node RPC endpoint that you run yourself or from a node provider.
+      - It must provide a standard layer 1 node RPC endpoint that you run yourself or from a node provider.
+      - Note: historical blob data is required for chains running [ArbOS 20](/node-running/reference/arbos-software-releases/arbos20.mdx) to properly sync up if they are new or have been offline for more than 18 days. This means that the consensus layer RPC endpoint you use may need to also provide historical blob data. Please see [Special notes on ArbOS 20: Atlas support for EIP-4844](../reference/arbos-software-releases/arbos20.mdx#special-notes-on-arbos-20-atlas-support-for-eip-4844) for more details.
   - Note: this parameter was called `--l1.url` in versions prior to `v2.1.0`
   - Note: 8545 is usually the default port for the execution layer. For the Beacon endpoint port, you should connect to the correct port that is set on your parent chain's consensus client.
 - L2 chain id or name

--- a/arbitrum-docs/node-running/reference/ethereum-beacon-rpc-providers.mdx
+++ b/arbitrum-docs/node-running/reference/ethereum-beacon-rpc-providers.mdx
@@ -15,11 +15,12 @@ Following [Ethereum's Dencun upgrade in March 2024](https://eips.ethereum.org/EI
 
 ### What does this mean for node operators?
 
-Validators for Arbitrum chains posting data to L1 Ethereum (i.e. Arbitrum One, Arbitrum Nova, and L2 Orbit chains) will require access to blob data to produce and confirm L2 state assertions (read more about how this works on our [Deep dive: Inside Arbitrum"](../../inside-arbitrum-nitro/inside-arbitrum-nitro.mdx) page).
+To run a node for an L2 Arbitrum chain (i.e. Arbitrum One, Arbitrum Nova, and L2 Orbit chains), your node will need access to blob data to sync up to the latest state of your Arbitrum L2 chain. Blob data on Ethereum is stored on the beacon chain and is inaccessible to the EVM, hence why dedicated RPC endpoints for the beacon chain will be required after the Dencun upgrade. You can find more details on node requirements in the [Run a full node guide](../how-tos/running-a-full-node.mdx).
 
-Furthermore, new node operators joining a network or node operators who come online following an extended period of offline time will require access to historical blob data to sync up to the latest state of Arbitrum. Offchain Labs has plans to reduce a Nitro validator's reliance on historical blob data and will share updates on this effort in the future.
+Furthermore, new node operators joining a network or node operators who come online following an extended period of offline time will require access to *historical* blob data to sync up to the latest state of their Arbitrum chain. 
 
-To run a node for an L2 Arbitrum chain (i.e. Arbitrum One, Arbitrum Nova, and L2 Orbit chains), you will need access to blob data. Blob data on Ethereum is stored on the beacon chain and is inaccessible to the EVM, hence why dedicated RPC endpoints for the beacon chain will be required after the Dencun upgrade. You can find more details on node requirements in the [Run a full node guide](../how-tos/running-a-full-node.mdx).
+Offchain Labs has plans to reduce a Nitro validator's reliance on historical blob data and will share updates on this effort in the future.
+
 ### List of Ethereum beacon chain RPC providers
 
 | Provider                                                                    | Beacon chain APIs? | Historical blob data? |

--- a/arbitrum-docs/node-running/reference/ethereum-beacon-rpc-providers.mdx
+++ b/arbitrum-docs/node-running/reference/ethereum-beacon-rpc-providers.mdx
@@ -13,14 +13,13 @@ This reference document provides an overview of Ethereum beacon chain RPC provid
 
 Following [Ethereum's Dencun upgrade in March 2024](https://eips.ethereum.org/EIPS/eip-7569), Layer 2 blockchains like Arbitrum will be able to roll up and post batches of transaction data on Ethereum in the form of a new transaction format called a Blob. This Blob data will be part of the beacon chain and is fully downloadable by all consensus nodes. This means that data stored in blobs are inaccessible by the EVM, unlike Calldata.
 
-### What does this mean for validators?
+### What does this mean for node operators?
 
 Validators for Arbitrum chains posting data to L1 Ethereum (i.e. Arbitrum One, Arbitrum Nova, and L2 Orbit chains) will require access to blob data to produce and confirm L2 state assertions (read more about how this works on our [Deep dive: Inside Arbitrum"](../../inside-arbitrum-nitro/inside-arbitrum-nitro.mdx) page).
 
-Furthermore, new validators joining a network or validators who come online following an extended period of offline time will require access to historical blob data to sync up to the latest state of Arbitrum. Offchain Labs has plans to reduce a Nitro validator's reliance on historical blob data and will share updates on this effort in the future.
+Furthermore, new node operators joining a network or node operators who come online following an extended period of offline time will require access to historical blob data to sync up to the latest state of Arbitrum. Offchain Labs has plans to reduce a Nitro validator's reliance on historical blob data and will share updates on this effort in the future.
 
-To run a validator for an L2 Arbitrum chain (i.e. Arbitrum One, Arbitrum Nova, and L2 Orbit chains), you will need access to blob data. Blob data on Ethereum is stored on the beacon chain and is inaccessible to the EVM, hence why dedicated RPC endpoints for the beacon chain will be required after the Dencun upgrade.
-
+To run a node for an L2 Arbitrum chain (i.e. Arbitrum One, Arbitrum Nova, and L2 Orbit chains), you will need access to blob data. Blob data on Ethereum is stored on the beacon chain and is inaccessible to the EVM, hence why dedicated RPC endpoints for the beacon chain will be required after the Dencun upgrade. You can find more details on node requirements in the [Run a full node guide](../how-tos/running-a-full-node.mdx).
 ### List of Ethereum beacon chain RPC providers
 
 | Provider                                                                    | Beacon chain APIs? | Historical blob data? |


### PR DESCRIPTION
This PR clarifies some language around what types of node operators need historical blob data to sync up to an Arbitrum chain's latest state. 