### PR TITLE
feat: adding guide on fixing contracts submodule not found"

### DIFF
--- a/arbitrum-docs/stylus/quickstart.mdx
+++ b/arbitrum-docs/stylus/quickstart.mdx
@@ -77,6 +77,13 @@ cd nitro-devnode
 ./run-dev-node.sh
 ```
 
+If you see an error like this run the following command:
+```shell title="Error: Contracts submodule not found."
+git submodule update --init --recursive
+```
+
+Then launch your devnode again.
+
 </details>
 
 ## Creating a Stylus project with cargo stylus


### PR DESCRIPTION
1. Audience: Writing for people building in Stylus and facing errors in running devnode
2. Problem: Contracts submodule not found when running devnode
3. Discovery: Running a git command
4. Document type: This is inside quickstart guide


This PR is for adding a quick guide on fixing contracts module not found.
