### PR TITLE
docs: graceful-shutdown-value

### DIFF
--- a/arbitrum-docs/node-running/how-tos/running-an-orbit-node.mdx
+++ b/arbitrum-docs/node-running/how-tos/running-an-orbit-node.mdx
@@ -121,7 +121,7 @@ Or:
 - When shutting down the Docker image, it is important to allow a graceful shutdown so that the current state can be saved to disk. Here is an example of how to do a graceful shutdown of all Docker images currently running
 
   ```shell
-  docker stop --time=300 $(docker ps -aq)
+  docker stop --time=1800 $(docker ps -aq)
   ```
 
 ### Note on permissions

--- a/arbitrum-docs/run-arbitrum-node/03-run-full-node.mdx
+++ b/arbitrum-docs/run-arbitrum-node/03-run-full-node.mdx
@@ -92,7 +92,7 @@ Even though there are alpha and beta versions of the <a data-quicklook-from='arb
   - When shutting down the Docker image, it is important to allow a graceful shutdown to save the current state to disk. Here is an example of how to do a graceful shutdown of all docker images currently running
 
   ```shell
-  docker stop --time=300 $(docker ps -aq)
+  docker stop --time=1800 $(docker ps -aq)
   ```
 
 ### Note on permissions

--- a/arbitrum-docs/run-arbitrum-node/06-troubleshooting.mdx
+++ b/arbitrum-docs/run-arbitrum-node/06-troubleshooting.mdx
@@ -183,7 +183,7 @@ You can check logs by different log types: info, warn, and error.
             This is usually because your node shuts down ungracefully. In most cases, it will
             recover in a few minutes, but if it not, you may have to re-sync your node. Remember to
             shut down your node gracefully with the following command:{' '}
-            <code>docker stop —time=300 $(docker ps -aq)</code>.
+            <code>docker stop —time=1800 $(docker ps -aq)</code>.
           </td>
         </tr>
         <tr className="scenario">


### PR DESCRIPTION
- Updating recommendation of 300 seconds to 1800 as the graceful shutdown value per [GH Issue 2112](https://github.com/OffchainLabs/arbitrum-docs/issues/2112)