### PR TITLE
docs: aep-license-broken-link

### DIFF
--- a/arbitrum-docs/launch-orbit-chain/aep-license.mdx
+++ b/arbitrum-docs/launch-orbit-chain/aep-license.mdx
@@ -20,4 +20,4 @@ Benefits:
 - Leverage battle-tested technology to permissionlessly deploy L2s/L3s that settle to any supported parent chain.
 - Governance freedom - Orbit chains are not required to be governed by the Arbitrum DAO.
 - Flexible licensing allows developers to modify chain configurations. Orbit chains are free to modify any part of the stack, including implementation of custom gas tokens, alternative DA integrations, novel sequencing mechanisms, account abstraction, altVMs, etc.
-- L3s that settle to parent chains other than Arb1 and Nova must contribute [net chain revenue](https://docs.arbitrum.io/launch-orbit-chain/02-configure-your-chain/common-configurations/calculate-aep-fees#calculating-aep-fees), where 8% flows to the DAO and 2% to the developer guild.
+- L3s that settle to parent chains other than Arb1 and Nova must contribute [net chain revenue](/launch-orbit-chain/02-configure-your-chain/common-configurations/calculate-aep-fees.mdx#calculating-aep-fees), where 8% flows to the DAO and 2% to the developer guild.

--- a/arbitrum-docs/launch-orbit-chain/aep-license.mdx
+++ b/arbitrum-docs/launch-orbit-chain/aep-license.mdx
@@ -20,4 +20,4 @@ Benefits:
 - Leverage battle-tested technology to permissionlessly deploy L2s/L3s that settle to any supported parent chain.
 - Governance freedom - Orbit chains are not required to be governed by the Arbitrum DAO.
 - Flexible licensing allows developers to modify chain configurations. Orbit chains are free to modify any part of the stack, including implementation of custom gas tokens, alternative DA integrations, novel sequencing mechanisms, account abstraction, altVMs, etc.
-- L3s that settle to parent chains other than Arb1 and Nova must contribute [net chain revenue](https://docs.arbitrum.io/launch-orbit-chain/how-tos/calculate-aep-fees#calculating-aep-fees), where 8% flows to the DAO and 2% to the developer guild.
+- L3s that settle to parent chains other than Arb1 and Nova must contribute [net chain revenue](https://docs.arbitrum.io/launch-orbit-chain/02-configure-your-chain/common-configurations/calculate-aep-fees#calculating-aep-fees), where 8% flows to the DAO and 2% to the developer guild.


### PR DESCRIPTION
- Fixing broken link based on [GH Issue 2119](https://github.com/OffchainLabs/arbitrum-docs/issues/2119)