### PR TITLE
fix(how-arbitrum-works): typo

### DIFF
--- a/arbitrum-docs/how-arbitrum-works/10-l1-to-l2-messaging.mdx
+++ b/arbitrum-docs/how-arbitrum-works/10-l1-to-l2-messaging.mdx
@@ -233,7 +233,7 @@ You can find additional details on message types in the next section of this doc
 
 :::note
 
-Please refer to the [Address aliasing](#address-aliasing) discussion for more background on address aliasing. This mechanism ensures that a parent chain contract can't impersonate a child chain address unless it provides a vlaid signature as an EOA.
+Please refer to the [Address aliasing](#address-aliasing) discussion for more background on address aliasing. This mechanism ensures that a parent chain contract can't impersonate a child chain address unless it provides a valid signature as an EOA.
 
 :::
 


### PR DESCRIPTION
Corrected "vlaid" to "valid" in the note about address aliasing.