### PR TITLE
fix: restore obtrusiveness of carets

### DIFF
--- a/website/src/css/partials/_sidebar.scss
+++ b/website/src/css/partials/_sidebar.scss
@@ -14,14 +14,6 @@ $child-sidebar-item-font-size: 14px;
     padding-top: 20px;
     font-weight: 400;
 
-    // make the carets less obtrusive
-    .menu__link--sublist-caret:after {
-      height: 1rem !important;
-      width: 1rem !important;
-      background: var(--ifm-menu-link-sublist-icon) 50% / 1.2rem 1.2rem;
-      opacity: 0.5;
-    }
-
     // style the root level items
     > li.theme-doc-sidebar-item-link-level-1,
     > li.theme-doc-sidebar-item-category-level-1 {


### PR DESCRIPTION
The carets in the sidebar weren't all the same size previously because the docs pages use a button with a caret inside instead of just a caret. So the CSS that targeted the caret to make it smaller was not targeting the caret for pages in the sidebar. This PR just removes the CSS that made carets smaller so they're now all the same size. 

If desired, we can also target the button so it's smaller to match the current sizes, but the larger caret size seems easier for me to see and makes more sense to use the default style in this case. 


**BEFORE**:
![Screenshot 2024-12-26 at 10 53 49 AM](https://github.com/user-attachments/assets/ab2a07b0-8f2b-4d36-b29c-665862016e3d)


**AFTER**:
![Screenshot 2024-12-26 at 10 53 42 AM](https://github.com/user-attachments/assets/343e4f6f-a5d1-4944-b251-0ccca317a9ff)
