### PR TITLE
Update other language frameworks

### DIFF
--- a/arbitrum-docs/stylus/reference/other-language-frameworks.mdx
+++ b/arbitrum-docs/stylus/reference/other-language-frameworks.mdx
@@ -3,7 +3,7 @@ title: 'Other language frameworks (non-Rust)'
 description: A table with links and minimal information about non-Rust Stylus SDKs
 author: anegg0
 sme: anegg0
-target_audience: Non-Rust developers writing and deploying Stylus programs
+target_audience: Non-Rust developers writing and deploying Stylus contracts
 sidebar_position: 2
 ---
 
@@ -11,7 +11,7 @@ import PublicPreviewBannerPartial from '../../partials/_public-preview-banner-pa
 
 <PublicPreviewBannerPartial />
 
-If you are looking to write and deploy Stylus programs without using Rust, please see the following SDKs.
+If you are looking to write and deploy Stylus contracts without using Rust, please see the following SDKs.
 
 | Repo                           | Use cases                   | License           |
 | :----------------------------- | :-------------------------- | :---------------- |

--- a/arbitrum-docs/stylus/reference/other-language-frameworks.mdx
+++ b/arbitrum-docs/stylus/reference/other-language-frameworks.mdx
@@ -1,0 +1,29 @@
+---
+title: 'Other language frameworks (non-Rust)'
+description: A table with links and minimal information about non-Rust Stylus SDKs
+author: anegg0
+sme: anegg0
+target_audience: Non-Rust developers writing and deploying Stylus programs
+sidebar_position: 2
+---
+
+import PublicPreviewBannerPartial from '../../partials/_public-preview-banner-partial.md';
+
+<PublicPreviewBannerPartial />
+
+If you are looking to write and deploy Stylus programs without using Rust, please see the following SDKs.
+
+| Repo                           | Use cases                   | License           |
+| :----------------------------- | :-------------------------- | :---------------- |
+| [C/C++ SDK][C]                 | Cryptography and algorithms | Apache 2.0 or MIT |
+| [Bf SDK][Bf]                   | Educational                 | Apache 2.0 or MIT |
+
+The Stylus SDKs are open-source, allowing anyone to build their own! The following SDKs have been developed from the ecosystem of Stylus developers.
+
+| Repo           |
+| :------------- |
+| [Zig SDK][Zig] |
+
+[C]: https://github.com/OffchainLabs/stylus-sdk-c
+[Bf]: https://github.com/OffchainLabs/stylus-sdk-bf
+[Zig]: https://github.com/Stylish-Stylus/zig-stylus

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -547,7 +547,7 @@ const sidebars = {
           items: [
             {
               type: 'doc',
-              id: 'stylus/reference/stylus-sdk',
+              id: 'stylus/reference/other-language-frameworks',
               label: 'Other language frameworks',
             },
             {

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -543,13 +543,12 @@ const sidebars = {
         {
           type: 'category',
           label: 'Other supported languages',
-          collapsed: true,
+          collapsed: false,
+          link: {
+            type: 'doc',
+            id: 'stylus/reference/other-language-frameworks',
+          },
           items: [
-            {
-              type: 'doc',
-              id: 'stylus/reference/other-language-frameworks',
-              label: 'Other language frameworks',
-            },
             {
               type: 'doc',
               label: 'Add a new smart contract language',


### PR DESCRIPTION
This PR adds an "other language frameworks" section to the Stylus content.
It corrects the previous section of the same title, which was actually about every repository including Rust.