### PR TITLE
Add stringStorage setter and getter tu stylus-sdk-guide

### DIFF
--- a/arbitrum-docs/stylus/reference/rust-sdk-guide.md
+++ b/arbitrum-docs/stylus/reference/rust-sdk-guide.md
@@ -115,7 +115,7 @@ impl Contract {
     }
 
     /// Unlike other storage type, stringStorage needs to
-    /// use `.set_str` and `.get_string()` to set and get.
+    /// use `.set_str()` and `.get_string()` to set and get.
     pub fn set_base_uri(&mut self, base_uri: String) {
         self.base_uri.set_str(base_uri);
     }

--- a/arbitrum-docs/stylus/reference/rust-sdk-guide.md
+++ b/arbitrum-docs/stylus/reference/rust-sdk-guide.md
@@ -113,6 +113,16 @@ impl Contract {
             self.owner.set(new_owner);
         }
     }
+
+    /// Unlike other storage type, stringStorage needs to
+    /// use `.set_str` and `.get_string()` to set and get.
+    pub fn set_base_uri(&mut self, base_uri: String) {
+        self.base_uri.set_str(base_uri);
+    }
+
+    pub fn get_base_uri(&self) -> String {
+        self.base_uri.get_string()
+    }
 }
 ```
 


### PR DESCRIPTION
Because stringStorage use different method to set and get its storage value, we need to mention it on docs.