### PR TITLE
Do not use homebrew to install Go

### DIFF
--- a/arbitrum-docs/run-arbitrum-node/nitro/01-build-nitro-locally.mdx
+++ b/arbitrum-docs/run-arbitrum-node/nitro/01-build-nitro-locally.mdx
@@ -109,7 +109,7 @@ Replace `~/.zprofile` with `~/.bash_profile` if you use bash instead of zsh).
 Install essentials:
 
 ```shell
-brew install git curl make cmake npm go golangci-lint wabt llvm lld libusb gotestsum
+brew install git curl make cmake npm wabt llvm lld libusb gotestsum
 npm install --global yarn
 sudo mkdir -p /usr/local/bin
 echo "export PATH=/opt/homebrew/opt/llvm/bin:$PATH" >> ~/.zprofile && source ~/.zprofile


### PR DESCRIPTION
Remove the suggestion of using homebrew to install Go since installing
gvm is more flexible and already in the instructions.
