### PR TITLE
Refactor CacheManager CLI Commands

### DIFF
--- a/arbitrum-docs/stylus/concepts/stylus-cache-manager.md
+++ b/arbitrum-docs/stylus/concepts/stylus-cache-manager.md
@@ -43,10 +43,20 @@ This section provides a practical guide for interacting with the `CacheManager` 
 
 ## Step 1: Determine the minimum bid
 
-Before placing a bid, it's important to know the minimum bid required to cache the Stylys contract. This can be done using the `getMinBid` function.
+Before placing a bid, it's important to know the minimum bid required to cache the Stylys contract. This can be done using the `getMinBid` function, or using the `cargo stylus cache suggest-bid` command.
+
+**Method 1: Direct smart contract call**
 
 ```solidity
 uint192 minBid = cacheManager.getMinBid(contractAddress);
+```
+
+**Method 2: Cargo stylus command**
+
+Note that here, <contractAddress> is the address of the Stylus contract you want to cache.
+
+```bash
+cargo stylus cache suggest-bid <contractAddress>
 ```
 
 ## Step 2: Place a bid
@@ -61,18 +71,26 @@ Here, `bidAmount` is the amount you want to bid, and `contractAddress` is the ad
 cacheManager.placeBid{value: bidAmount}(contractAddress);
 ```
 
-**Method 2: cargo stylus command**
+**Method 2: Cargo stylus command**
 
-To place a bid using the `cargo stylus` command-line tool, you can use the `cache` command with the appropriate arguments:
+You can place a bid using the `cargo stylus cache bid` command:
 
 ```bash
-cargo stylus cache --address=<contractAddress> --bid=<bidAmount>
+cargo stylus cache bid <contractAddress> <bidAmount>
 ```
 
-- `--address`: The address of the Stylus contract you want to cache.
-- `--bid`: The amount you want to bid. If not specified, the default bid is 0.
+- `<contractAddress>`: The address of the Stylus contract you want to cache.
+- `<bidAmount>`: The amount you want to bid. If not specified, the default bid is 0.
 
 If you specify a bid amount using `cargo stylus`, it will automatically validate that the bid is greater than or equal to the result of the `getMinBid` function. If the bid is insufficient, the command will fail, ensuring that only valid bids are placed.
+
+## Step 3: Check cache status
+
+To check if a specific address is cached, you can use the `cargo stylus status` command:
+
+```bash
+cargo stylus status --address=<contractAddress>
+```
 
 ### Additional information
 

--- a/arbitrum-docs/stylus/concepts/stylus-cache-manager.md
+++ b/arbitrum-docs/stylus/concepts/stylus-cache-manager.md
@@ -53,10 +53,10 @@ uint192 minBid = cacheManager.getMinBid(contractAddress);
 
 **Method 2: Cargo stylus command**
 
-Note that here, <contractAddress> is the address of the Stylus contract you want to cache.
+Note that here, [contractAddress] is the address of the Stylus contract you want to cache.
 
 ```bash
-cargo stylus cache suggest-bid <contractAddress>
+cargo stylus cache suggest-bid [contractAddress]
 ```
 
 ## Step 2: Place a bid
@@ -76,11 +76,11 @@ cacheManager.placeBid{value: bidAmount}(contractAddress);
 You can place a bid using the `cargo stylus cache bid` command:
 
 ```bash
-cargo stylus cache bid <contractAddress> <bidAmount>
+cargo stylus cache bid [contractAddress] [bidAmount]
 ```
 
-- `<contractAddress>`: The address of the Stylus contract you want to cache.
-- `<bidAmount>`: The amount you want to bid. If not specified, the default bid is 0.
+- `[contractAddress]`: The address of the Stylus contract you want to cache.
+- `[bidAmount]`: The amount you want to bid. If not specified, the default bid is 0.
 
 If you specify a bid amount using `cargo stylus`, it will automatically validate that the bid is greater than or equal to the result of the `getMinBid` function. If the bid is insufficient, the command will fail, ensuring that only valid bids are placed.
 
@@ -89,7 +89,7 @@ If you specify a bid amount using `cargo stylus`, it will automatically validate
 To check if a specific address is cached, you can use the `cargo stylus status` command:
 
 ```bash
-cargo stylus status --address=<contractAddress>
+cargo stylus status --address=[contractAddress]
 ```
 
 ### Additional information


### PR DESCRIPTION
This PR refactors the cargo stylus command-line interface to adopt a subcommand model for interacting with the CacheManager contract. The updates include:

- Implementing the new cargo stylus cache bid, cargo stylus cache suggest-bid, and cargo stylus status commands.

- Revising the documentation to reflect the new command structure, providing clear guidance on using these commands for managing the Stylus cache.

These changes align with recent feedback and aim to improve the developer experience when working with Stylus contracts and the CacheManager.