### PR TITLE
update rollupcreator address list to v3.1

### DIFF
--- a/arbitrum-docs/launch-arbitrum-chain/03-deploy-an-arbitrum-chain/07-canonical-factory-contracts.mdx
+++ b/arbitrum-docs/launch-arbitrum-chain/03-deploy-an-arbitrum-chain/07-canonical-factory-contracts.mdx
@@ -32,13 +32,13 @@ This table shows the addresses of the deployed and maintained canonical factory 
 
 | Network          | Chain id | RollupCreator                                                                   | TokenBridgeCreator                                                              |
 | ---------------- | -------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| Ethereum         | 1        | <AEL address="0x8c88430658a03497D13cDff7684D37b15aA2F3e1" chainID={1} />        | <AEL address="0x60D9A46F24D5a35b95A78Dd3E793e55D94EE0660" chainID={1} />        |
-| Arbitrum One     | 42161    | <AEL address="0x79607f00e61E6d7C0E6330bd7E9c4AC320D50FC9" chainID={42161} />    | <AEL address="0x2f5624dc8800dfA0A82AC03509Ef8bb8E7Ac000e" chainID={42161} />    |
-| Arbitrum Nova    | 42170    | <AEL address="0x9B523BF5F77e8d90e0E9eb0924aEA6E40B081aE6" chainID={42170} />    | <AEL address="0x8B9D9490a68B1F16ac8A21DdAE5Fd7aB9d708c14" chainID={42170} />    |
-| Base             | 8453     | <AEL address="0x091b8FC0F48613b191f81009797ce55Cf97Af7C8" chainID={8453} />     | <AEL address="0x4C240987d6fE4fa8C7a0004986e3db563150CA55" chainID={8453} />     |
-| Sepolia          | 11155111 | <AEL address="0xfb774eA8A92ae528A596c8D90CBCF1bdBC4Cee79" chainID={11155111} /> | <AEL address="0x7edb2dfBeEf9417e0454A80c51EE0C034e45a570" chainID={11155111} /> |
-| Arbitrum Sepolia | 421614   | <AEL address="0xd2Ec8376B1dF436fAb18120E416d3F2BeC61275b" chainID={421614} />   | <AEL address="0x56C486D3786fA26cc61473C499A36Eb9CC1FbD8E" chainID={421614} />   |
-| Base Sepolia     | 84532    | <AEL address="0x6e244cD02BBB8a6dbd7F626f05B2ef82151Ab502" chainID={84532} />    | <AEL address="0xFC71d21a4FE10Cc0d34745ba9c713836f82f8DE3" chainID={84532} />    |
+| Ethereum         | 1        | <AEL address="0x43698080f40dB54DEE6871540037b8AB8fD0AB44" chainID={1} />        | <AEL address="0x60D9A46F24D5a35b95A78Dd3E793e55D94EE0660" chainID={1} />        |
+| Arbitrum One     | 42161    | <AEL address="0xB90e53fd945Cd28Ec4728cBfB566981dD571eB8b" chainID={42161} />    | <AEL address="0x2f5624dc8800dfA0A82AC03509Ef8bb8E7Ac000e" chainID={42161} />    |
+| Arbitrum Nova    | 42170    | <AEL address="0xF916Bfe431B7A7AaE083273F5b862e00a15d60F4" chainID={42170} />    | <AEL address="0x8B9D9490a68B1F16ac8A21DdAE5Fd7aB9d708c14" chainID={42170} />    |
+| Base             | 8453     | <AEL address="0xDbe3e840569a0446CDfEbc65D7d429c5Da5537b7" chainID={8453} />     | <AEL address="0x4C240987d6fE4fa8C7a0004986e3db563150CA55" chainID={8453} />     |
+| Sepolia          | 11155111 | <AEL address="0x687Bc1D23390875a868Db158DA1cDC8998E31640" chainID={11155111} /> | <AEL address="0x7edb2dfBeEf9417e0454A80c51EE0C034e45a570" chainID={11155111} /> |
+| Arbitrum Sepolia | 421614   | <AEL address="0x5F45675AC8DDF7d45713b2c7D191B287475C16cF" chainID={421614} />   | <AEL address="0x56C486D3786fA26cc61473C499A36Eb9CC1FbD8E" chainID={421614} />   |
+| Base Sepolia     | 84532    | <AEL address="0x70cA29dA3B116A2c4A267c549bf7947d47f41e22" chainID={84532} />    | <AEL address="0xFC71d21a4FE10Cc0d34745ba9c713836f82f8DE3" chainID={84532} />    |
 
 ## How to deploy new factory contracts
 


### PR DESCRIPTION
Update rollup creator addresses from v2.1 to v3.1 based on [orbit sdk address list](https://github.com/OffchainLabs/arbitrum-orbit-sdk/blob/main/wagmi.config.ts#L104-L141)