### PR TITLE
Fix broken link to Bwarelabs sepolia faucet

### DIFF
--- a/arbitrum-docs/stylus/stylus-quickstart.md
+++ b/arbitrum-docs/stylus/stylus-quickstart.md
@@ -50,7 +50,7 @@ If you’re using [MetaMask](https://metamask.io/), simply click the dropdown at
 
 The Stylus testnet settles directly to the [Arbitrum Sepolia](/build-decentralized-apps/03-public-chains.md#arbitrum-sepolia) testnet. Follow these steps to acquire testnet ETH on the Stylus testnet:
 
-1. Navigate to [https://bwarelabs.com/faucets/arbitrum-stylus-testnet](https://bwarelabs.com/faucets/arbitrum-stylus-testnet).
+1. Navigate to [https://bwarelabs.com/faucets/sepolia](https://bwarelabs.com/faucets/sepolia).
 2. Enter your wallet address into the text field.
 3. Click `Claim` and optionally follow the second step to receive extra testnet tokens.
 4. You should now have Sepolia ETH on the Stylus testnet.

--- a/arbitrum-docs/stylus/stylus-quickstart.md
+++ b/arbitrum-docs/stylus/stylus-quickstart.md
@@ -50,7 +50,7 @@ If you’re using [MetaMask](https://metamask.io/), simply click the dropdown at
 
 The Stylus testnet settles directly to the [Arbitrum Sepolia](/build-decentralized-apps/03-public-chains.md#arbitrum-sepolia) testnet. Follow these steps to acquire testnet ETH on the Stylus testnet:
 
-1. Navigate to [https://bwarelabs.com/faucets/sepolia](https://bwarelabs.com/faucets/sepolia).
+1. Navigate to [https://bwarelabs.com/faucets/arbitrum-sepolia](https://bwarelabs.com/faucets/arbitrum-sepolia).
 2. Enter your wallet address into the text field.
 3. Click `Claim` and optionally follow the second step to receive extra testnet tokens.
 4. You should now have Sepolia ETH on the Stylus testnet.


### PR DESCRIPTION
This PR aims at fixing a `404` on the stylus-quickstart.md file.
The problem was mentioned in [this issue](https://github.com/OffchainLabs/arbitrum-docs/issues/1437)