### PR TITLE
Update nitro version

### DIFF
--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbAddressTable.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbAddressTable.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAddressTable.go#L17"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbAddressTable.go#L17"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAddressTable.go#L22"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbAddressTable.go#L22"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAddressTable.go#L27"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbAddressTable.go#L27"
           target="_blank"
         >
           Implementation
@@ -90,7 +90,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAddressTable.go#L40"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbAddressTable.go#L40"
           target="_blank"
         >
           Implementation
@@ -112,7 +112,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAddressTable.go#L52"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbAddressTable.go#L52"
           target="_blank"
         >
           Implementation
@@ -134,7 +134,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAddressTable.go#L67"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbAddressTable.go#L67"
           target="_blank"
         >
           Implementation
@@ -156,7 +156,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAddressTable.go#L73"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbAddressTable.go#L73"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbAddressTable.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbAddressTable.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbAddressTable.sol#L17"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbAddressTable.sol#L17"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbAddressTable.go#L17"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAddressTable.go#L17"
           target="_blank"
         >
           Implementation
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbAddressTable.sol#L24"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbAddressTable.sol#L24"
           target="_blank"
         >
           Interface
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbAddressTable.go#L22"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAddressTable.go#L22"
           target="_blank"
         >
           Implementation
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbAddressTable.sol#L32"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbAddressTable.sol#L32"
           target="_blank"
         >
           Interface
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbAddressTable.go#L27"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAddressTable.go#L27"
           target="_blank"
         >
           Implementation
@@ -82,7 +82,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbAddressTable.sol#L41"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbAddressTable.sol#L41"
           target="_blank"
         >
           Interface
@@ -90,7 +90,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbAddressTable.go#L40"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAddressTable.go#L40"
           target="_blank"
         >
           Implementation
@@ -104,7 +104,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbAddressTable.sol#L47"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbAddressTable.sol#L47"
           target="_blank"
         >
           Interface
@@ -112,7 +112,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbAddressTable.go#L52"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAddressTable.go#L52"
           target="_blank"
         >
           Implementation
@@ -126,7 +126,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbAddressTable.sol#L54"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbAddressTable.sol#L54"
           target="_blank"
         >
           Interface
@@ -134,7 +134,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbAddressTable.go#L67"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAddressTable.go#L67"
           target="_blank"
         >
           Implementation
@@ -148,7 +148,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbAddressTable.sol#L59"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbAddressTable.sol#L59"
           target="_blank"
         >
           Interface
@@ -156,7 +156,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbAddressTable.go#L73"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAddressTable.go#L73"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbAggregator.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbAggregator.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbAggregator.sol#L14"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbAggregator.sol#L14"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbAggregator.go#L24"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAggregator.go#L24"
           target="_blank"
         >
           Implementation
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbAggregator.sol#L18"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbAggregator.sol#L18"
           target="_blank"
         >
           Interface
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbAggregator.go#L30"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAggregator.go#L30"
           target="_blank"
         >
           Implementation
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbAggregator.sol#L22"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbAggregator.sol#L22"
           target="_blank"
         >
           Interface
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbAggregator.go#L35"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAggregator.go#L35"
           target="_blank"
         >
           Implementation
@@ -80,7 +80,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbAggregator.sol#L27"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbAggregator.sol#L27"
           target="_blank"
         >
           Interface
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbAggregator.go#L39"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAggregator.go#L39"
           target="_blank"
         >
           Implementation
@@ -102,7 +102,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbAggregator.sol#L32"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbAggregator.sol#L32"
           target="_blank"
         >
           Interface
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbAggregator.go#L62"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAggregator.go#L62"
           target="_blank"
         >
           Implementation
@@ -124,7 +124,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbAggregator.sol#L38"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbAggregator.sol#L38"
           target="_blank"
         >
           Interface
@@ -132,7 +132,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbAggregator.go#L71"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAggregator.go#L71"
           target="_blank"
         >
           Implementation
@@ -149,7 +149,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbAggregator.sol#L43"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbAggregator.sol#L43"
           target="_blank"
         >
           Interface
@@ -157,7 +157,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbAggregator.go#L93"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAggregator.go#L93"
           target="_blank"
         >
           Implementation
@@ -171,7 +171,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbAggregator.sol#L51"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbAggregator.sol#L51"
           target="_blank"
         >
           Interface
@@ -179,7 +179,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbAggregator.go#L99"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAggregator.go#L99"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbAggregator.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbAggregator.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAggregator.go#L24"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbAggregator.go#L24"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAggregator.go#L30"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbAggregator.go#L30"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAggregator.go#L35"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbAggregator.go#L35"
           target="_blank"
         >
           Implementation
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAggregator.go#L39"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbAggregator.go#L39"
           target="_blank"
         >
           Implementation
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAggregator.go#L62"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbAggregator.go#L62"
           target="_blank"
         >
           Implementation
@@ -132,7 +132,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAggregator.go#L71"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbAggregator.go#L71"
           target="_blank"
         >
           Implementation
@@ -157,7 +157,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAggregator.go#L93"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbAggregator.go#L93"
           target="_blank"
         >
           Implementation
@@ -179,7 +179,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbAggregator.go#L99"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbAggregator.go#L99"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbDebug.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbDebug.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbDebug.sol#L13"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbDebug.sol#L13"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbDebug.go#L55"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbDebug.go#L55"
           target="_blank"
         >
           Implementation
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbDebug.sol#L16"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbDebug.sol#L16"
           target="_blank"
         >
           Interface
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbDebug.go#L27"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbDebug.go#L27"
           target="_blank"
         >
           Implementation
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbDebug.sol#L19"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbDebug.sol#L19"
           target="_blank"
         >
           Interface
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbDebug.go#L45"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbDebug.go#L45"
           target="_blank"
         >
           Implementation
@@ -80,7 +80,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbDebug.sol#L38"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbDebug.sol#L38"
           target="_blank"
         >
           Interface
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbDebug.go#L50"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbDebug.go#L50"
           target="_blank"
         >
           Implementation
@@ -102,7 +102,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbDebug.sol#L40"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbDebug.sol#L40"
           target="_blank"
         >
           Interface
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbDebug.go#L60"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbDebug.go#L60"
           target="_blank"
         >
           Implementation
@@ -124,7 +124,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbDebug.sol#L42"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbDebug.sol#L42"
           target="_blank"
         >
           Interface
@@ -132,7 +132,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbDebug.go#L64"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbDebug.go#L64"
           target="_blank"
         >
           Implementation
@@ -158,7 +158,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbDebug.sol#L22"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbDebug.sol#L22"
           target="_blank"
         >
           Interface
@@ -166,7 +166,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbDebug.go#L32"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbDebug.go#L32"
           target="_blank"
         >
           Implementation
@@ -182,7 +182,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbDebug.sol#L23"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbDebug.sol#L23"
           target="_blank"
         >
           Interface
@@ -190,7 +190,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbDebug.go#L37"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbDebug.go#L37"
           target="_blank"
         >
           Implementation
@@ -206,7 +206,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbDebug.sol#L30"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbDebug.sol#L30"
           target="_blank"
         >
           Interface
@@ -214,7 +214,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbDebug.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbDebug.go#L0"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbDebug.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbDebug.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbDebug.go#L55"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbDebug.go#L55"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbDebug.go#L27"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbDebug.go#L27"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbDebug.go#L45"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbDebug.go#L45"
           target="_blank"
         >
           Implementation
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbDebug.go#L50"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbDebug.go#L50"
           target="_blank"
         >
           Implementation
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbDebug.go#L60"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbDebug.go#L60"
           target="_blank"
         >
           Implementation
@@ -132,7 +132,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbDebug.go#L64"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbDebug.go#L64"
           target="_blank"
         >
           Implementation
@@ -166,7 +166,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbDebug.go#L32"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbDebug.go#L32"
           target="_blank"
         >
           Implementation
@@ -190,7 +190,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbDebug.go#L37"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbDebug.go#L37"
           target="_blank"
         >
           Implementation
@@ -214,7 +214,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbDebug.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbDebug.go#L0"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbFunctionTable.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbFunctionTable.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbFunctionTable.sol#L15"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbFunctionTable.sol#L15"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbFunctionTable.go#L19"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbFunctionTable.go#L19"
           target="_blank"
         >
           Implementation
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbFunctionTable.sol#L18"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbFunctionTable.sol#L18"
           target="_blank"
         >
           Interface
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbFunctionTable.go#L24"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbFunctionTable.go#L24"
           target="_blank"
         >
           Implementation
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbFunctionTable.sol#L21"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbFunctionTable.sol#L21"
           target="_blank"
         >
           Interface
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbFunctionTable.go#L29"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbFunctionTable.go#L29"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbFunctionTable.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbFunctionTable.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbFunctionTable.go#L19"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbFunctionTable.go#L19"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbFunctionTable.go#L24"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbFunctionTable.go#L24"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbFunctionTable.go#L29"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbFunctionTable.go#L29"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbGasInfo.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbGasInfo.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L22"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L22"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L26"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L26"
           target="_blank"
         >
           Implementation
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L44"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L44"
           target="_blank"
         >
           Interface
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L101"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L101"
           target="_blank"
         >
           Implementation
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L58"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L58"
           target="_blank"
         >
           Interface
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L106"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L106"
           target="_blank"
         >
           Implementation
@@ -82,7 +82,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L69"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L69"
           target="_blank"
         >
           Interface
@@ -90,7 +90,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L158"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L158"
           target="_blank"
         >
           Implementation
@@ -104,7 +104,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L80"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L80"
           target="_blank"
         >
           Interface
@@ -112,7 +112,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L163"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L163"
           target="_blank"
         >
           Implementation
@@ -126,7 +126,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L90"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L90"
           target="_blank"
         >
           Interface
@@ -134,7 +134,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L171"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L171"
           target="_blank"
         >
           Implementation
@@ -148,7 +148,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L93"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L93"
           target="_blank"
         >
           Interface
@@ -156,7 +156,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L176"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L176"
           target="_blank"
         >
           Implementation
@@ -170,7 +170,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L96"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L96"
           target="_blank"
         >
           Interface
@@ -178,7 +178,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L181"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L181"
           target="_blank"
         >
           Implementation
@@ -194,7 +194,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L100"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L100"
           target="_blank"
         >
           Interface
@@ -202,7 +202,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L186"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L186"
           target="_blank"
         >
           Implementation
@@ -216,7 +216,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L104"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L104"
           target="_blank"
         >
           Interface
@@ -224,7 +224,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L191"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L191"
           target="_blank"
         >
           Implementation
@@ -238,7 +238,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L107"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L107"
           target="_blank"
         >
           Interface
@@ -246,7 +246,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L196"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L196"
           target="_blank"
         >
           Implementation
@@ -260,7 +260,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L110"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L110"
           target="_blank"
         >
           Interface
@@ -268,7 +268,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L201"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L201"
           target="_blank"
         >
           Implementation
@@ -282,7 +282,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L113"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L113"
           target="_blank"
         >
           Interface
@@ -290,7 +290,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L206"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L206"
           target="_blank"
         >
           Implementation
@@ -304,7 +304,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L116"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L116"
           target="_blank"
         >
           Interface
@@ -312,7 +312,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L211"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L211"
           target="_blank"
         >
           Implementation
@@ -326,7 +326,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L119"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L119"
           target="_blank"
         >
           Interface
@@ -334,7 +334,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L216"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L216"
           target="_blank"
         >
           Implementation
@@ -351,7 +351,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L122"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L122"
           target="_blank"
         >
           Interface
@@ -359,7 +359,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L221"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L221"
           target="_blank"
         >
           Implementation
@@ -373,7 +373,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L125"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L125"
           target="_blank"
         >
           Interface
@@ -381,7 +381,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L245"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L245"
           target="_blank"
         >
           Implementation
@@ -397,7 +397,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L128"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L128"
           target="_blank"
         >
           Interface
@@ -405,7 +405,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L250"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L250"
           target="_blank"
         >
           Implementation
@@ -419,7 +419,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L131"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L131"
           target="_blank"
         >
           Interface
@@ -427,7 +427,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L255"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L255"
           target="_blank"
         >
           Implementation
@@ -441,7 +441,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L135"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L135"
           target="_blank"
         >
           Interface
@@ -449,7 +449,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L260"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L260"
           target="_blank"
         >
           Implementation
@@ -466,7 +466,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L139"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L139"
           target="_blank"
         >
           Interface
@@ -474,7 +474,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L265"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L265"
           target="_blank"
         >
           Implementation
@@ -488,7 +488,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L143"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L143"
           target="_blank"
         >
           Interface
@@ -496,7 +496,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L270"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L270"
           target="_blank"
         >
           Implementation
@@ -513,7 +513,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L147"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L147"
           target="_blank"
         >
           Interface
@@ -521,7 +521,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L275"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L275"
           target="_blank"
         >
           Implementation
@@ -537,7 +537,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbGasInfo.sol#L151"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbGasInfo.sol#L151"
           target="_blank"
         >
           Interface
@@ -545,7 +545,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbGasInfo.go#L280"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L280"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbGasInfo.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbGasInfo.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L26"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L26"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L101"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L101"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L106"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L106"
           target="_blank"
         >
           Implementation
@@ -90,7 +90,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L158"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L158"
           target="_blank"
         >
           Implementation
@@ -112,7 +112,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L163"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L163"
           target="_blank"
         >
           Implementation
@@ -134,7 +134,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L171"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L171"
           target="_blank"
         >
           Implementation
@@ -156,7 +156,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L176"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L176"
           target="_blank"
         >
           Implementation
@@ -178,7 +178,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L181"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L181"
           target="_blank"
         >
           Implementation
@@ -202,7 +202,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L186"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L186"
           target="_blank"
         >
           Implementation
@@ -224,7 +224,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L191"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L191"
           target="_blank"
         >
           Implementation
@@ -246,7 +246,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L196"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L196"
           target="_blank"
         >
           Implementation
@@ -268,7 +268,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L201"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L201"
           target="_blank"
         >
           Implementation
@@ -290,7 +290,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L206"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L206"
           target="_blank"
         >
           Implementation
@@ -312,7 +312,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L211"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L211"
           target="_blank"
         >
           Implementation
@@ -334,7 +334,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L216"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L216"
           target="_blank"
         >
           Implementation
@@ -359,7 +359,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L221"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L221"
           target="_blank"
         >
           Implementation
@@ -381,7 +381,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L245"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L245"
           target="_blank"
         >
           Implementation
@@ -405,7 +405,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L250"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L250"
           target="_blank"
         >
           Implementation
@@ -427,7 +427,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L255"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L255"
           target="_blank"
         >
           Implementation
@@ -449,7 +449,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L260"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L260"
           target="_blank"
         >
           Implementation
@@ -474,7 +474,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L265"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L265"
           target="_blank"
         >
           Implementation
@@ -496,7 +496,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L270"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L270"
           target="_blank"
         >
           Implementation
@@ -521,7 +521,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L275"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L275"
           target="_blank"
         >
           Implementation
@@ -545,7 +545,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbGasInfo.go#L280"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbGasInfo.go#L280"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbInfo.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbInfo.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbInfo.sol#L11"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbInfo.sol#L11"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbInfo.go#L17"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbInfo.go#L17"
           target="_blank"
         >
           Implementation
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbInfo.sol#L14"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbInfo.sol#L14"
           target="_blank"
         >
           Interface
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbInfo.go#L25"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbInfo.go#L25"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbInfo.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbInfo.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbInfo.go#L17"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbInfo.go#L17"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbInfo.go#L25"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbInfo.go#L25"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwner.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwner.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L37"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L37"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L42"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L42"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L51"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L51"
           target="_blank"
         >
           Implementation
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L56"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L56"
           target="_blank"
         >
           Implementation
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L61"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L61"
           target="_blank"
         >
           Implementation
@@ -134,7 +134,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L66"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L66"
           target="_blank"
         >
           Implementation
@@ -156,7 +156,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L71"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L71"
           target="_blank"
         >
           Implementation
@@ -178,7 +178,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L79"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L79"
           target="_blank"
         >
           Implementation
@@ -200,7 +200,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L84"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L84"
           target="_blank"
         >
           Implementation
@@ -222,7 +222,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L89"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L89"
           target="_blank"
         >
           Implementation
@@ -244,7 +244,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L94"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L94"
           target="_blank"
         >
           Implementation
@@ -266,7 +266,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L99"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L99"
           target="_blank"
         >
           Implementation
@@ -288,7 +288,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L104"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L104"
           target="_blank"
         >
           Implementation
@@ -310,7 +310,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L109"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L109"
           target="_blank"
         >
           Implementation
@@ -332,7 +332,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L114"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L114"
           target="_blank"
         >
           Implementation
@@ -354,7 +354,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L119"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L119"
           target="_blank"
         >
           Implementation
@@ -376,7 +376,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L123"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L123"
           target="_blank"
         >
           Implementation
@@ -398,7 +398,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L127"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L127"
           target="_blank"
         >
           Implementation
@@ -420,7 +420,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L131"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L131"
           target="_blank"
         >
           Implementation
@@ -442,7 +442,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L135"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L135"
           target="_blank"
         >
           Implementation
@@ -464,7 +464,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L139"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L139"
           target="_blank"
         >
           Implementation
@@ -486,7 +486,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L143"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L143"
           target="_blank"
         >
           Implementation
@@ -508,7 +508,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L151"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L151"
           target="_blank"
         >
           Implementation
@@ -533,7 +533,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L147"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L147"
           target="_blank"
         >
           Implementation
@@ -555,7 +555,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L155"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L155"
           target="_blank"
         >
           Implementation
@@ -577,7 +577,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L176"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L176"
           target="_blank"
         >
           Implementation
@@ -599,7 +599,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L190"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L190"
           target="_blank"
         >
           Implementation
@@ -621,7 +621,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L200"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L200"
           target="_blank"
         >
           Implementation
@@ -643,7 +643,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L210"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L210"
           target="_blank"
         >
           Implementation
@@ -665,7 +665,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L220"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L220"
           target="_blank"
         >
           Implementation
@@ -687,7 +687,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L230"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L230"
           target="_blank"
         >
           Implementation
@@ -709,7 +709,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L241"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L241"
           target="_blank"
         >
           Implementation
@@ -731,7 +731,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L251"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L251"
           target="_blank"
         >
           Implementation
@@ -753,7 +753,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L261"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L261"
           target="_blank"
         >
           Implementation
@@ -775,7 +775,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L271"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L271"
           target="_blank"
         >
           Implementation
@@ -797,7 +797,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L281"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L281"
           target="_blank"
         >
           Implementation
@@ -819,7 +819,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L286"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L286"
           target="_blank"
         >
           Implementation
@@ -841,7 +841,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L298"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L298"
           target="_blank"
         >
           Implementation
@@ -875,7 +875,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwner.go#L0"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwner.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwner.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L18"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L18"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L37"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L37"
           target="_blank"
         >
           Implementation
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L21"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L21"
           target="_blank"
         >
           Interface
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L42"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L42"
           target="_blank"
         >
           Implementation
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L24"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L24"
           target="_blank"
         >
           Interface
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L51"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L51"
           target="_blank"
         >
           Implementation
@@ -80,7 +80,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L27"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L27"
           target="_blank"
         >
           Interface
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L56"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L56"
           target="_blank"
         >
           Implementation
@@ -102,7 +102,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L30"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L30"
           target="_blank"
         >
           Interface
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L61"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L61"
           target="_blank"
         >
           Implementation
@@ -126,7 +126,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L33"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L33"
           target="_blank"
         >
           Interface
@@ -134,7 +134,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L66"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L66"
           target="_blank"
         >
           Implementation
@@ -148,7 +148,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L36"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L36"
           target="_blank"
         >
           Interface
@@ -156,7 +156,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L71"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L71"
           target="_blank"
         >
           Implementation
@@ -170,7 +170,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L39"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L39"
           target="_blank"
         >
           Interface
@@ -178,7 +178,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L76"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L79"
           target="_blank"
         >
           Implementation
@@ -192,7 +192,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L42"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L42"
           target="_blank"
         >
           Interface
@@ -200,7 +200,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L81"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L84"
           target="_blank"
         >
           Implementation
@@ -214,7 +214,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L45"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L45"
           target="_blank"
         >
           Interface
@@ -222,7 +222,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L86"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L89"
           target="_blank"
         >
           Implementation
@@ -236,7 +236,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L48"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L48"
           target="_blank"
         >
           Interface
@@ -244,7 +244,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L91"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L94"
           target="_blank"
         >
           Implementation
@@ -258,7 +258,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L51"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L51"
           target="_blank"
         >
           Interface
@@ -266,7 +266,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L96"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L99"
           target="_blank"
         >
           Implementation
@@ -280,7 +280,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L54"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L54"
           target="_blank"
         >
           Interface
@@ -288,7 +288,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L101"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L104"
           target="_blank"
         >
           Implementation
@@ -302,7 +302,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L57"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L57"
           target="_blank"
         >
           Interface
@@ -310,7 +310,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L106"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L109"
           target="_blank"
         >
           Implementation
@@ -324,7 +324,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L60"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L60"
           target="_blank"
         >
           Interface
@@ -332,7 +332,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L111"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L114"
           target="_blank"
         >
           Implementation
@@ -346,7 +346,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L63"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L63"
           target="_blank"
         >
           Interface
@@ -354,7 +354,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L116"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L119"
           target="_blank"
         >
           Implementation
@@ -368,7 +368,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L66"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L66"
           target="_blank"
         >
           Interface
@@ -376,7 +376,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L120"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L123"
           target="_blank"
         >
           Implementation
@@ -390,7 +390,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L69"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L69"
           target="_blank"
         >
           Interface
@@ -398,7 +398,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L124"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L127"
           target="_blank"
         >
           Implementation
@@ -412,7 +412,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L72"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L72"
           target="_blank"
         >
           Interface
@@ -420,7 +420,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L128"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L131"
           target="_blank"
         >
           Implementation
@@ -434,7 +434,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L75"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L75"
           target="_blank"
         >
           Interface
@@ -442,7 +442,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L132"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L135"
           target="_blank"
         >
           Implementation
@@ -456,7 +456,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L78"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L78"
           target="_blank"
         >
           Interface
@@ -464,7 +464,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L136"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L139"
           target="_blank"
         >
           Implementation
@@ -478,7 +478,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L81"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L81"
           target="_blank"
         >
           Interface
@@ -486,7 +486,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L140"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L143"
           target="_blank"
         >
           Implementation
@@ -500,7 +500,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L87"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L87"
           target="_blank"
         >
           Interface
@@ -508,7 +508,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L148"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L151"
           target="_blank"
         >
           Implementation
@@ -525,7 +525,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L90"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L90"
           target="_blank"
         >
           Interface
@@ -533,7 +533,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L144"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L147"
           target="_blank"
         >
           Implementation
@@ -547,7 +547,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L93"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L93"
           target="_blank"
         >
           Interface
@@ -555,7 +555,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L152"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L155"
           target="_blank"
         >
           Implementation
@@ -569,7 +569,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L97"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L97"
           target="_blank"
         >
           Interface
@@ -577,7 +577,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L173"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L176"
           target="_blank"
         >
           Implementation
@@ -591,7 +591,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L100"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L100"
           target="_blank"
         >
           Interface
@@ -599,7 +599,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L187"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L190"
           target="_blank"
         >
           Implementation
@@ -613,7 +613,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L103"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L103"
           target="_blank"
         >
           Interface
@@ -621,7 +621,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L197"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L200"
           target="_blank"
         >
           Implementation
@@ -635,7 +635,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L106"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L106"
           target="_blank"
         >
           Interface
@@ -643,7 +643,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L207"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L210"
           target="_blank"
         >
           Implementation
@@ -657,7 +657,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L109"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L109"
           target="_blank"
         >
           Interface
@@ -665,7 +665,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L217"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L220"
           target="_blank"
         >
           Implementation
@@ -679,7 +679,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L114"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L114"
           target="_blank"
         >
           Interface
@@ -687,7 +687,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L227"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L230"
           target="_blank"
         >
           Implementation
@@ -701,7 +701,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L118"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L118"
           target="_blank"
         >
           Interface
@@ -709,7 +709,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L238"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L241"
           target="_blank"
         >
           Implementation
@@ -723,7 +723,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L121"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L121"
           target="_blank"
         >
           Interface
@@ -731,7 +731,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L248"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L251"
           target="_blank"
         >
           Implementation
@@ -745,7 +745,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L124"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L124"
           target="_blank"
         >
           Interface
@@ -753,7 +753,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L258"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L261"
           target="_blank"
         >
           Implementation
@@ -767,7 +767,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L127"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L127"
           target="_blank"
         >
           Interface
@@ -775,7 +775,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L268"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L271"
           target="_blank"
         >
           Implementation
@@ -789,7 +789,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L130"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L130"
           target="_blank"
         >
           Interface
@@ -797,7 +797,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L278"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L281"
           target="_blank"
         >
           Implementation
@@ -811,7 +811,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L133"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L133"
           target="_blank"
         >
           Interface
@@ -819,7 +819,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L283"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L286"
           target="_blank"
         >
           Implementation
@@ -833,7 +833,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L136"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L136"
           target="_blank"
         >
           Interface
@@ -841,7 +841,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L295"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L298"
           target="_blank"
         >
           Implementation
@@ -867,7 +867,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwner.sol#L139"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwner.sol#L139"
           target="_blank"
         >
           Interface
@@ -875,7 +875,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwner.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwner.go#L0"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwnerPublic.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwnerPublic.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwnerPublic.go#L34"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwnerPublic.go#L34"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwnerPublic.go#L25"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwnerPublic.go#L25"
           target="_blank"
         >
           Implementation
@@ -68,7 +68,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwnerPublic.go#L20"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwnerPublic.go#L20"
           target="_blank"
         >
           Implementation
@@ -90,7 +90,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwnerPublic.go#L39"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwnerPublic.go#L39"
           target="_blank"
         >
           Implementation
@@ -112,7 +112,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwnerPublic.go#L44"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwnerPublic.go#L44"
           target="_blank"
         >
           Implementation
@@ -134,7 +134,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwnerPublic.go#L52"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwnerPublic.go#L52"
           target="_blank"
         >
           Implementation
@@ -159,7 +159,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwnerPublic.go#L58"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwnerPublic.go#L58"
           target="_blank"
         >
           Implementation
@@ -193,7 +193,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwnerPublic.go#L30"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbOwnerPublic.go#L30"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwnerPublic.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwnerPublic.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwnerPublic.sol#L11"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwnerPublic.sol#L11"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwnerPublic.go#L34"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwnerPublic.go#L34"
           target="_blank"
         >
           Implementation
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwnerPublic.sol#L18"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwnerPublic.sol#L18"
           target="_blank"
         >
           Interface
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwnerPublic.go#L25"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwnerPublic.go#L25"
           target="_blank"
         >
           Implementation
@@ -60,7 +60,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwnerPublic.sol#L21"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwnerPublic.sol#L21"
           target="_blank"
         >
           Interface
@@ -68,7 +68,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwnerPublic.go#L20"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwnerPublic.go#L20"
           target="_blank"
         >
           Implementation
@@ -82,7 +82,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwnerPublic.sol#L24"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwnerPublic.sol#L24"
           target="_blank"
         >
           Interface
@@ -90,7 +90,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwnerPublic.go#L39"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwnerPublic.go#L39"
           target="_blank"
         >
           Implementation
@@ -104,7 +104,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwnerPublic.sol#L27"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwnerPublic.sol#L27"
           target="_blank"
         >
           Interface
@@ -112,7 +112,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwnerPublic.go#L44"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwnerPublic.go#L44"
           target="_blank"
         >
           Implementation
@@ -126,7 +126,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwnerPublic.sol#L30"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwnerPublic.sol#L30"
           target="_blank"
         >
           Interface
@@ -134,7 +134,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwnerPublic.go#L52"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwnerPublic.go#L52"
           target="_blank"
         >
           Implementation
@@ -151,7 +151,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwnerPublic.sol#L35"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwnerPublic.sol#L35"
           target="_blank"
         >
           Interface
@@ -159,7 +159,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwnerPublic.go#L58"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwnerPublic.go#L58"
           target="_blank"
         >
           Implementation
@@ -185,7 +185,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbOwnerPublic.sol#L40"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbOwnerPublic.sol#L40"
           target="_blank"
         >
           Interface
@@ -193,7 +193,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbOwnerPublic.go#L30"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbOwnerPublic.go#L30"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbRetryableTx.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbRetryableTx.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L49"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbRetryableTx.go#L49"
           target="_blank"
         >
           Implementation
@@ -47,7 +47,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L134"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbRetryableTx.go#L134"
           target="_blank"
         >
           Implementation
@@ -69,7 +69,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L139"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbRetryableTx.go#L139"
           target="_blank"
         >
           Implementation
@@ -91,7 +91,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L156"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbRetryableTx.go#L156"
           target="_blank"
         >
           Implementation
@@ -113,7 +113,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L185"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbRetryableTx.go#L185"
           target="_blank"
         >
           Implementation
@@ -135,7 +135,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L198"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbRetryableTx.go#L198"
           target="_blank"
         >
           Implementation
@@ -157,7 +157,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L226"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbRetryableTx.go#L226"
           target="_blank"
         >
           Implementation
@@ -179,7 +179,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L233"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbRetryableTx.go#L233"
           target="_blank"
         >
           Implementation
@@ -216,7 +216,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbRetryableTx.go#L0"
           target="_blank"
         >
           Implementation
@@ -238,7 +238,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L180"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbRetryableTx.go#L180"
           target="_blank"
         >
           Implementation
@@ -260,7 +260,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L116"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbRetryableTx.go#L116"
           target="_blank"
         >
           Implementation
@@ -282,7 +282,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L223"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbRetryableTx.go#L223"
           target="_blank"
         >
           Implementation
@@ -304,7 +304,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbRetryableTx.go#L0"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbRetryableTx.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbRetryableTx.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbRetryableTx.sol#L18"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbRetryableTx.sol#L18"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbRetryableTx.go#L49"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L49"
           target="_blank"
         >
           Implementation
@@ -39,7 +39,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbRetryableTx.sol#L24"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbRetryableTx.sol#L24"
           target="_blank"
         >
           Interface
@@ -47,7 +47,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbRetryableTx.go#L134"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L134"
           target="_blank"
         >
           Implementation
@@ -61,7 +61,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbRetryableTx.sol#L31"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbRetryableTx.sol#L31"
           target="_blank"
         >
           Interface
@@ -69,7 +69,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbRetryableTx.go#L139"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L139"
           target="_blank"
         >
           Implementation
@@ -83,7 +83,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbRetryableTx.sol#L41"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbRetryableTx.sol#L41"
           target="_blank"
         >
           Interface
@@ -91,7 +91,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbRetryableTx.go#L156"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L156"
           target="_blank"
         >
           Implementation
@@ -105,7 +105,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbRetryableTx.sol#L49"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbRetryableTx.sol#L49"
           target="_blank"
         >
           Interface
@@ -113,7 +113,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbRetryableTx.go#L184"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L185"
           target="_blank"
         >
           Implementation
@@ -127,7 +127,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbRetryableTx.sol#L56"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbRetryableTx.sol#L56"
           target="_blank"
         >
           Interface
@@ -135,7 +135,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbRetryableTx.go#L197"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L198"
           target="_blank"
         >
           Implementation
@@ -149,7 +149,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbRetryableTx.sol#L63"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbRetryableTx.sol#L63"
           target="_blank"
         >
           Interface
@@ -157,7 +157,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbRetryableTx.go#L225"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L226"
           target="_blank"
         >
           Implementation
@@ -171,7 +171,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbRetryableTx.sol#L69"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbRetryableTx.sol#L69"
           target="_blank"
         >
           Interface
@@ -179,7 +179,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbRetryableTx.go#L232"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L233"
           target="_blank"
         >
           Implementation
@@ -208,7 +208,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbRetryableTx.sol#L83"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbRetryableTx.sol#L83"
           target="_blank"
         >
           Interface
@@ -216,7 +216,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbRetryableTx.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L0"
           target="_blank"
         >
           Implementation
@@ -230,7 +230,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbRetryableTx.sol#L84"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbRetryableTx.sol#L84"
           target="_blank"
         >
           Interface
@@ -238,7 +238,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbRetryableTx.go#L179"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L180"
           target="_blank"
         >
           Implementation
@@ -252,7 +252,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbRetryableTx.sol#L85"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbRetryableTx.sol#L85"
           target="_blank"
         >
           Interface
@@ -260,7 +260,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbRetryableTx.go#L116"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L116"
           target="_blank"
         >
           Implementation
@@ -274,7 +274,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbRetryableTx.sol#L94"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbRetryableTx.sol#L94"
           target="_blank"
         >
           Interface
@@ -282,7 +282,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbRetryableTx.go#L222"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L223"
           target="_blank"
         >
           Implementation
@@ -296,7 +296,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbRetryableTx.sol#L97"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbRetryableTx.sol#L97"
           target="_blank"
         >
           Interface
@@ -304,7 +304,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbRetryableTx.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbRetryableTx.go#L0"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbStatistics.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbStatistics.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbStatistics.go#L18"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbStatistics.go#L18"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbStatistics.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbStatistics.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbStatistics.sol#L18"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbStatistics.sol#L18"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbStatistics.go#L18"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbStatistics.go#L18"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbSys.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbSys.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L32"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbSys.go#L32"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L37"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbSys.go#L37"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L58"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbSys.go#L58"
           target="_blank"
         >
           Implementation
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L63"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbSys.go#L63"
           target="_blank"
         >
           Implementation
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L69"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbSys.go#L69"
           target="_blank"
         >
           Implementation
@@ -132,7 +132,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L74"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbSys.go#L74"
           target="_blank"
         >
           Implementation
@@ -154,7 +154,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L79"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbSys.go#L79"
           target="_blank"
         >
           Implementation
@@ -176,7 +176,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L84"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbSys.go#L84"
           target="_blank"
         >
           Implementation
@@ -198,7 +198,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L94"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbSys.go#L94"
           target="_blank"
         >
           Implementation
@@ -222,7 +222,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L206"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbSys.go#L206"
           target="_blank"
         >
           Implementation
@@ -244,7 +244,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L110"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbSys.go#L110"
           target="_blank"
         >
           Implementation
@@ -266,7 +266,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L190"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbSys.go#L190"
           target="_blank"
         >
           Implementation
@@ -303,7 +303,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L169"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbSys.go#L169"
           target="_blank"
         >
           Implementation
@@ -325,7 +325,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbSys.go#L0"
           target="_blank"
         >
           Implementation
@@ -349,7 +349,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L153"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbSys.go#L153"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbSys.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbSys.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbSys.sol#L17"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbSys.sol#L17"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbSys.go#L32"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L32"
           target="_blank"
         >
           Implementation
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbSys.sol#L23"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbSys.sol#L23"
           target="_blank"
         >
           Interface
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbSys.go#L37"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L37"
           target="_blank"
         >
           Implementation
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbSys.sol#L29"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbSys.sol#L29"
           target="_blank"
         >
           Interface
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbSys.go#L58"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L58"
           target="_blank"
         >
           Implementation
@@ -80,7 +80,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbSys.sol#L35"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbSys.sol#L35"
           target="_blank"
         >
           Interface
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbSys.go#L63"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L63"
           target="_blank"
         >
           Implementation
@@ -102,7 +102,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbSys.sol#L41"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbSys.sol#L41"
           target="_blank"
         >
           Interface
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbSys.go#L69"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L69"
           target="_blank"
         >
           Implementation
@@ -124,7 +124,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbSys.sol#L48"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbSys.sol#L48"
           target="_blank"
         >
           Interface
@@ -132,7 +132,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbSys.go#L74"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L74"
           target="_blank"
         >
           Implementation
@@ -146,7 +146,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbSys.sol#L56"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbSys.sol#L56"
           target="_blank"
         >
           Interface
@@ -154,7 +154,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbSys.go#L79"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L79"
           target="_blank"
         >
           Implementation
@@ -168,7 +168,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbSys.sol#L65"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbSys.sol#L65"
           target="_blank"
         >
           Interface
@@ -176,7 +176,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbSys.go#L84"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L84"
           target="_blank"
         >
           Implementation
@@ -190,7 +190,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbSys.sol#L71"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbSys.sol#L71"
           target="_blank"
         >
           Interface
@@ -198,7 +198,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbSys.go#L94"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L94"
           target="_blank"
         >
           Implementation
@@ -214,7 +214,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbSys.sol#L79"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbSys.sol#L79"
           target="_blank"
         >
           Interface
@@ -222,7 +222,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbSys.go#L206"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L206"
           target="_blank"
         >
           Implementation
@@ -236,7 +236,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbSys.sol#L89"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbSys.sol#L89"
           target="_blank"
         >
           Interface
@@ -244,7 +244,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbSys.go#L110"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L110"
           target="_blank"
         >
           Implementation
@@ -258,7 +258,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbSys.sol#L100"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbSys.sol#L100"
           target="_blank"
         >
           Interface
@@ -266,7 +266,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbSys.go#L190"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L190"
           target="_blank"
         >
           Implementation
@@ -295,7 +295,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbSys.sol#L113"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbSys.sol#L113"
           target="_blank"
         >
           Interface
@@ -303,7 +303,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbSys.go#L169"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L169"
           target="_blank"
         >
           Implementation
@@ -317,7 +317,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbSys.sol#L126"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbSys.sol#L126"
           target="_blank"
         >
           Interface
@@ -325,7 +325,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbSys.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L0"
           target="_blank"
         >
           Implementation
@@ -341,7 +341,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbSys.sol#L145"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbSys.sol#L145"
           target="_blank"
         >
           Interface
@@ -349,7 +349,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbSys.go#L153"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbSys.go#L153"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbWasm.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbWasm.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L33"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L33"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L93"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L93"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L170"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L170"
           target="_blank"
         >
           Implementation
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L57"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L57"
           target="_blank"
         >
           Implementation
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L179"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L179"
           target="_blank"
         >
           Implementation
@@ -132,7 +132,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L188"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L188"
           target="_blank"
         >
           Implementation
@@ -154,7 +154,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L197"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L197"
           target="_blank"
         >
           Implementation
@@ -176,7 +176,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L206"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L206"
           target="_blank"
         >
           Implementation
@@ -198,7 +198,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L215"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L215"
           target="_blank"
         >
           Implementation
@@ -220,7 +220,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L99"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L99"
           target="_blank"
         >
           Implementation
@@ -242,7 +242,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L105"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L105"
           target="_blank"
         >
           Implementation
@@ -264,7 +264,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L111"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L111"
           target="_blank"
         >
           Implementation
@@ -286,7 +286,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L117"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L117"
           target="_blank"
         >
           Implementation
@@ -308,7 +308,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L123"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L123"
           target="_blank"
         >
           Implementation
@@ -330,7 +330,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L129"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L129"
           target="_blank"
         >
           Implementation
@@ -352,7 +352,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L135"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L135"
           target="_blank"
         >
           Implementation
@@ -374,7 +374,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L146"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L146"
           target="_blank"
         >
           Implementation
@@ -396,7 +396,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L152"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L152"
           target="_blank"
         >
           Implementation
@@ -418,7 +418,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L158"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L158"
           target="_blank"
         >
           Implementation
@@ -440,7 +440,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L164"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L164"
           target="_blank"
         >
           Implementation
@@ -474,7 +474,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L53"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L53"
           target="_blank"
         >
           Implementation
@@ -496,7 +496,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L69"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasm.go#L69"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbWasm.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbWasm.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L16"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L16"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L31"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L33"
           target="_blank"
         >
           Implementation
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L23"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L23"
           target="_blank"
         >
           Interface
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L90"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L93"
           target="_blank"
         >
           Implementation
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L27"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L27"
           target="_blank"
         >
           Interface
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L164"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L170"
           target="_blank"
         >
           Implementation
@@ -80,7 +80,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L31"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L31"
           target="_blank"
         >
           Interface
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L54"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L57"
           target="_blank"
         >
           Implementation
@@ -102,7 +102,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L36"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L36"
           target="_blank"
         >
           Interface
@@ -110,7 +110,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L173"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L179"
           target="_blank"
         >
           Implementation
@@ -124,7 +124,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L40"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L40"
           target="_blank"
         >
           Interface
@@ -132,7 +132,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L182"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L188"
           target="_blank"
         >
           Implementation
@@ -146,7 +146,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L45"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L45"
           target="_blank"
         >
           Interface
@@ -154,7 +154,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L191"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L197"
           target="_blank"
         >
           Implementation
@@ -168,7 +168,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L52"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L52"
           target="_blank"
         >
           Interface
@@ -176,7 +176,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L200"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L206"
           target="_blank"
         >
           Implementation
@@ -190,7 +190,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L56"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L56"
           target="_blank"
         >
           Interface
@@ -198,7 +198,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L209"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L215"
           target="_blank"
         >
           Implementation
@@ -212,7 +212,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L60"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L60"
           target="_blank"
         >
           Interface
@@ -220,7 +220,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L96"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L99"
           target="_blank"
         >
           Implementation
@@ -234,7 +234,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L64"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L64"
           target="_blank"
         >
           Interface
@@ -242,7 +242,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L102"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L105"
           target="_blank"
         >
           Implementation
@@ -256,7 +256,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L68"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L68"
           target="_blank"
         >
           Interface
@@ -264,7 +264,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L108"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L111"
           target="_blank"
         >
           Implementation
@@ -278,7 +278,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L72"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L72"
           target="_blank"
         >
           Interface
@@ -286,7 +286,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L114"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L117"
           target="_blank"
         >
           Implementation
@@ -300,7 +300,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L76"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L76"
           target="_blank"
         >
           Interface
@@ -308,7 +308,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L120"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L123"
           target="_blank"
         >
           Implementation
@@ -322,7 +322,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L80"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L80"
           target="_blank"
         >
           Interface
@@ -330,7 +330,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L126"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L129"
           target="_blank"
         >
           Implementation
@@ -344,7 +344,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L85"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L85"
           target="_blank"
         >
           Interface
@@ -352,7 +352,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L132"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L135"
           target="_blank"
         >
           Implementation
@@ -366,7 +366,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L89"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L89"
           target="_blank"
         >
           Interface
@@ -374,7 +374,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L140"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L146"
           target="_blank"
         >
           Implementation
@@ -388,7 +388,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L93"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L93"
           target="_blank"
         >
           Interface
@@ -396,7 +396,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L146"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L152"
           target="_blank"
         >
           Implementation
@@ -410,7 +410,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L97"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L97"
           target="_blank"
         >
           Interface
@@ -418,7 +418,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L152"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L158"
           target="_blank"
         >
           Implementation
@@ -432,7 +432,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L101"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L101"
           target="_blank"
         >
           Interface
@@ -440,7 +440,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L158"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L164"
           target="_blank"
         >
           Implementation
@@ -466,7 +466,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L103"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L103"
           target="_blank"
         >
           Interface
@@ -474,7 +474,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L50"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L53"
           target="_blank"
         >
           Implementation
@@ -488,7 +488,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasm.sol#L110"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasm.sol#L110"
           target="_blank"
         >
           Interface
@@ -496,7 +496,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasm.go#L66"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasm.go#L69"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbWasmCache.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbWasmCache.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasmCache.go#L16"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasmCache.go#L16"
           target="_blank"
         >
           Implementation
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasmCache.go#L21"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasmCache.go#L21"
           target="_blank"
         >
           Implementation
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasmCache.go#L26"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasmCache.go#L26"
           target="_blank"
         >
           Implementation
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasmCache.go#L31"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasmCache.go#L31"
           target="_blank"
         >
           Implementation
@@ -113,7 +113,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasmCache.go#L40"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasmCache.go#L40"
           target="_blank"
         >
           Implementation
@@ -137,7 +137,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasmCache.go#L45"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasmCache.go#L45"
           target="_blank"
         >
           Implementation
@@ -171,7 +171,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasmCache.go#L62"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbWasmCache.go#L62"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbWasmCache.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbWasmCache.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasmCache.sol#L13"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasmCache.sol#L13"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasmCache.go#L16"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasmCache.go#L16"
           target="_blank"
         >
           Implementation
@@ -36,7 +36,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasmCache.sol#L17"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasmCache.sol#L17"
           target="_blank"
         >
           Interface
@@ -44,7 +44,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasmCache.go#L21"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasmCache.go#L21"
           target="_blank"
         >
           Implementation
@@ -58,7 +58,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasmCache.sol#L20"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasmCache.sol#L20"
           target="_blank"
         >
           Interface
@@ -66,7 +66,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasmCache.go#L26"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasmCache.go#L26"
           target="_blank"
         >
           Implementation
@@ -80,7 +80,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasmCache.sol#L26"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasmCache.sol#L26"
           target="_blank"
         >
           Interface
@@ -88,7 +88,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasmCache.go#L31"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasmCache.go#L31"
           target="_blank"
         >
           Implementation
@@ -105,7 +105,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasmCache.sol#L30"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasmCache.sol#L30"
           target="_blank"
         >
           Interface
@@ -113,7 +113,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasmCache.go#L40"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasmCache.go#L40"
           target="_blank"
         >
           Implementation
@@ -129,7 +129,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasmCache.sol#L33"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasmCache.sol#L33"
           target="_blank"
         >
           Interface
@@ -137,7 +137,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasmCache.go#L45"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasmCache.go#L45"
           target="_blank"
         >
           Implementation
@@ -163,7 +163,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbWasmCache.sol#L35"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbWasmCache.sol#L35"
           target="_blank"
         >
           Interface
@@ -171,7 +171,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbWasmCache.go#L62"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbWasmCache.go#L62"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbosTest.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbosTest.md
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbosTest.go#L16"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/precompiles/ArbosTest.go#L16"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbosTest.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbosTest.md
@@ -14,7 +14,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/precompiles/ArbosTest.sol#L13"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/precompiles/ArbosTest.sol#L13"
           target="_blank"
         >
           Interface
@@ -22,7 +22,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/precompiles/ArbosTest.go#L16"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/precompiles/ArbosTest.go#L16"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_NodeInterface.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_NodeInterface.md
@@ -17,7 +17,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/node-interface/NodeInterface.sol#L25"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/node-interface/NodeInterface.sol#L25"
           target="_blank"
         >
           Interface
@@ -25,7 +25,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/nodeInterface/NodeInterface.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/nodeInterface/NodeInterface.go#L0"
           target="_blank"
         >
           Implementation
@@ -39,7 +39,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/node-interface/NodeInterface.sol#L44"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/node-interface/NodeInterface.sol#L44"
           target="_blank"
         >
           Interface
@@ -47,7 +47,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/nodeInterface/NodeInterface.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/nodeInterface/NodeInterface.go#L0"
           target="_blank"
         >
           Implementation
@@ -61,7 +61,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/node-interface/NodeInterface.sol#L60"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/node-interface/NodeInterface.sol#L60"
           target="_blank"
         >
           Interface
@@ -69,7 +69,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/nodeInterface/NodeInterface.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/nodeInterface/NodeInterface.go#L0"
           target="_blank"
         >
           Implementation
@@ -83,7 +83,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/node-interface/NodeInterface.sol#L71"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/node-interface/NodeInterface.sol#L71"
           target="_blank"
         >
           Interface
@@ -91,7 +91,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/nodeInterface/NodeInterface.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/nodeInterface/NodeInterface.go#L0"
           target="_blank"
         >
           Implementation
@@ -107,7 +107,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/node-interface/NodeInterface.sol#L84"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/node-interface/NodeInterface.sol#L84"
           target="_blank"
         >
           Interface
@@ -115,7 +115,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/nodeInterface/NodeInterface.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/nodeInterface/NodeInterface.go#L0"
           target="_blank"
         >
           Implementation
@@ -129,7 +129,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/node-interface/NodeInterface.sol#L112"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/node-interface/NodeInterface.sol#L112"
           target="_blank"
         >
           Interface
@@ -137,7 +137,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/nodeInterface/NodeInterface.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/nodeInterface/NodeInterface.go#L0"
           target="_blank"
         >
           Implementation
@@ -151,7 +151,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/node-interface/NodeInterface.sol#L139"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/node-interface/NodeInterface.sol#L139"
           target="_blank"
         >
           Interface
@@ -159,7 +159,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/nodeInterface/NodeInterface.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/nodeInterface/NodeInterface.go#L0"
           target="_blank"
         >
           Implementation
@@ -173,7 +173,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/node-interface/NodeInterface.sol#L157"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/node-interface/NodeInterface.sol#L157"
           target="_blank"
         >
           Interface
@@ -181,7 +181,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/nodeInterface/NodeInterface.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/nodeInterface/NodeInterface.go#L0"
           target="_blank"
         >
           Implementation
@@ -195,7 +195,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/node-interface/NodeInterface.sol#L161"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/node-interface/NodeInterface.sol#L161"
           target="_blank"
         >
           Interface
@@ -203,7 +203,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/nodeInterface/NodeInterface.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/nodeInterface/NodeInterface.go#L0"
           target="_blank"
         >
           Implementation
@@ -217,7 +217,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro-contracts/blob/61204dd455966cb678192427a07aa9795ff91c14/src/node-interface/NodeInterface.sol#L170"
+          href="https://github.com/OffchainLabs/nitro-contracts/blob/7396313311ab17cb30e2eef27cccf96f0a9e8f7f/src/node-interface/NodeInterface.sol#L170"
           target="_blank"
         >
           Interface
@@ -225,7 +225,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.1.0/nodeInterface/NodeInterface.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/nodeInterface/NodeInterface.go#L0"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_NodeInterface.md
+++ b/arbitrum-docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_NodeInterface.md
@@ -25,7 +25,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/nodeInterface/NodeInterface.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/nodeInterface/NodeInterface.go#L0"
           target="_blank"
         >
           Implementation
@@ -47,7 +47,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/nodeInterface/NodeInterface.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/nodeInterface/NodeInterface.go#L0"
           target="_blank"
         >
           Implementation
@@ -69,7 +69,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/nodeInterface/NodeInterface.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/nodeInterface/NodeInterface.go#L0"
           target="_blank"
         >
           Implementation
@@ -91,7 +91,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/nodeInterface/NodeInterface.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/nodeInterface/NodeInterface.go#L0"
           target="_blank"
         >
           Implementation
@@ -115,7 +115,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/nodeInterface/NodeInterface.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/nodeInterface/NodeInterface.go#L0"
           target="_blank"
         >
           Implementation
@@ -137,7 +137,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/nodeInterface/NodeInterface.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/nodeInterface/NodeInterface.go#L0"
           target="_blank"
         >
           Implementation
@@ -159,7 +159,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/nodeInterface/NodeInterface.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/nodeInterface/NodeInterface.go#L0"
           target="_blank"
         >
           Implementation
@@ -181,7 +181,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/nodeInterface/NodeInterface.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/nodeInterface/NodeInterface.go#L0"
           target="_blank"
         >
           Implementation
@@ -203,7 +203,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/nodeInterface/NodeInterface.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/nodeInterface/NodeInterface.go#L0"
           target="_blank"
         >
           Implementation
@@ -225,7 +225,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.2.0/nodeInterface/NodeInterface.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.2.1/nodeInterface/NodeInterface.go#L0"
           target="_blank"
         >
           Implementation

--- a/arbitrum-docs/run-arbitrum-node/more-types/02-run-validator-node.md
+++ b/arbitrum-docs/run-arbitrum-node/more-types/02-run-validator-node.md
@@ -44,7 +44,7 @@ Here we describe different strategies that validators follow and provide instruc
 - All other validators require a funded wallet to immediately post stake, as well as additional funds that will be spent at regular intervals
 - Here is an example of how to tell Nitro to create validator wallet for Arbitrum One and exit:
   ```shell
-  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum @latestNitroNodeImage@ --parent-chain.connection.url=https://l1-mainnet-node:8545 --chain.id=42161 --node.staker.enable --node.staker.parent-chain-wallet.only-create-key --node.staker.parent-chain-wallet.password="SOME SECURE PASSWORD"
+  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum @latestNitroNodeImageForValidators@ --parent-chain.connection.url=https://l1-mainnet-node:8545 --chain.id=42161 --node.staker.enable --node.staker.parent-chain-wallet.only-create-key --node.staker.parent-chain-wallet.password="SOME SECURE PASSWORD"
   ```
 - Wallet file will be created under the mounted directory inside the `arb1/wallet/` directory for Arb1, or `nova/wallet/` directory for Nova. Be sure to backup the wallet, it will be the only way to withdraw stake when desired
 
@@ -55,7 +55,7 @@ Here we describe different strategies that validators follow and provide instruc
 - If a defensive validator detects a deviation, it will log `bringing defensive validator online because of incorrect assertion`, and wait for funds to be added to wallet so stake can be posted and a dispute created
 - Here is an example of how to run an allowlisted defensive validator for Arbitrum One:
   ```shell
-  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum @latestNitroNodeImage@ --parent-chain.connection.url=https://l1-mainnet-node:8545 --chain.id=42161 --node.staker.enable --node.staker.strategy=Defensive --node.staker.parent-chain-wallet.password="SOME SECURE PASSWORD"
+  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum @latestNitroNodeImageForValidators@ --parent-chain.connection.url=https://l1-mainnet-node:8545 --chain.id=42161 --node.staker.enable --node.staker.strategy=Defensive --node.staker.parent-chain-wallet.password="SOME SECURE PASSWORD"
   ```
 - For Orbit chains, you need to set the `--chain.info-json=<Orbit Chain's chain info>` flag instead of `--chain.id=<chain id>`
 - To verify validator is working, this log line shows the wallet is setup correctly:

--- a/arbitrum-docs/run-arbitrum-node/more-types/02-run-validator-node.md
+++ b/arbitrum-docs/run-arbitrum-node/more-types/02-run-validator-node.md
@@ -44,7 +44,7 @@ Here we describe different strategies that validators follow and provide instruc
 - All other validators require a funded wallet to immediately post stake, as well as additional funds that will be spent at regular intervals
 - Here is an example of how to tell Nitro to create validator wallet for Arbitrum One and exit:
   ```shell
-  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum @latestNitroNodeImageForValidators@ --parent-chain.connection.url=https://l1-mainnet-node:8545 --chain.id=42161 --node.staker.enable --node.staker.parent-chain-wallet.only-create-key --node.staker.parent-chain-wallet.password="SOME SECURE PASSWORD"
+  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum @latestNitroNodeImage@ --parent-chain.connection.url=https://l1-mainnet-node:8545 --chain.id=42161 --node.staker.enable --node.staker.parent-chain-wallet.only-create-key --node.staker.parent-chain-wallet.password="SOME SECURE PASSWORD"
   ```
 - Wallet file will be created under the mounted directory inside the `arb1/wallet/` directory for Arb1, or `nova/wallet/` directory for Nova. Be sure to backup the wallet, it will be the only way to withdraw stake when desired
 
@@ -55,7 +55,7 @@ Here we describe different strategies that validators follow and provide instruc
 - If a defensive validator detects a deviation, it will log `bringing defensive validator online because of incorrect assertion`, and wait for funds to be added to wallet so stake can be posted and a dispute created
 - Here is an example of how to run an allowlisted defensive validator for Arbitrum One:
   ```shell
-  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum @latestNitroNodeImageForValidators@ --parent-chain.connection.url=https://l1-mainnet-node:8545 --chain.id=42161 --node.staker.enable --node.staker.strategy=Defensive --node.staker.parent-chain-wallet.password="SOME SECURE PASSWORD"
+  docker run --rm -it  -v /some/local/dir/arbitrum:/home/user/.arbitrum @latestNitroNodeImage@ --parent-chain.connection.url=https://l1-mainnet-node:8545 --chain.id=42161 --node.staker.enable --node.staker.strategy=Defensive --node.staker.parent-chain-wallet.password="SOME SECURE PASSWORD"
   ```
 - For Orbit chains, you need to set the `--chain.info-json=<Orbit Chain's chain info>` flag instead of `--chain.id=<chain id>`
 - To verify validator is working, this log line shows the wallet is setup correctly:

--- a/website/.prettierignore
+++ b/website/.prettierignore
@@ -1,9 +1,9 @@
 # Generated files from notion tables
-../arbitrum-docs/partials/_glossary-partial.md
-../arbitrum-docs/partials/_troubleshooting-bridging-partial.md
-../arbitrum-docs/partials/_troubleshooting-building-partial.md
-../arbitrum-docs/partials/_troubleshooting-nodes-partial.md
-../arbitrum-docs/partials/_troubleshooting-orbit-partial.md
-../arbitrum-docs/partials/_troubleshooting-stylus-partial.md
-../arbitrum-docs/partials/_troubleshooting-users-partial.md
+../arbitrum-docs/partials/_glossary-partial.mdx
+../arbitrum-docs/partials/_troubleshooting-bridging-partial.mdx
+../arbitrum-docs/partials/_troubleshooting-building-partial.mdx
+../arbitrum-docs/partials/_troubleshooting-nodes-partial.mdx
+../arbitrum-docs/partials/_troubleshooting-orbit-partial.mdx
+../arbitrum-docs/partials/_troubleshooting-stylus-partial.mdx
+../arbitrum-docs/partials/_troubleshooting-users-partial.mdx
 ../arbitrum-docs/CODEOWNERS.md

--- a/website/src/resources/globalVars.js
+++ b/website/src/resources/globalVars.js
@@ -14,8 +14,7 @@ const sepoliaForceIncludePeriodBlocks = 5760;
 
 const globalVars = {
   // Node docker images
-  latestNitroNodeImage: 'offchainlabs/nitro-node:v3.2.0-f847be0',
-  latestNitroNodeImageForValidators: 'offchainlabs/nitro-node:v3.2.1-d81324d',
+  latestNitroNodeImage: 'offchainlabs/nitro-node:v3.2.1-d81324d',
   latestClassicNodeImage: 'offchainlabs/arb-node:v1.4.5-e97c1a4',
 
   // Node snapshots (taken around April 20th, 2013)

--- a/website/src/resources/globalVars.js
+++ b/website/src/resources/globalVars.js
@@ -31,7 +31,7 @@ const globalVars = {
 
   // Nitro Github references
   nitroRepositorySlug: 'nitro',
-  nitroVersionTag: 'v3.2.0',
+  nitroVersionTag: 'v3.2.1',
   nitroPathToPrecompiles: 'precompiles',
 
   nitroContractsRepositorySlug: 'nitro-contracts',

--- a/website/src/resources/globalVars.js
+++ b/website/src/resources/globalVars.js
@@ -15,6 +15,7 @@ const sepoliaForceIncludePeriodBlocks = 5760;
 const globalVars = {
   // Node docker images
   latestNitroNodeImage: 'offchainlabs/nitro-node:v3.2.0-f847be0',
+  latestNitroNodeImageForValidators: 'offchainlabs/nitro-node:v3.2.1-d81324d',
   latestClassicNodeImage: 'offchainlabs/arb-node:v1.4.5-e97c1a4',
 
   // Node snapshots (taken around April 20th, 2013)

--- a/website/src/resources/globalVars.js
+++ b/website/src/resources/globalVars.js
@@ -14,7 +14,7 @@ const sepoliaForceIncludePeriodBlocks = 5760;
 
 const globalVars = {
   // Node docker images
-  latestNitroNodeImage: 'offchainlabs/nitro-node:v3.1.2-309340a',
+  latestNitroNodeImage: 'offchainlabs/nitro-node:v3.2.0-f847be0',
   latestClassicNodeImage: 'offchainlabs/arb-node:v1.4.5-e97c1a4',
 
   // Node snapshots (taken around April 20th, 2013)
@@ -31,14 +31,14 @@ const globalVars = {
 
   // Nitro Github references
   nitroRepositorySlug: 'nitro',
-  nitroVersionTag: 'v3.1.2',
+  nitroVersionTag: 'v3.2.0',
   nitroPathToPrecompiles: 'precompiles',
 
   nitroContractsRepositorySlug: 'nitro-contracts',
-  nitroContractsCommit: '61204dd455966cb678192427a07aa9795ff91c14',
+  nitroContractsCommit: '7396313311ab17cb30e2eef27cccf96f0a9e8f7f',
   nitroContractsPathToPrecompilesInterface: 'src/precompiles',
 
-  goEthereumCommit: 'e35bf9cdd3d02034ac1be34a479d101f12012ba6',
+  goEthereumCommit: '17cd00167543a5a2b0b083e32820051100154c2f',
 
   nitroPathToArbos: 'arbos',
   nitroPathToArbosState: 'arbos/arbosState',


### PR DESCRIPTION
This PR updates the nitro version referenced in the docs to v3.2.1.
It also updates the precompiles and NodeInterface reference links.