### PR TITLE
Replay tx macos warning

### DIFF
--- a/arbitrum-docs/partials/_macos-verify-tx-issue-banner-partial.mdx
+++ b/arbitrum-docs/partials/_macos-verify-tx-issue-banner-partial.mdx
@@ -1,0 +1,5 @@
+:::caution MacOS Users
+
+This feature is currently unavailable to MacOS users. We are working on a solution and will update this page when this limitation is resolved.
+
+:::

--- a/arbitrum-docs/stylus/how-tos/debugging-stylus-tx.mdx
+++ b/arbitrum-docs/stylus/how-tos/debugging-stylus-tx.mdx
@@ -9,6 +9,7 @@ sidebar_position: 2
 ---
 
 import PublicPreviewBannerPartial from '../../partials/_public-preview-banner-partial.md';
+import MacosVerifyTxIssueBannerPartial from '../../partials/_macos-verify-tx-issue-banner-partial.mdx';
 
 <PublicPreviewBannerPartial />
 
@@ -23,7 +24,7 @@ Cargo Stylus is a tool designed to simplify the development and debugging proces
 
 ### Replaying transactions
 
-**Note:** Currently, this has only been tested on Linux, x86 systems with GDB installed.
+<MacosVerifyTxIssueBannerPartial />
 
 #### Requirements
 


### PR DESCRIPTION
This PR add a warning for MacOS users: the `replay` function won't work in the current version.