### PR TITLE
Drop code owners file for faster iterations

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,0 @@
-# Code owners are automatically requested for review when someone opens a pull request that modifies code that they own.
-# Learn more here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-
-# recursively assign all markdown files to @foo @bar
-**/*.md @symbolpunk @tucksondev @mahsamoosavi @anegg0 @hkalodner
-**/*.mdx @symbolpunk @tucksondev @mahsamoosavi @anegg0 @hkalodner
-
-# assign ownership of `sidebars.js` to @foo @bar
-./website/sidebars.js @symbolpunk @tucksondev @mahsamoosavi @anegg0 @hkalodner


### PR DESCRIPTION
Although best practice, restricting approval reviews to a subset of individuals throttles the pace of publications.
As an experiment and with Harry's approval, the list will be deleted.