### PR TITLE
Add yarn format to yarn start

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
     "update_variable_refs": "ts-node src/scripts/update-variable-references.ts",
     "prepare": "husky",
     "postinstall": "git config core.hooksPath .husky",
-    "start": "yarn clear && yarn install_sdk_dependencies && docusaurus start",
+    "start": "yarn clear && yarn format && yarn install_sdk_dependencies && docusaurus start",
     "build_translation": "yarn ts-node ./src/scripts/move-untranslated-files.ts",
     "build": "yarn install_sdk_dependencies && docusaurus build",
     "swizzle": "docusaurus swizzle",


### PR DESCRIPTION
Many PRs have failed due to contributors forgetting to run `yarn format`.
This PR adds `yarn format` to `yarn start, ' ensuring the submitted files are properly formatted before submission.