### PR TITLE
Stylus sidebar restructure

### DIFF
--- a/arbitrum-docs/stylus/concepts/stylus-cache-manager.md
+++ b/arbitrum-docs/stylus/concepts/stylus-cache-manager.md
@@ -1,5 +1,5 @@
 ---
-title: 'Stylus caching strategy'
+title: 'Caching strategy'
 description: 'A conceptual overview of the Stylus caching strategy and `CacheManager` contract, and explaining its functionality.'
 sme: mahsa-moosavi
 target_audience: 'Developers deploying smart contracts using Stylus.'

--- a/arbitrum-docs/stylus/concepts/stylus-gas.md
+++ b/arbitrum-docs/stylus/concepts/stylus-gas.md
@@ -7,7 +7,7 @@ target_audience: 'Developers deploying smart contracts using Stylus.'
 sidebar_position: 3
 ---
 
-**Gas and ink** are the pricing primitives that are used to determine the cost of handling specific opcodes and host I/Os on Stylus. For an overview of specific opcode and host I/O costs, see [Gas and Ink costs](/stylus/reference/opcode-hostio-pricing).
+**Gas and ink** are the pricing primitives that are used to determine the cost of handling specific opcodes and host I/Os on Stylus. For an overview of specific opcode and host I/O costs, see [Gas and ink costs](/stylus/reference/opcode-hostio-pricing).
 
 import PublicPreviewBannerPartial from '../../partials/_public-preview-banner-partial.md';
 
@@ -78,5 +78,5 @@ However, developers optimizing contracts may choose to measure performance in in
 
 ### See also
 
-- [Gas and Ink costs](/stylus/reference/opcode-hostio-pricing): Detailed costs per opcode and host I/O
+- [Gas and ink costs](/stylus/reference/opcode-hostio-pricing): Detailed costs per opcode and host I/O
 - [Caching strategy](/stylus/concepts/stylus-cache-manager): Description of the Stylus caching strategy and the `CacheManager` contract

--- a/arbitrum-docs/stylus/concepts/stylus-gas.md
+++ b/arbitrum-docs/stylus/concepts/stylus-gas.md
@@ -7,7 +7,7 @@ target_audience: 'Developers deploying smart contracts using Stylus.'
 sidebar_position: 3
 ---
 
-**Gas and ink** are the pricing primitives that are used to determine the cost of handling specific opcodes and host I/Os on Stylus. For an overview of specific opcode and host I/O costs, see [Opcode and host I/O pricing](/stylus/reference/opcode-hostio-pricing).
+**Gas and ink** are the pricing primitives that are used to determine the cost of handling specific opcodes and host I/Os on Stylus. For an overview of specific opcode and host I/O costs, see [Gas and Ink costs](/stylus/reference/opcode-hostio-pricing).
 
 import PublicPreviewBannerPartial from '../../partials/_public-preview-banner-partial.md';
 
@@ -78,4 +78,5 @@ However, developers optimizing contracts may choose to measure performance in in
 
 ### See also
 
-- [Opcode and host I/O pricing reference](/stylus/reference/opcode-hostio-pricing): Detailed costs per opcode and host I/O
+- [Gas and Ink costs](/stylus/reference/opcode-hostio-pricing): Detailed costs per opcode and host I/O
+- [Caching strategy](/stylus/concepts/stylus-cache-manager): Description of the Stylus caching strategy and the `CacheManager` contract

--- a/arbitrum-docs/stylus/how-tos/optimizing-binaries.mdx
+++ b/arbitrum-docs/stylus/how-tos/optimizing-binaries.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'How to reduce the size of Stylus WASM binaries'
+title: 'How to optimize Stylus WASM binaries'
 description: 'A guide on optimizing Stylus WASM program sizes'
 author: rauljordan
 sme: rauljordan
@@ -14,7 +14,9 @@ import PublicPreviewBannerPartial from '../../partials/_public-preview-banner-pa
 
 To be deployed onchain, the size of your **uncompressed WebAssembly (WASM) file** must not exceed 128Kb, while the **compressed binary** must not exceed 24KB. Stylus conforms with the same contract size limit as the EVM to remain fully interoperable with all smart contracts on Arbitrum chains.
 
-The [Stylus CLI](https://github.com/OffchainLabs/cargo-stylus) automatically compresses your WASM programs, but there are additional steps that you can take to further reduce the size of your binaries. Your options fall into two categories: Rust compiler flags, and third-party optimization tools.
+[cargo-stylus](https://github.com/OffchainLabs/cargo-stylus), the Stylus CLI tool, automatically compresses your WASM programs, but there are additional steps that you can take to further reduce the size of your binaries.
+
+Your options fall into two categories: Rust compiler flags, and third-party optimization tools.
 
 ## Rust compiler flags
 
@@ -33,32 +35,6 @@ debug = false            # no debug data
 rpath = false            # no run-time search path
 debug-assertions = false # prune debug assertions
 incremental = false      # no incremental builds
-```
-
-### `.cargo/config.toml`
-
-```toml
-[build]
-target = "wasm32-unknown-unknown"
-
-[target.wasm32-unknown-unknown]
-rustflags = [
-  "-C", "link-arg=-zstack-size=8192", # shrink the heap
-]
-```
-
-### `nightly flags`
-
-Additional unstable nightly flags may help too.
-
-```bash
-cargo +nightly build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
-```
-
-The above configures the standard library to not include panic strings, which are useless on chain but may take up considerable space.
-
-```bash
-cargo stylus deploy --nightly
 ```
 
 ## Third-party optimization tooling

--- a/arbitrum-docs/stylus/reference/opcode-hostio-pricing.md
+++ b/arbitrum-docs/stylus/reference/opcode-hostio-pricing.md
@@ -1,5 +1,5 @@
 ---
-title: 'Opcode and host I/O pricing'
+title: 'Gas and Ink costs'
 description: 'A reference of how much opcodes and host I/Os cost in Stylus, with measurements in ink and gas.'
 author: rachel-bousfield
 sme: rachel-bousfield

--- a/arbitrum-docs/stylus/reference/opcode-hostio-pricing.md
+++ b/arbitrum-docs/stylus/reference/opcode-hostio-pricing.md
@@ -1,5 +1,5 @@
 ---
-title: 'Gas and Ink costs'
+title: 'Gas and ink costs'
 description: 'A reference of how much opcodes and host I/Os cost in Stylus, with measurements in ink and gas.'
 author: rachel-bousfield
 sme: rachel-bousfield

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -437,19 +437,7 @@ const sidebars = {
         },
         {
           type: 'doc',
-          id: 'stylus/concepts/stylus-cache-manager',
-          label: 'Stylus caching strategy',
-        },
-        {
-          type: 'html',
-          value:
-            '<a class="menu__link menu__list-item" href="/run-arbitrum-node/run-local-dev-node">Run a Stylus dev node<span class="other-section-icon">↑</span></a>',
-          // q: why use an anchor html tag here?/node-running/how-tos/running-an-stylus-node
-          // a: see note at end of file
-        },
-        {
-          type: 'doc',
-          label: 'Testnets',
+          label: 'Testnet',
           id: 'stylus/reference/testnet-information',
         },
         {
@@ -457,10 +445,26 @@ const sidebars = {
           label: 'Stylus by example',
           href: 'https://stylus-by-example.org/',
         },
-
         {
           type: 'category',
-          label: 'Gas and ink',
+          label: 'Stylus Rust SDK',
+          collapsed: true,
+          items: [
+            {
+              type: 'doc',
+              id: 'stylus/reference/rust-sdk-guide',
+              label: 'Rust SDK overview',
+            },
+            {
+              type: 'link',
+              label: 'Rust crate docs',
+              href: 'https://docs.rs/stylus-sdk/latest/stylus_sdk/index.html',
+            },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Gas, ink and caching',
           collapsed: true,
           items: [
             {
@@ -473,22 +477,61 @@ const sidebars = {
               id: 'stylus/reference/opcode-hostio-pricing',
               label: 'Gas and ink costs',
             },
+            {
+              type: 'doc',
+              id: 'stylus/concepts/stylus-cache-manager',
+              label: 'Caching strategy',
+            },
           ],
         },
         {
           type: 'category',
-          label: 'Stylus SDK',
+          label: 'CLI tools (cargo-stylus)',
           collapsed: true,
           items: [
             {
               type: 'doc',
-              id: 'stylus/reference/rust-sdk-guide',
-              label: 'Rust SDK overview',
+              label: 'Optimize WASM binaries',
+              id: 'stylus/how-tos/optimizing-binaries',
             },
             {
               type: 'doc',
+              label: 'Debug Stylus transactions',
+              id: 'stylus/how-tos/debugging-stylus-tx',
+            },
+            {
+              type: 'doc',
+              label: 'Verify Stylus contracts',
+              id: 'stylus/how-tos/verifying-contracts',
+            },
+            {
+              type: 'link',
+              label: 'cargo-stylus repository',
+              href: 'https://github.com/OffchainLabs/cargo-stylus',
+            },
+          ],
+        },
+        {
+          type: 'html',
+          value:
+            '<a class="menu__link menu__list-item" href="/run-arbitrum-node/run-local-dev-node">Run a Stylus dev node<span class="other-section-icon">↑</span></a>',
+          // q: why use an anchor html tag here?/node-running/how-tos/running-an-stylus-node
+          // a: see note at end of file
+        },
+        {
+          type: 'category',
+          label: 'Other supported languages',
+          collapsed: true,
+          items: [
+            {
+              type: 'doc',
               id: 'stylus/reference/stylus-sdk',
-              label: 'SDK repositories',
+              label: 'Other language frameworks',
+            },
+            {
+              type: 'doc',
+              label: 'Add a new smart contract language',
+              id: 'stylus/how-tos/adding-support-for-new-languages',
             },
           ],
         },
@@ -496,32 +539,6 @@ const sidebars = {
           type: 'doc',
           label: 'Troubleshooting',
           id: 'stylus/troubleshooting-building-stylus',
-        },
-
-        {
-          type: 'doc',
-          label: 'Add a new smart contract language',
-          id: 'stylus/how-tos/adding-support-for-new-languages',
-        },
-        {
-          type: 'doc',
-          label: 'Reduce the size of WASM binaries',
-          id: 'stylus/how-tos/optimizing-binaries',
-        },
-        {
-          type: 'doc',
-          label: 'Debug Stylus transactions',
-          id: 'stylus/how-tos/debugging-stylus-tx',
-        },
-        {
-          type: 'doc',
-          label: 'Verifying Stylus contracts',
-          id: 'stylus/how-tos/verifying-contracts',
-        },
-        {
-          type: 'link',
-          label: 'Rust crate docs',
-          href: 'https://docs.rs/stylus-sdk/latest/stylus_sdk/index.html',
         },
         {
           type: 'link',


### PR DESCRIPTION
This PR attempts to restructure the sidebar menu for the Stylus section. It includes the following:
- Reorder the menu entries for a shorter sidebar and meaningful subsections to increase discoverability
- Adds the "Caching strategy" page to the "Gas and Ink" subsection, and adapts the Overview to mention it
- Modifies the "Reduce the size of WASM binaries" to remove outdated information and adapt the language to the new "CLI tools" subsection