### PR TITLE
Added parameter table to l1-to-l2-messaging page

### DIFF
--- a/arbitrum-docs/arbos/l1-to-l2-messaging.mdx
+++ b/arbitrum-docs/arbos/l1-to-l2-messaging.mdx
@@ -27,17 +27,17 @@ Here we walk through the different stages of the lifecycle of a retryable ticket
 
 1. Creating a retryable ticket is initiated with a call (direct or internal) to the `createRetryableTicket` function of the [`inbox` contract][inbox_link]. A ticket is guaranteed to be created if this call succeeds. Here, we describe parameters that need to be carefully set. Note that, this function forces the sender to provide a _reasonable_ amount of funds (at least enough to submitting, and _attempting_ to executing the ticket), but that doesn't guarantee a successful auto-redemption.
 
-```
-- `l1CallValue (also referred to as deposit)`: Not a real function parameter, it is rather the callValue that is sent along with the transaction
-- `address to`: The destination L2 address
-- `uint256 l2CallValue`: The callvalue for retryable L2 message that is supplied within the deposit (l1CallValue)
-- `uint256 maxSubmissionCost`: The maximum amount of ETH to be paid for submitting the ticket. This amount is (1) supplied within the deposit (l1CallValue) to be later deducted from sender's L2 balance and is (2) directly proportional to the size of the retryable’s data and L1 basefee
-- `address excessFeeRefundAddress`: The L2 address to which the excess fee is credited (l1CallValue - (autoredeem ? ticket execution cost : submission cost) - l2CallValue)
-- `address callValueRefundAddress`: The L2 address to which the l2CallValue is credited if the ticket times out or gets cancelled (this is also called the `beneficiary`, who's got a critical permission to cancel the ticket)
-- `uint256 gasLimit`: Maximum amount of gas used to cover L2 execution of the ticket
-- `uint256 maxFeePerGas`: The gas price bid for L2 execution of the ticket that is supplied within the deposit (l1CallValue)
-- `bytes calldata data`: The calldata to the destination L2 address
-```
+| Parameter                                   | Description                                                                                                                                                                                                                                                    |
+|:--------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `l1CallValue (also referred to as deposit)` | Not a real function parameter, it is rather the callValue that is sent along with the transaction                                                                                                                                                              |
+| `address to`                                | The destination L2 address                                                                                                                                                                                                                                     |
+| `uint256 l2CallValue`                       | The callvalue for retryable L2 message that is supplied within the deposit (l1CallValue)                                                                                                                                                                       | 
+| `uint256 maxSubmissionCost`                 | The maximum amount of ETH to be paid for submitting the ticket. This amount is (1) supplied within the deposit (l1CallValue) to be later deducted from sender's L2 balance and is (2) directly proportional to the size of the retryable’s data and L1 basefee |
+| `address excessFeeRefundAddress`            | The L2 address to which the excess fee is credited (l1CallValue - (autoredeem ? ticket execution cost : submission cost) - l2CallValue)                                                                                                                        |
+| `address callValueRefundAddress`            | The L2 address to which the l2CallValue is credited if the ticket times out or gets cancelled (this is also called the `beneficiary`, who's got a critical permission to cancel the ticket)                                                                    |
+| `uint256 gasLimit`                          | Maximum amount of gas used to cover L2 execution of the ticket                                                                                                                                                                                                 |
+| `uint256 maxFeePerGas`                      | The gas price bid for L2 execution of the ticket that is supplied within the deposit (l1CallValue)                                                                                                                                                             |
+| `bytes calldata data`                       | The calldata to the destination L2 address                                                                                                                                                                                                                     |
 
 2. Sender's deposit must be enough to make the L1 submission succeed and for the L2 execution to be _attempted_. If provided correctly, a new ticket with a unique `TicketID` is created and added to retryable buffer. Also, funds (`submissionCost` + `l2CallValue`) are deducted from the sender and placed into the escrow for later use in redeeming the ticket.
 


### PR DESCRIPTION
The parameters listed in this article were rendered as code instead of a list, so I converted this text block to a table.