### PR TITLE
Changed admonition phrasing

### DIFF
--- a/arbitrum-docs/partials/_not-for-production-banner-partial.mdx
+++ b/arbitrum-docs/partials/_not-for-production-banner-partial.mdx
@@ -1,5 +1,5 @@
 :::note
 
-This code has yet to be audited. We don't recommend using it for production.
+This code has yet to be audited. Please use at your own risk.
 
 :::


### PR DESCRIPTION
This PR changes the warning in front of SBE's code to: 
`This code has yet to be audited. Please use at your own risk.`