### PR TITLE
fix s3 bucket URLs

### DIFF
--- a/arbitrum-docs/how-arbitrum-works/timeboost/how-to-use-timeboost.mdx
+++ b/arbitrum-docs/how-arbitrum-works/timeboost/how-to-use-timeboost.mdx
@@ -517,8 +517,10 @@ In the current implementation, information about the winning bid for a resolved 
 | Chain            | S3 bucket URL                                                   |
 | ---------------- | --------------------------------------------------------------- |
 | Arbitrum Sepolia | s3://timeboost-auctioneer-sepolia/ue2/validated-timeboost-bids/ |
-| Arbitrum One     | s3://timeboost-auctioneer-arb1/ue2/validated-timeboost-bids/    |
-| Arbitrum Nova    | s3://timeboost-auctioneer-nova/ue2/validated-timeboost-bids/    |
+| Arbitrum One     | s3://timeboost-auctioneer-arb1/uw2/validated-timeboost-bids/    |
+| Arbitrum Nova    | s3://timeboost-auctioneer-nova/uw2/validated-timeboost-bids/    |
+
+Note: Make sure you use `--no-sign-request` with the [AWS S3 CLI](https://docs.aws.amazon.com/cli/latest/reference/s3/).
 
 ## Troubleshooting and best practices
 


### PR DESCRIPTION
this pull request fixes the broken URL link for the s3 bucket in our docs for the historical bid data