### PR TITLE
Add `skipErrorChecking: true` to docusaurus config

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -74,6 +74,7 @@ const config = {
         entryPointStrategy: 'expand',
         exclude: [`abi`, `node_modules`, `tests`, `scripts`],
         excludeNotDocumented: true,
+        skipErrorChecking: true,
         excludeInternal: true,
         excludeExternals: true,
         readme: 'none',


### PR DESCRIPTION
Currently, when invoking `yarn build` or `yarn start`, many errors are thrown when the Arbitrum-sdk references are generated. This results in stopping the build.
Adding `skipErrorChecking: true` doesn't solve the errors but allows third-party devs to build.