### PR TITLE
Update 01-quickstart-solidity-hardhat.mdx

### DIFF
--- a/arbitrum-docs/build-decentralized-apps/01-quickstart-solidity-hardhat.mdx
+++ b/arbitrum-docs/build-decentralized-apps/01-quickstart-solidity-hardhat.mdx
@@ -185,6 +185,7 @@ main().catch((error) => {
 We'll use this to deploy our smart contract in a moment. Next, delete `contracts/Lock.sol` and replace it with `contracts/VendingMachine.sol`, the smarter alternative to our Javascript implementation:
 
 ```solidity title="VendingMachine.sol"
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
 // Rule 2: The vending machine's rules can't be changed by anyone.


### PR DESCRIPTION
add _License-Identifier_ otherwise, it'll give a warning to developers.

updated with **// SPDX-License-Identifier: MIT**



![image](https://github.com/user-attachments/assets/f14f7c4d-1fdb-4cea-8609-05c72456941a)
