### PR TITLE
change notion-docs commands to be able to use them in Node 20

### DIFF
--- a/notion-docs/package.json
+++ b/notion-docs/package.json
@@ -6,8 +6,8 @@
   "private": true,
   "scripts": {
     "build": "tsc",
-    "update:all": "node --loader ts-node/esm ./scripts/update.ts",
-    "verifyQuicklooks": "node --loader ts-node/esm ./scripts/verifyQuicklooks.ts",
+    "update:all": "ts-node ./scripts/update.ts",
+    "verifyQuicklooks": "ts-node ./scripts/verifyQuicklooks.ts",
     "format": "prettier --config .prettierrc.js 'scripts/**/*.ts' --write",
     "lint": "eslint . --ext .ts"
   },


### PR DESCRIPTION
This PR changes the commands used to update FAQs and verify quicklooks within the notion-docs folder, so they can be used with Node 20.