### PR TITLE
update docs to stylus sdk v6

### DIFF
--- a/arbitrum-docs/stylus/reference/rust-sdk-guide.md
+++ b/arbitrum-docs/stylus/reference/rust-sdk-guide.md
@@ -230,6 +230,9 @@ The above allows consumers of `Erc20` to choose immutable constants via speciali
 
 This section provides extra information about how the Stylus Rust SDK handles functions. You can find more information and basic examples in [Functions](/stylus-by-example/function.mdx), [Bytes in, bytes out programming](/stylus-by-example/bytes_in_bytes_out.mdx), [Inheritance] and [Sending ether](/stylus-by-example/sending_ether.mdx).
 
+### Pure, View, and Write functions
+
+For non-payable methods the [`#[public]`][public] macro can figure state mutability out for you based on the types of the arguments. Functions with `&self` will be considered `view`, those with `&mut self` will be considered `write`, and those with neither will be considered `pure`. Please note that `pure` and `view` functions may change the state of other contracts by calling into them, or even this one if the `reentrant` feature is enabled.
 
 ### [`#[entrypoint]`][entrypoint]
 

--- a/arbitrum-docs/stylus/reference/rust-sdk-guide.md
+++ b/arbitrum-docs/stylus/reference/rust-sdk-guide.md
@@ -1,8 +1,8 @@
 ---
 title: 'Stylus Rust SDK advanced features'
 description: 'Advanced features of the Stylus Rust SDK'
-author: rachel-bousfield, jose-franco
-sme: rachel-bousfield, jose-franco
+author: rachel-bousfield, jose-franco, mehdi-salehi
+sme: rachel-bousfield, jose-franco, mehdi-salehi
 sidebar_position: 1
 target_audience: Developers using the Stylus Rust SDK to write and deploy smart contracts.
 ---

--- a/arbitrum-docs/stylus/reference/rust-sdk-guide.md
+++ b/arbitrum-docs/stylus/reference/rust-sdk-guide.md
@@ -230,9 +230,6 @@ The above allows consumers of `Erc20` to choose immutable constants via speciali
 
 This section provides extra information about how the Stylus Rust SDK handles functions. You can find more information and basic examples in [Functions](/stylus-by-example/function.mdx), [Bytes in, bytes out programming](/stylus-by-example/bytes_in_bytes_out.mdx), [Inheritance] and [Sending ether](/stylus-by-example/sending_ether.mdx).
 
-### [`#[pure]`][pure], [`#[view]`][view], and `#[write]`
-
-For non-payable methods the [`#[public]`][public] macro can figure state mutability out for you based on the types of the arguments. Functions with `&self` will be considered `view`, those with `&mut self` will be considered `write`, and those with neither will be considered `pure`. Please note that `pure` and `view` functions may change the state of other contracts by calling into them, or even this one if the `reentrant` feature is enabled.
 
 ### [`#[entrypoint]`][entrypoint]
 


### PR DESCRIPTION
Deleted the paragraph about [view], [pure] and [write] macros which are not existing anymore.