### PR TITLE
docs: calculate-aep-fees-remove-assertion

### DIFF
--- a/arbitrum-docs/launch-arbitrum-chain/02-configure-your-chain/advanced-configurations/03-aep-fee-router/03-calculate-aep-fees.mdx
+++ b/arbitrum-docs/launch-arbitrum-chain/02-configure-your-chain/advanced-configurations/03-aep-fee-router/03-calculate-aep-fees.mdx
@@ -29,7 +29,7 @@ From here on, we will refer to the three onchain components (security, execution
 As the Arbitrum chain (Orbit) license allows chain owners to customize their Rollup, the AEP license accounts for revenue sources that could arise out of innovations. As such, it’s worth noting that the total calculation of revenue will also include:
 
 - Revenue from transaction ordering policies
-- Revenue earned through fees on top of the bridge
+- Revenue earned through fees on top of the bridge's
 - Broadly, any revenue earned in connection with your use of Arbitrum Nitro
 
 You can read the relevant legal terminology in Section 2 of the [AEP Terms](https://docs.arbitrum.foundation/aep/ArbitrumExpansionProgramTerms.pdf).


### PR DESCRIPTION
- Removed assertion fees section(s)
- Left announcement about removing them as a notice, I think we could remove it, or leave it for a little while and then remove