### PR TITLE
Update QuickNode Supported L1 Beacon Chain Networks

### DIFF
--- a/arbitrum-docs/run-arbitrum-node/05-l1-ethereum-beacon-chain-rpc-providers.md
+++ b/arbitrum-docs/run-arbitrum-node/05-l1-ethereum-beacon-chain-rpc-providers.md
@@ -32,7 +32,7 @@ Offchain Labs has plans to reduce a Nitro validator's reliance on historical blo
 | [BlastAPI](https://blastapi.io/public-api/ethereum)                         |                            |                               | ✅                         |                            |
 | [Nirvana Labs](https://nirvanalabs.io)                                      | ✅                         | ✅                            |                            |                            |
 | [NodeReal](https://nodereal.io/)                                            | ✅                         |                               |                            |                            |
-| [Quicknode](https://www.quicknode.com/docs/ethereum)                        | ✅                         | ✅                            |                            |                            |
+| [QuickNode](https://www.quicknode.com/docs/ethereum)                        | ✅                         | ✅                            | ✅                         | ✅                         |
 
 Please reach out to these teams individually if you need assistance with setting up your validator with any of the above providers.
 


### PR DESCRIPTION
- Updates the L1 Ethereum beacon chain RPC providers table to reflect that QuickNode now supports both Sepolia and Holesky beacon chain APIs
- Updates `Quicknode` to `QuickNode`

<img width="544" alt="image" src="https://github.com/user-attachments/assets/d6860a5b-91a1-4b4d-8bfb-1aaebab43674">
