### PR TITLE
Add warning about Stylus not supporting contract multi-inheritance yet

### DIFF
--- a/arbitrum-docs/stylus/partials/_stylus-no-multi-inheritance-banner-partial.mdx
+++ b/arbitrum-docs/stylus/partials/_stylus-no-multi-inheritance-banner-partial.mdx
@@ -1,0 +1,5 @@
+:::info
+
+Stylus doesn't support contract multi-inheritance yet.
+
+:::

--- a/arbitrum-docs/stylus/partials/_stylus-no-multi-inheritance-banner-partial.mdx
+++ b/arbitrum-docs/stylus/partials/_stylus-no-multi-inheritance-banner-partial.mdx
@@ -1,5 +1,5 @@
 :::info
 
-Stylus doesn't support contract multi-inheritance yet.
+Stylus doesn't support contract multi-inheritance yet
 
 :::

--- a/arbitrum-docs/stylus/partials/_stylus-no-multi-inheritance-banner-partial.mdx
+++ b/arbitrum-docs/stylus/partials/_stylus-no-multi-inheritance-banner-partial.mdx
@@ -1,5 +1,5 @@
 :::info
 
-Stylus doesn't support contract multi-inheritance yet
+Stylus doesn't support contract multi-inheritance yet.
 
 :::

--- a/arbitrum-docs/stylus/reference/overview.md
+++ b/arbitrum-docs/stylus/reference/overview.md
@@ -8,8 +8,11 @@ target_audience: Developers using the Stylus Rust SDK to write and deploy smart 
 ---
 
 import PublicPreviewBannerPartial from '../../partials/_public-preview-banner-partial.mdx';
+import StylusNoMultiInheritanceBannerPartial from '../partials/_stylus-no-multi-inheritance-banner-partial.mdx'
 
 <PublicPreviewBannerPartial />
+
+<StylusNoMultiInheritanceBannerPartial />
 
 This section provides an in-depth overview of the features provided by the [Stylus Rust SDK](https://github.com/OffchainLabs/stylus-sdk-rs). For information about deploying Rust smart contracts, see the `cargo stylus` [CLI Tool](https://github.com/OffchainLabs/cargo-stylus). For a conceptual introduction to Stylus, see [Stylus: A Gentle Introduction](../stylus-gentle-introduction.md). To deploy your first Stylus smart contract using Rust, refer to the [Quickstart](../stylus-quickstart.md).
 

--- a/arbitrum-docs/stylus/reference/overview.md
+++ b/arbitrum-docs/stylus/reference/overview.md
@@ -12,7 +12,6 @@ import StylusNoMultiInheritanceBannerPartial from '../partials/_stylus-no-multi-
 
 <PublicPreviewBannerPartial />
 
-<StylusNoMultiInheritanceBannerPartial />
 
 This section provides an in-depth overview of the features provided by the [Stylus Rust SDK](https://github.com/OffchainLabs/stylus-sdk-rs). For information about deploying Rust smart contracts, see the `cargo stylus` [CLI Tool](https://github.com/OffchainLabs/cargo-stylus). For a conceptual introduction to Stylus, see [Stylus: A Gentle Introduction](../stylus-gentle-introduction.md). To deploy your first Stylus smart contract using Rust, refer to the [Quickstart](../stylus-quickstart.md).
 

--- a/arbitrum-docs/stylus/reference/overview.md
+++ b/arbitrum-docs/stylus/reference/overview.md
@@ -8,7 +8,6 @@ target_audience: Developers using the Stylus Rust SDK to write and deploy smart 
 ---
 
 import PublicPreviewBannerPartial from '../../partials/_public-preview-banner-partial.mdx';
-import StylusNoMultiInheritanceBannerPartial from '../partials/_stylus-no-multi-inheritance-banner-partial.mdx'
 
 <PublicPreviewBannerPartial />
 

--- a/arbitrum-docs/stylus/reference/rust-sdk-guide.md
+++ b/arbitrum-docs/stylus/reference/rust-sdk-guide.md
@@ -9,6 +9,8 @@ target_audience: Developers using the Stylus Rust SDK to write and deploy smart 
 
 import PublicPreviewBannerPartial from '../../partials/_public-preview-banner-partial.mdx';
 
+import StylusNoMultiInheritanceBannerPartial from '../partials/_stylus-no-multi-inheritance-banner-partial.mdx'
+
 <PublicPreviewBannerPartial />
 
 This document provides information about advanced features included in the [Stylus Rust SDK](https://github.com/OffchainLabs/stylus-sdk-rs), that are not described in the previous pages. For information about deploying Rust smart contracts, see the `cargo stylus` [CLI Tool](https://github.com/OffchainLabs/cargo-stylus). For a conceptual introduction to Stylus, see [Stylus: A Gentle Introduction](../stylus-gentle-introduction.md). To deploy your first Stylus smart contract using Rust, refer to the [Quickstart](../stylus-quickstart.md).
@@ -271,6 +273,10 @@ If enabled, the Stylus SDK will flush the storage cache in between reentrant cal
 The [`#[entrypoint]`][entrypoint] macro will automatically implement the [`TopLevelStorage`][TopLevelStorage] trait for the annotated `struct`. The single type implementing [`TopLevelStorage`][TopLevelStorage] is special in that mutable access to it represents mutable access to the entire program’s state. This idea will become important when discussing calls to other programs in later sections.
 
 ### Inheritance, `#[inherit]`, and `#[borrow]`.
+
+
+
+<StylusNoMultiInheritanceBannerPartial />
 
 Composition in Rust follows that of Solidity. Types that implement [`Router`][Router], the trait that [`#[public]`][public] provides, can be connected via inheritance.
 

--- a/website/src/scripts/stylusByExampleDocsHandler.ts
+++ b/website/src/scripts/stylusByExampleDocsHandler.ts
@@ -130,7 +130,7 @@ function copyFiles(source, target) {
 
 // Adjust the file path
 const firstCodeBlock = `\`\`\`rust`;
-const admonition = `
+const admonitionNotForProduction = `
 import NotForProductionBannerPartial from '../partials/_not-for-production-banner-partial.mdx';
 
 <NotForProductionBannerPartial />
@@ -146,7 +146,7 @@ function addAdmonitionOneLineAboveFirstCodeBlock(content) {
   // Find the position two lines before firstCodeBlock
   const lines = content.substring(0, index).split('\n');
   const insertLineIndex = lines.length - 2;
-  lines.splice(insertLineIndex, 0, admonition);
+  lines.splice(insertLineIndex, 0, admonitionNotForProduction);
 
   const newText = lines.join('\n') + content.substring(index);
   return newText;


### PR DESCRIPTION
This PR warns about Stylus not supporting contract multi-inheritance yet in the SDK overview.