### PR TITLE
docs: removing-redirect-high-availability-seq

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -865,11 +865,6 @@
       "destination": "/run-arbitrum-node/run-full-node",
       "permanent": false
     },
-     {
-      "source": "/(run-arbitrum-node/sequencer/high-availability-sequencer-docs/?)",
-      "destination": "/run-arbitrum-node/sequencer/high-availability-sequencer-docs",
-      "permanent": false
-    },   
     {
       "source": "/docs/public_testnet",
       "destination": "/for-devs/concepts/public-chains",
@@ -2183,11 +2178,6 @@
     {
       "source": "/(partials/_troubleshooting-orbit-partial/?)",
       "destination": "/partials/_troubleshooting-arbitrum-chain-partial",
-      "permanent": false
-    },
-    {
-      "source": "/(run-arbitrum-node/sequencer/high-availability-sequencer-docs/?)",
-      "destination": "/(run-arbitrum-node/sequencer/high-availability-sequencer-docs/?)",
       "permanent": false
     }
   ]


### PR DESCRIPTION
- New page shouldn't require redirect
  - also duplicate redirect (2 in vercel.json) seem to be causing an infinite redirect loop