### PR TITLE
docs: run-archive-node-update

### DIFF
--- a/arbitrum-docs/run-arbitrum-node/more-types/01-run-archive-node.mdx
+++ b/arbitrum-docs/run-arbitrum-node/more-types/01-run-archive-node.mdx
@@ -16,7 +16,7 @@ An Arbitrum **archive node** is a full node that maintains an archive of histori
 
 ### Before we begin
 
-Before the Nitro upgrade, Arbitrum One ran on the Classic stack for about one year (before block height 22207817). Although the Nitro chain uses the latest snapshot of the Classic chain's state as its genesis state, **the Nitro stack can only serve six RPC requests for pre-Nitro blocks. Full details are outlined [here](/run-arbitrum-node/more-types/03-run-classic-node.mdx#do-you-need-to-run-a-classic-node).**.
+Before the Nitro upgrade, Arbitrum One ran on the Classic stack for about one year (before block height 22207817). Although the Nitro chain uses the latest snapshot of the Classic chain's state as its genesis state, **the Nitro stack can serve all but six RPC requests for pre-Nitro blocks. Full details are outlined [here](/run-arbitrum-node/more-types/03-run-classic-node.mdx#do-you-need-to-run-a-classic-node).**.
 
 Running an Arbitrum One **full node** in **archive mode** lets you access both pre-Nitro and post-Nitro blocks, but it requires you to run **both Classic and Nitro nodes** together. You may not need to do this, depending on your use case:
 

--- a/arbitrum-docs/run-arbitrum-node/more-types/01-run-archive-node.mdx
+++ b/arbitrum-docs/run-arbitrum-node/more-types/01-run-archive-node.mdx
@@ -16,7 +16,7 @@ An Arbitrum **archive node** is a full node that maintains an archive of histori
 
 ### Before we begin
 
-Before the Nitro upgrade, Arbitrum One ran on the Classic stack for about one year (before block height 22207817). Although the Nitro chain uses the latest snapshot of the Classic chain's state as its genesis state, **the Nitro stack can't serve archive requests for pre-Nitro blocks**.
+Before the Nitro upgrade, Arbitrum One ran on the Classic stack for about one year (before block height 22207817). Although the Nitro chain uses the latest snapshot of the Classic chain's state as its genesis state, **the Nitro stack can only serve six RPC requests for pre-Nitro blocks. Full details are outlined [here](/run-arbitrum-node/more-types/03-run-classic-node.mdx#do-you-need-to-run-a-classic-node).**.
 
 Running an Arbitrum One **full node** in **archive mode** lets you access both pre-Nitro and post-Nitro blocks, but it requires you to run **both Classic and Nitro nodes** together. You may not need to do this, depending on your use case:
 


### PR DESCRIPTION
- Fixing an inaccuracy; and linking to the proper material (to avoid duplication - single source of truth)