### PR TITLE
add Note-on-sequencer-feed to orbit node running

### DIFF
--- a/arbitrum-docs/node-running/how-tos/running-an-orbit-node.mdx
+++ b/arbitrum-docs/node-running/how-tos/running-an-orbit-node.mdx
@@ -124,6 +124,24 @@ Or:
   chmod -fR 777 /data/arbitrum
   ```
 
+### Note on Sequencer feed
+
+The Arbitrum node requires a feed to receive real time ordered transactions from the sequencer. If you don't set feed input url, your node will listen to parent chain inbox contract to get ordered transaction which will cause your node to be unable to synchronize the latest state.
+
+To make your node listen to sequencer feed, you need to set those configurations to your sequencer node:
+  
+  ```shell
+  --node.feed.output.enable=true --node.feed.output.addr=<Sequencer feed url> --node.feed.output.port=<Sequencer feed port>
+  ```
+
+Then set the following configurations to your new node:
+  
+  ```shell
+  --node.feed.input.url=<Sequencer feed url>
+  ```
+
+After that, your node can synchronize the latest state from the sequencer feed.
+
 ## Optional parameters
 
 We show here a list of the parameters that are most commonly used when running your Orbit node. You can also use the flag `--help` for a full comprehensive list of the available parameters.


### PR DESCRIPTION
Because some orbit node operator follows this docs and said their node doesn't sync to the latest state, so we can add this note to this docs page