### PR TITLE
fix: update deprecated `estimate-gas-only` option

### DIFF
--- a/arbitrum-docs/stylus/stylus-quickstart.md
+++ b/arbitrum-docs/stylus/stylus-quickstart.md
@@ -156,7 +156,7 @@ Once you're ready to deploy your program onchain, you can use the `cargo stylus
 ```
 cargo stylus deploy \
   --private-key-path=<PRIVKEY_FILE_PATH> \
-  --estimate-gas-only
+  --estimate-gas
 ```
 
 and see:


### PR DESCRIPTION
This PR is a fix for the deprecated option `--estimate-gas-only`, now: `--estimate-gas`.