### PR TITLE
Fix: Arbitrum SDK's BasePath returns a 404 

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -116,6 +116,9 @@ const config = {
           sidebar: true,
           toc_max_heading_level: 5,
         },
+        path: './sdk-docs',
+        routeBasePath: 'sdk-docs',
+        sidebarItemsGenerator: sdkSidebarGenerator,
       },
     ],
     [


### PR DESCRIPTION
- Bug: Currently, "arbitrum sdk" [queries on google.com](https://www.google.com/search?q=arbitrum+sdk) or kagi.com return a link: `https://docs.arbitrum.io/sdk` that [lands a 404](https://docs.arbitrum.io/sdk).
- Every direct query on the Arbitrum SDK's methods returns a 404 as well.

- This PR is an attempt to fix this issue.