### PR TITLE
docs: add archive snapshot warning to docs

### DIFF
--- a/arbitrum-docs/run-arbitrum-node/more-types/01-run-archive-node.md
+++ b/arbitrum-docs/run-arbitrum-node/more-types/01-run-archive-node.md
@@ -29,6 +29,11 @@ Running an Arbitrum One **full node** in **archive mode** lets you access both p
 | Send **post-Nitro** _and_ **pre-Nitro** archive requests                        | Full node (Nitro) _and_ full node (Classic)               | That's what this how-to is for; you're in the right place.                                          |
 
 ### System requirements
+:::caution
+As of May 2024, archive node snapshots for Arbitrum One, Arbitrum Nova, and Arbitrum Sepolia are no longer being updated on https://snapshot.arbitrum.foundation/index.html due to accelerated database and state growth. Teams who use these publicly available archive snapshots will need to wait longer than usual for their nodes to sync up. 
+
+The Offchain Labs team is actively exploring and working on solutions to address this and will provide an update as soon as possible. In the meantime, the Offchain Labs team continues to recommend that teams periodically create their own snapshots by stopping one of their archive nodes and backup the database.
+:::
 
 :::caution
 


### PR DESCRIPTION
Due to state growth rate acceleration, archive snapshots are no longer being updated to https://snapshot.arbitrum.foundation/index.html.

This PR adds a disclaimer to the "archive node" docs to ensure folks are aware of this update when considering running an Archive Node