### PR TITLE
Update build nitro locally and update nitro version

### DIFF
--- a/arbitrum-docs/run-arbitrum-node/nitro/01-build-nitro-locally.md
+++ b/arbitrum-docs/run-arbitrum-node/nitro/01-build-nitro-locally.md
@@ -199,7 +199,7 @@ To run your node using the generated binaries, use the following command from th
 
 #### WASM module root error (v2.3.4 or later)
 
-If your node shutdown due to this error
+Since v2.3.4, the State Transition Function (STF) contains code that is not yet activated on the current mainnet and testnet chains. Because of that, you might receive the following error when connecting your built node to those chains:
 
 ```
 ERROR[05-21|21:59:17.415] unable to find validator machine directory for the on-chain WASM module root err="stat {WASM_MODULE_ROOT}: no such file or directory"

--- a/arbitrum-docs/run-arbitrum-node/nitro/01-build-nitro-locally.md
+++ b/arbitrum-docs/run-arbitrum-node/nitro/01-build-nitro-locally.md
@@ -6,7 +6,7 @@ sidebar_position: 7
 content_type: how-to
 ---
 
-import PublicPreviewBannerPartial from '../../partials/\_public-preview-banner-partial.md';
+import PublicPreviewBannerPartial from '../../partials/_public-preview-banner-partial.md';
 
 <PublicPreviewBannerPartial />
 
@@ -197,7 +197,7 @@ To run your node using the generated binaries, use the following command from th
 ./target/bin/nitro <node parameters>
 ```
 
-#### WASM module root error
+#### WASM module root error (v2.3.4 or later)
 
 If your node shutdown due to this error
 

--- a/arbitrum-docs/run-arbitrum-node/nitro/01-build-nitro-locally.md
+++ b/arbitrum-docs/run-arbitrum-node/nitro/01-build-nitro-locally.md
@@ -202,11 +202,11 @@ To run your node using the generated binaries, use the following command from th
 If your node shutdown due to this error
 
 ```
-ERROR[05-21|21:59:17.415] unable to find validator machine directory for the on-chain WASM module root err="stat 0x8b104a2e80ac6165dc58b9048de12f301d70b02a0ab51396c22b4b4b802a16a4: no such file or directory"
+ERROR[05-21|21:59:17.415] unable to find validator machine directory for the on-chain WASM module root err="stat {WASM_MODULE_ROOT}: no such file or directory"
 ```
 
 Try add flag:
 
 ```bash
---validation.wasm.allowed-wasm-module-roots=0x8b104a2e80ac6165dc58b9048de12f301d70b02a0ab51396c22b4b4b802a16a4
+--validation.wasm.allowed-wasm-module-roots={WASM_MODULE_ROOT}
 ```

--- a/arbitrum-docs/run-arbitrum-node/nitro/01-build-nitro-locally.md
+++ b/arbitrum-docs/run-arbitrum-node/nitro/01-build-nitro-locally.md
@@ -6,7 +6,7 @@ sidebar_position: 7
 content_type: how-to
 ---
 
-import PublicPreviewBannerPartial from '../../partials/_public-preview-banner-partial.md';
+import PublicPreviewBannerPartial from '../../partials/\_public-preview-banner-partial.md';
 
 <PublicPreviewBannerPartial />
 
@@ -142,7 +142,7 @@ rustup target add wasm32-wasi --toolchain 1.73
 cargo install cbindgen
 ```
 
-### Step 7. Configure Go [1.21](https://github.com/moovweb/gvm)
+### Step 7. Configure Go [1.20](https://github.com/moovweb/gvm)
 
 #### Install Bison
 
@@ -163,12 +163,19 @@ brew install bison
 ```bash
 bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)
 source "$HOME/.gvm/scripts/gvm"
-gvm install go1.21
-gvm use go1.21 --default
+gvm install go1.20
+gvm use go1.20 --default
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2
 ```
 
 If you use zsh, replace `bash` with `zsh`.
+
+#### Install foundry
+
+```bash
+curl -L https://foundry.paradigm.xyz | bash
+foundryup
+```
 
 ### Step 8. Start build
 
@@ -188,4 +195,18 @@ To run your node using the generated binaries, use the following command from th
 
 ```bash
 ./target/bin/nitro <node parameters>
+```
+
+#### WASM module root error
+
+If your node shutdown due to this error
+
+```
+ERROR[05-21|21:59:17.415] unable to find validator machine directory for the on-chain WASM module root err="stat 0x8b104a2e80ac6165dc58b9048de12f301d70b02a0ab51396c22b4b4b802a16a4: no such file or directory"
+```
+
+Try add flag:
+
+```bash
+--validation.wasm.allowed-wasm-module-roots=0x8b104a2e80ac6165dc58b9048de12f301d70b02a0ab51396c22b4b4b802a16a4
 ```

--- a/website/src/resources/globalVars.js
+++ b/website/src/resources/globalVars.js
@@ -14,7 +14,7 @@ const sepoliaForceIncludePeriodBlocks = 5760;
 
 const globalVars = {
   // Node docker images
-  latestNitroNodeImage: 'offchainlabs/nitro-node:v2.3.3-6a1c1a7',
+  latestNitroNodeImage: 'offchainlabs/nitro-node:v2.3.4-b4cc111',
   latestClassicNodeImage: 'offchainlabs/arb-node:v1.4.5-e97c1a4',
 
   // Node snapshots (taken around April 20th, 2013)
@@ -31,7 +31,7 @@ const globalVars = {
 
   // Nitro Github references
   nitroRepositorySlug: 'nitro',
-  nitroVersionTag: 'v2.3.3',
+  nitroVersionTag: 'v2.3.4',
   nitroPathToPrecompiles: 'precompiles',
 
   nitroContractsRepositorySlug: 'nitro-contracts',


### PR DESCRIPTION
1. tell ppl to download foundry.
2. Use golang version v1.20 because v1.21 is not compatible with ubuntu 22.04:  https://github.com/OffchainLabs/nitro/issues/2311
3. tell people to add flag` --validation.wasm.allowed-wasm-module-roots={}` if they build v2.3.4
4. update nitro version