### PR TITLE
Update website/package.json` to avoid compile errors

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -1,75 +1,67 @@
 {
-  "name": "nitro-docs",
-  "version": "0.0.0",
-  "private": true,
-  "scripts": {
-    "docusaurus": "docusaurus",
-    "install_sdk_dependencies": "cd ../arbitrum-sdk && yarn install && cd ../website",
-    "generate_precompiles_ref_tables": "ts-node src/scripts/precompile-reference-generator.ts",
-    "start": "docusaurus start",
-    "build_translation": "yarn ts-node ./src/scripts/move-untranslated-files.ts",
-    "build": "yarn install_sdk_dependencies && docusaurus build",
-    "swizzle": "docusaurus swizzle",
-    "deploy": "docusaurus deploy",
-    "clear": "docusaurus clear",
-    "serve": "docusaurus serve",
-    "write-translations": "docusaurus write-translations",
-    "write-heading-ids": "docusaurus write-heading-ids",
-    "find-orphan-pages": "ts-node src/scripts/find-orphan-pages.ts",
-    "format": "yarn format:docs && yarn format:app",
-    "format:app": "prettier --write --config \"./.prettierrc.js\" -- \"./*.{js,json}\" \"src/**/*.{tsx,ts,scss,json,js}\"",
-    "format:docs": "prettier --write --config \"./.prettierrc.js\" -- \"../arbitrum-docs/**/*.{md,mdx}\"",
-    "format:check": "prettier --check --config \"./.prettierrc.js\" -- \"./*.{js,json}\" \"src/**/*.{tsx,ts,scss,json,js}\" \"../arbitrum-docs/**/*.{md,mdx}\"",
-    "typecheck": "tsc"
-  },
-  "dependencies": {
-    "@arbitrum/sdk": "^3.0.0",
-    "@cmfcmf/docusaurus-search-local": "^0.11.0",
-    "@docusaurus/core": "^3.3.2",
-    "@docusaurus/preset-classic": "^3.3.2",
-    "@docusaurus/theme-live-codeblock": "^3.3.2",
-    "@docusaurus/theme-mermaid": "^3.3.2",
-    "classnames": "^2.5.1",
-    "clsx": "^1.2.1",
-    "docusaurus-lunr-search": "^3.3.2",
-    "docusaurus-plugin-fathom": "^1.2.0",
-    "docusaurus-plugin-sass": "^0.2.5",
-    "ethers": "5.7.2",
-    "got": "11.8.5",
-    "posthog-docusaurus": "^2.0.0",
-    "prism-react-renderer": "^1.3.5",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "sass": "^1.66.1",
-    "tippy.js": "^6.3.7",
-    "trim": "0.0.3"
-  },
-  "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.3.2",
-    "@offchainlabs/prettier-config": "0.2.1",
-    "@tsconfig/docusaurus": "^2.0.3",
-    "markdown-link-extractor": "^3.1.0",
-    "prettier": "^2.8.3",
-    "ts-node": "^10.9.1",
-    "typedoc": "^0.25.13",
-    "docusaurus-plugin-typedoc": "^1.0.1",
-    "typedoc-plugin-frontmatter": "^1.0.0",
-    "typedoc-plugin-markdown": "4.0.1",
-    "typescript": "^4.7.4"
-  },
-  "browserslist": {
-    "production": [
-      ">0.5%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
-  "engines": {
-    "node": ">=16.14"
-  }
+    "name": "nitro-docs",
+    "version": "0.0.0",
+    "private": true,
+    "scripts": {
+        "docusaurus": "docusaurus",
+        "install_sdk_dependencies": "cd ../arbitrum-sdk && yarn install && cd ../website",
+        "generate_precompiles_ref_tables": "ts-node src/scripts/precompile-reference-generator.ts",
+        "start": "yarn clear && yarn install_sdk_dependencies && docusaurus start",
+        "build_translation": "yarn ts-node ./src/scripts/move-untranslated-files.ts",
+        "build": "yarn install_sdk_dependencies && docusaurus build",
+        "swizzle": "docusaurus swizzle",
+        "deploy": "docusaurus deploy",
+        "clear": "docusaurus clear",
+        "serve": "docusaurus serve",
+        "write-translations": "docusaurus write-translations",
+        "write-heading-ids": "docusaurus write-heading-ids",
+        "find-orphan-pages": "ts-node src/scripts/find-orphan-pages.ts",
+        "format": "yarn format:docs && yarn format:app",
+        "format:app": "prettier --write --config \"./.prettierrc.js\" -- \"./*.{js,json}\" \"src/**/*.{tsx,ts,scss,json,js}\"",
+        "format:docs": "prettier --write --config \"./.prettierrc.js\" -- \"../arbitrum-docs/**/*.{md,mdx}\"",
+        "format:check": "prettier --check --config \"./.prettierrc.js\" -- \"./*.{js,json}\" \"src/**/*.{tsx,ts,scss,json,js}\" \"../arbitrum-docs/**/*.{md,mdx}\"",
+        "typecheck": "tsc"
+    },
+    "dependencies": {
+        "@arbitrum/sdk": "^3.0.0",
+        "@cmfcmf/docusaurus-search-local": "^0.11.0",
+        "@docusaurus/core": "^3.3.2",
+        "@docusaurus/preset-classic": "^3.3.2",
+        "@docusaurus/theme-live-codeblock": "^3.3.2",
+        "@docusaurus/theme-mermaid": "^3.3.2",
+        "classnames": "^2.5.1",
+        "clsx": "^1.2.1",
+        "docusaurus-lunr-search": "^3.3.2",
+        "docusaurus-plugin-fathom": "^1.2.0",
+        "docusaurus-plugin-sass": "^0.2.5",
+        "ethers": "5.7.2",
+        "got": "11.8.5",
+        "posthog-docusaurus": "^2.0.0",
+        "prism-react-renderer": "^1.3.5",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.66.1",
+        "tippy.js": "^6.3.7",
+        "trim": "0.0.3"
+    },
+    "devDependencies": {
+        "@docusaurus/module-type-aliases": "^3.3.2",
+        "@offchainlabs/prettier-config": "0.2.1",
+        "@tsconfig/docusaurus": "^2.0.3",
+        "markdown-link-extractor": "^3.1.0",
+        "prettier": "^2.8.3",
+        "ts-node": "^10.9.1",
+        "typedoc": "^0.25.13",
+        "docusaurus-plugin-typedoc": "^1.0.1",
+        "typedoc-plugin-frontmatter": "^1.0.0",
+        "typedoc-plugin-markdown": "4.0.1",
+        "typescript": "^4.7.4"
+    },
+    "browserslist": {
+        "production": [">0.5%", "not dead", "not op_mini all"],
+        "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
+    },
+    "engines": {
+        "node": ">=16.14"
+    }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -1,67 +1,75 @@
 {
-    "name": "nitro-docs",
-    "version": "0.0.0",
-    "private": true,
-    "scripts": {
-        "docusaurus": "docusaurus",
-        "install_sdk_dependencies": "cd ../arbitrum-sdk && yarn install && cd ../website",
-        "generate_precompiles_ref_tables": "ts-node src/scripts/precompile-reference-generator.ts",
-        "start": "yarn clear && yarn install_sdk_dependencies && docusaurus start",
-        "build_translation": "yarn ts-node ./src/scripts/move-untranslated-files.ts",
-        "build": "yarn install_sdk_dependencies && docusaurus build",
-        "swizzle": "docusaurus swizzle",
-        "deploy": "docusaurus deploy",
-        "clear": "docusaurus clear",
-        "serve": "docusaurus serve",
-        "write-translations": "docusaurus write-translations",
-        "write-heading-ids": "docusaurus write-heading-ids",
-        "find-orphan-pages": "ts-node src/scripts/find-orphan-pages.ts",
-        "format": "yarn format:docs && yarn format:app",
-        "format:app": "prettier --write --config \"./.prettierrc.js\" -- \"./*.{js,json}\" \"src/**/*.{tsx,ts,scss,json,js}\"",
-        "format:docs": "prettier --write --config \"./.prettierrc.js\" -- \"../arbitrum-docs/**/*.{md,mdx}\"",
-        "format:check": "prettier --check --config \"./.prettierrc.js\" -- \"./*.{js,json}\" \"src/**/*.{tsx,ts,scss,json,js}\" \"../arbitrum-docs/**/*.{md,mdx}\"",
-        "typecheck": "tsc"
-    },
-    "dependencies": {
-        "@arbitrum/sdk": "^3.0.0",
-        "@cmfcmf/docusaurus-search-local": "^0.11.0",
-        "@docusaurus/core": "^3.3.2",
-        "@docusaurus/preset-classic": "^3.3.2",
-        "@docusaurus/theme-live-codeblock": "^3.3.2",
-        "@docusaurus/theme-mermaid": "^3.3.2",
-        "classnames": "^2.5.1",
-        "clsx": "^1.2.1",
-        "docusaurus-lunr-search": "^3.3.2",
-        "docusaurus-plugin-fathom": "^1.2.0",
-        "docusaurus-plugin-sass": "^0.2.5",
-        "ethers": "5.7.2",
-        "got": "11.8.5",
-        "posthog-docusaurus": "^2.0.0",
-        "prism-react-renderer": "^1.3.5",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "sass": "^1.66.1",
-        "tippy.js": "^6.3.7",
-        "trim": "0.0.3"
-    },
-    "devDependencies": {
-        "@docusaurus/module-type-aliases": "^3.3.2",
-        "@offchainlabs/prettier-config": "0.2.1",
-        "@tsconfig/docusaurus": "^2.0.3",
-        "markdown-link-extractor": "^3.1.0",
-        "prettier": "^2.8.3",
-        "ts-node": "^10.9.1",
-        "typedoc": "^0.25.13",
-        "docusaurus-plugin-typedoc": "^1.0.1",
-        "typedoc-plugin-frontmatter": "^1.0.0",
-        "typedoc-plugin-markdown": "4.0.1",
-        "typescript": "^4.7.4"
-    },
-    "browserslist": {
-        "production": [">0.5%", "not dead", "not op_mini all"],
-        "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
-    },
-    "engines": {
-        "node": ">=16.14"
-    }
+  "name": "nitro-docs",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "docusaurus": "docusaurus",
+    "install_sdk_dependencies": "cd ../arbitrum-sdk && yarn install && cd ../website",
+    "generate_precompiles_ref_tables": "ts-node src/scripts/precompile-reference-generator.ts",
+    "start": "yarn clear && yarn install_sdk_dependencies && docusaurus start",
+    "build_translation": "yarn ts-node ./src/scripts/move-untranslated-files.ts",
+    "build": "yarn install_sdk_dependencies && docusaurus build",
+    "swizzle": "docusaurus swizzle",
+    "deploy": "docusaurus deploy",
+    "clear": "docusaurus clear",
+    "serve": "docusaurus serve",
+    "write-translations": "docusaurus write-translations",
+    "write-heading-ids": "docusaurus write-heading-ids",
+    "find-orphan-pages": "ts-node src/scripts/find-orphan-pages.ts",
+    "format": "yarn format:docs && yarn format:app",
+    "format:app": "prettier --write --config \"./.prettierrc.js\" -- \"./*.{js,json}\" \"src/**/*.{tsx,ts,scss,json,js}\"",
+    "format:docs": "prettier --write --config \"./.prettierrc.js\" -- \"../arbitrum-docs/**/*.{md,mdx}\"",
+    "format:check": "prettier --check --config \"./.prettierrc.js\" -- \"./*.{js,json}\" \"src/**/*.{tsx,ts,scss,json,js}\" \"../arbitrum-docs/**/*.{md,mdx}\"",
+    "typecheck": "tsc"
+  },
+  "dependencies": {
+    "@arbitrum/sdk": "^3.0.0",
+    "@cmfcmf/docusaurus-search-local": "^0.11.0",
+    "@docusaurus/core": "^3.3.2",
+    "@docusaurus/preset-classic": "^3.3.2",
+    "@docusaurus/theme-live-codeblock": "^3.3.2",
+    "@docusaurus/theme-mermaid": "^3.3.2",
+    "classnames": "^2.5.1",
+    "clsx": "^1.2.1",
+    "docusaurus-lunr-search": "^3.3.2",
+    "docusaurus-plugin-fathom": "^1.2.0",
+    "docusaurus-plugin-sass": "^0.2.5",
+    "ethers": "5.7.2",
+    "got": "11.8.5",
+    "posthog-docusaurus": "^2.0.0",
+    "prism-react-renderer": "^1.3.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "sass": "^1.66.1",
+    "tippy.js": "^6.3.7",
+    "trim": "0.0.3"
+  },
+  "devDependencies": {
+    "@docusaurus/module-type-aliases": "^3.3.2",
+    "@offchainlabs/prettier-config": "0.2.1",
+    "@tsconfig/docusaurus": "^2.0.3",
+    "markdown-link-extractor": "^3.1.0",
+    "prettier": "^2.8.3",
+    "ts-node": "^10.9.1",
+    "typedoc": "^0.25.13",
+    "docusaurus-plugin-typedoc": "^1.0.1",
+    "typedoc-plugin-frontmatter": "^1.0.0",
+    "typedoc-plugin-markdown": "4.0.1",
+    "typescript": "^4.7.4"
+  },
+  "browserslist": {
+    "production": [
+      ">0.5%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "engines": {
+    "node": ">=16.14"
+  }
 }


### PR DESCRIPTION
When running `yarn build` without installing arbitrum-sdk submodule dependencies, the compilation will fail with various errors.
Add `yarn clear` and `install_sdk_dependencies` to flush the cache and avoid compile errors.
