### PR TITLE
removes unnecessary redirect for sequencer

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -516,11 +516,6 @@
       "permanent": false
     },
     {
-      "source": "/(how-arbitrum-works/sequencer/?)",
-      "destination": "/how-arbitrum-works/sequencer",
-      "permanent": false
-    },
-    {
       "source": "/(docs/l1_l2_messages/?)",
       "destination": "/how-arbitrum-works/l1-to-l2-messaging",
       "permanent": false


### PR DESCRIPTION
[this PR](https://github.com/OffchainLabs/arbitrum-docs/pull/1866/files#diff-a3265310f552fb66876e8bfe8809737e59e5ba946bdf39138b44d9baf4e21240R519) added a redirect that wasn't needed.

the file was removed, renamed, and then added to the same location, so its redirect wasn't needed. The redirect of a route to itself, caused an endless loop which eventually timed out and broke links to that page.