### PR TITLE
feat: add https://traceye.io/ to indexers list

### DIFF
--- a/arbitrum-docs/launch-orbit-chain/infra-options-orbit-chains.md
+++ b/arbitrum-docs/launch-orbit-chain/infra-options-orbit-chains.md
@@ -64,6 +64,7 @@ Indexers provide a convenient way to retrieve historic or application-specific d
 - [The Graph](https://thegraph.com/)
 - [Goldsky](https://goldsky.com/)
 - [Ormi](https://www.ormilabs.xyz/)
+- [Traceye](https://traceye.io/)
 
 ## Oracles
 


### PR DESCRIPTION
This PR adds https://traceye.io/ to the indexers' list in the [infra options for orbit chains](https://docs.arbitrum.io/launch-orbit-chain/infra-options-orbit-chains) page.