### PR TITLE
Add twiggy and link to recommended librairies

### DIFF
--- a/arbitrum-docs/stylus/how-tos/optimizing-binaries.mdx
+++ b/arbitrum-docs/stylus/how-tos/optimizing-binaries.mdx
@@ -45,6 +45,12 @@ Additional WASM-specific tooling exists to shrink binaries. Due to being 3rd par
 
 [wasm-opt](https://docs.rs/wasm-opt/0.113.0/wasm_opt/) applies techniques to further reduce binary size, usually netting around 10%.
 
+### `twiggy`
+
+[twiggy](https://github.com/rustwasm/twiggy) is a code size profiler for WASM, it can help you estimate the impact of each added component on your binaries' size. 
+
+Our team has also curated a [list of recommended libraries](/stylus/recommended-libraries) that are helpful to Stylus development and optimally sized.
+
 ### Frequently asked questions
 
 **Will future releases of Stylus introduce additional optimizations?**


### PR DESCRIPTION
This PR adds two references to Stylus' "How to optimize Stylus WASM binaries" page:
- Twiggy
- Cross-link to the recommended libraries page