### PR TITLE
update timeboost historical bid data instructions to be region-change resistant

### DIFF
--- a/arbitrum-docs/how-arbitrum-works/timeboost/how-to-use-timeboost.mdx
+++ b/arbitrum-docs/how-arbitrum-works/timeboost/how-to-use-timeboost.mdx
@@ -514,11 +514,11 @@ In the current implementation, information about the winning bid for a resolved 
 
 #### Table 4: S3 URLs for historical bid data
 
-| Chain            | S3 bucket URL                        |
-| ---------------- | ------------------------------------ |
-| Arbitrum Sepolia | s3://timeboost-auctioneer-sepolia/   |
-| Arbitrum One     | s3://timeboost-auctioneer-arb1/      |
-| Arbitrum Nova    | s3://timeboost-auctioneer-nova/      |
+| Chain            | S3 bucket URL                      |
+| ---------------- | ---------------------------------- |
+| Arbitrum Sepolia | s3://timeboost-auctioneer-sepolia/ |
+| Arbitrum One     | s3://timeboost-auctioneer-arb1/    |
+| Arbitrum Nova    | s3://timeboost-auctioneer-nova/    |
 
 Note: Make sure you use `--no-sign-request` with the [AWS S3 CLI](https://docs.aws.amazon.com/cli/latest/reference/s3/).
 

--- a/arbitrum-docs/how-arbitrum-works/timeboost/how-to-use-timeboost.mdx
+++ b/arbitrum-docs/how-arbitrum-works/timeboost/how-to-use-timeboost.mdx
@@ -5,6 +5,8 @@ author: jose-franco
 content_type: how-to
 ---
 
+import { VanillaAdmonition } from '@site/src/components/VanillaAdmonition/';
+
 Timeboost is a new transaction ordering policy for Arbitrum chains. With Timeboost, anyone can bid for the right to access an express lane on the **Sequencer** faster transaction inclusion.
 
 In this how-to, you'll learn how to bid for the right to use the express lane and submit transactions through the express lane. To learn more about Timeboost and the key terms used on this page, refer to the [gentle introduction](/how-arbitrum-works/timeboost/gentle-introduction.mdx).
@@ -14,23 +16,23 @@ This how-to assumes that you're familiar with the following:
 - [How Timeboost works](/how-arbitrum-works/timeboost/gentle-introduction.mdx)
 - [viem](https://viem.sh/), since the snippets of code present in the how-to use this library
 
-::::info Note about transferring express lane rights
+<VanillaAdmonition type="note"  title="Note about transferring express lane rights">
 
 Please note that in the initial release of Timeboost, transferring of express lane control via the either the `setTransferor` or the `transferExpressLaneController` will not be supported by the Arbitrum Nitro node software in the initial launch and may be implemented at a future date via a regular node upgrade. Calls made to these two functions on the auction contract will be successful, but actual transfer of the rights will not be recognized by the node software (including the Sequencer).
 
 A round's express lane controller, at their choice, can still send transactions signed by others on a per-transaction basis, as explained later in this guide.
 
-::::
+</VanillaAdmonition>
 
 ## How to submit bids for the right to be the express lane controller
 
 To use the express lane for faster transaction inclusion, you must win an auction for the right to be the express lane controller for a specific round.
 
-::::info
+<VanillaAdmonition type="note">
 
 Remember that, by default, each round lasts 60 seconds, and the auction for a specific round closes 15 seconds before the round starts. These default values can be configured on a chain using the `roundDurationSeconds` and `auctionClosingSeconds` parameters.
 
-::::
+</VanillaAdmonition>
 
 Auctions are facilitated by an auction contract, and bids get submitted to an autonomous auctioneer that interact with the contract. Let's look at the process of submitting bids and finding out the winner of an auction.
 
@@ -80,11 +82,11 @@ const biddingTokenContractAddress = await publicClient.readContract({
 console.log(`biddingToken: ${biddingTokenContractAddress}`);
 ```
 
-::::info Bidding token in Arbitrum chains
+<VanillaAdmonition type="note"  title="Bidding token in Arbitrum chains">
 
 On Arbitrum One and Arbitrum Nova, the default bidding token is `WETH`.
 
-::::
+</VanillaAdmonition>
 
 Once we know what the bidding token is, we can deposit funds to the auction contract by calling the function `deposit` of the contract after having it approved as spender of the amount we want to deposit:
 
@@ -152,11 +154,11 @@ Bids are submitted to the autonomous auctioneer endpoint. We need to send a `auc
 - amount in `wei` of the deposit `ERC-20` token to bid
 - signature (explained below)
 
-::::info Minimum reserve price
+<VanillaAdmonition type="info"  title="Minimum reserve price">
 
 The amount to bid must be above the minimum reserve price at the moment you are bidding. This parameter is configurable per chain. You can obtain the minimum reserve price by calling the method `minReservePrice()(uint256)` in the `Auction` contract.
 
-::::
+</VanillaAdmonition>
 
 Let's see an example of a call to this RPC method:
 
@@ -223,11 +225,11 @@ const signature = await account.sign({
 });
 ```
 
-::::info
+<VanillaAdmonition type="note">
 
 You can also call the function `getBidHash` in the auction contract to obtain the `signatureData`, specifying the `round`, `userAddress` and `amountToBid`.
 
-::::
+</VanillaAdmonition>
 
 When sending the request, the autonomous auctioneer will return an empty result with an HTTP status `200` if received correctly. If the result returned contains an error message, it means that something went wrong. Following are some of the error messages that can help us understand what's happening:
 
@@ -514,18 +516,21 @@ In the current implementation, information about the winning bid for a resolved 
 
 #### Table 4: S3 URLs for historical bid data
 
-| Chain            | S3 bucket URL                      |
-| ---------------- | ---------------------------------- |
-| Arbitrum Sepolia | s3://timeboost-auctioneer-sepolia/ |
-| Arbitrum One     | s3://timeboost-auctioneer-arb1/    |
-| Arbitrum Nova    | s3://timeboost-auctioneer-nova/    |
+:::info URL updates for historical bid data
+On June 9 2025, at around 17:27 ET (UTC−05:00), the region in which the Amazon S3 bucket for historical bid data on Arbitrum One was _changed_ from `s3://timeboost-auctioneer-arb1/uw2/validated-timeboost-bids/` to `s3://timeboost-auctioneer-arb1/ue2/validated-timeboost-bids/`. The below table has been updated for the new, correct URL to access bid data after June 9, 2025 17:27 ET, but if you require data from before June 9, 2025 17:27 ET, then please use `s3://timeboost-auctioneer-arb1/uw2/validated-timeboost-bids/`.
+
+| Chain            | S3 bucket URL                                                   |
+| ---------------- | --------------------------------------------------------------- |
+| Arbitrum Sepolia | s3://timeboost-auctioneer-sepolia/ue2/validated-timeboost-bids/ |
+| Arbitrum One     | s3://timeboost-auctioneer-arb1/ue2/validated-timeboost-bids/    |
+| Arbitrum Nova    | s3://timeboost-auctioneer-nova/ue2/validated-timeboost-bids/    |
 
 Note: Make sure you use `--no-sign-request` with the [AWS S3 CLI](https://docs.aws.amazon.com/cli/latest/reference/s3/).
 
 Here is an example query on how to look up and download historical bid data:
 
-```bash
-➜  ~ aws s3 ls s3://timeboost-auctioneer-arb1/ --recursive --no-sign-request | grep "2025/06/09/"
+```shell
+➜  ~ aws s3 ls s3://timeboost-auctioneer-arb1/ue2/validated-timeboost-bids/2025/06/10/  --no-sign-request --recursive
 
 2025-06-09 18:21:47      12553 ue2/validated-timeboost-bids/2025/06/09/0130304-0130343.csv.gzip
 2025-06-09 18:36:46       4725 ue2/validated-timeboost-bids/2025/06/09/0130344-0130358.csv.gzip

--- a/arbitrum-docs/how-arbitrum-works/timeboost/how-to-use-timeboost.mdx
+++ b/arbitrum-docs/how-arbitrum-works/timeboost/how-to-use-timeboost.mdx
@@ -510,37 +510,31 @@ In the sequencer feed, the `BroadcastFeedMessage` struct now contains a `blockMe
 
 ## How to view historical bid data
 
-In the current implementation, information about the winning bid for a resolved auction is emitted via the `AuctionResolved` event ([sample interface](https://github.com/OffchainLabs/nitro-contracts/blob/main/src/express-lane-auction/IExpressLaneAuction.sol#L95-L103)). Historical bid information, including the round number and bid amounts, are published to a public S3 bucket at a regular cadence. Teams can use the URLs below to download the data:
+In the current implementation, information about the winning bid for a resolved auction is emitted via the `AuctionResolved` event ([sample interface](https://github.com/OffchainLabs/nitro-contracts/blob/main/src/express-lane-auction/IExpressLaneAuction.sol#L95-L103)). Historical bid information, including the round number and bid amounts, are published to a public S3 bucket at a regular cadence. The domain for the S3 bucket where historical bids are saved is:
 
 #### Table 4: S3 URLs for historical bid data
 
-:::info URL updates for historical bid data
-On June 9 2025, at around 17:27 ET (UTC−05:00), the region in which the Amazon S3 bucket for historical bid data on Arbitrum One was *changed* from `s3://timeboost-auctioneer-arb1/uw2/validated-timeboost-bids/` to `s3://timeboost-auctioneer-arb1/ue2/validated-timeboost-bids/`. The below table has been updated for the new, correct URL to access bid data after June 9, 2025 17:27 ET, but if you require data from before June 9, 2025 17:27 ET, then please use `s3://timeboost-auctioneer-arb1/uw2/validated-timeboost-bids/`.
-
-:::
-
-| Chain            | S3 bucket URL                                                   |
-| ---------------- | --------------------------------------------------------------- |
-| Arbitrum Sepolia | s3://timeboost-auctioneer-sepolia/ue2/validated-timeboost-bids/ |
-| Arbitrum One     | s3://timeboost-auctioneer-arb1/ue2/validated-timeboost-bids/    |
-| Arbitrum Nova    | s3://timeboost-auctioneer-nova/ue2/validated-timeboost-bids/    |
+| Chain            | S3 bucket URL                        |
+| ---------------- | ------------------------------------ |
+| Arbitrum Sepolia | s3://timeboost-auctioneer-sepolia/   |
+| Arbitrum One     | s3://timeboost-auctioneer-arb1/      |
+| Arbitrum Nova    | s3://timeboost-auctioneer-nova/      |
 
 Note: Make sure you use `--no-sign-request` with the [AWS S3 CLI](https://docs.aws.amazon.com/cli/latest/reference/s3/).
 
 Here is an example query on how to look up and download historical bid data:
 
 ```bash
-➜  ~ aws s3 ls s3://timeboost-auctioneer-arb1/ue2/validated-timeboost-bids/2025/06/10/  --no-sign-request --recursive
+➜  ~ aws s3 ls s3://timeboost-auctioneer-arb1/ --recursive --no-sign-request | grep "2025/06/09/"
 
-2025-06-09 20:06:46       4872 ue2/validated-timeboost-bids/2025/06/10/0130434-0130448.csv.gzip
-2025-06-09 20:21:46       5042 ue2/validated-timeboost-bids/2025/06/10/0130449-0130463.csv.gzip
+2025-06-09 18:21:47      12553 ue2/validated-timeboost-bids/2025/06/09/0130304-0130343.csv.gzip
+2025-06-09 18:36:46       4725 ue2/validated-timeboost-bids/2025/06/09/0130344-0130358.csv.gzip
 ...
-2025-06-10 19:36:46       4382 ue2/validated-timeboost-bids/2025/06/10/0131844-0131858.csv.gzip
-2025-06-10 19:51:46       4395 ue2/validated-timeboost-bids/2025/06/10/0131859-0131873.csv.gzip
+2025-06-09 17:23:28       3407 uw2/validated-timeboost-bids/2025/06/09/0130264-0130284.csv.gzip
+2025-06-09 17:27:32       1228 uw2/validated-timeboost-bids/2025/06/09/0130285-0130288.csv.gzip
 
-
-➜ ~ aws s3 cp s3://timeboost-auctioneer-arb1/ue2/validated-timeboost-bids/2025/06/10/0131844-0131858.csv.gzip local.csv.gzip --no-sign-request
-download: s3://timeboost-auctioneer-arb1/ue2/validated-timeboost-bids/2025/06/10/0131844-0131858.csv.gzip to ./local.csv.gzip
+➜ ~ aws s3 cp s3://timeboost-auctioneer-arb1/ue2/validated-timeboost-bids/2025/06/09/0130304-0130343.csv.gzip local.csv.gzip --no-sign-request
+download: s3://timeboost-auctioneer-arb1/ue2/validated-timeboost-bids/2025/06/09/0130304-0130343.csv.gzip to ./local.csv.gzip
 ```
 
 ## Troubleshooting and best practices

--- a/arbitrum-docs/how-arbitrum-works/timeboost/how-to-use-timeboost.mdx
+++ b/arbitrum-docs/how-arbitrum-works/timeboost/how-to-use-timeboost.mdx
@@ -514,32 +514,33 @@ In the current implementation, information about the winning bid for a resolved 
 
 #### Table 4: S3 URLs for historical bid data
 
+:::info URL updates for historical bid data
+On June 9 2025, at around 17:27 ET (UTC−05:00), the region in which the Amazon S3 bucket for historical bid data on Arbitrum One was *changed* from `s3://timeboost-auctioneer-arb1/uw2/validated-timeboost-bids/` to `s3://timeboost-auctioneer-arb1/ue2/validated-timeboost-bids/`. The below table has been updated for the new, correct URL to access bid data after June 9, 2025 17:27 ET, but if you require data from before June 9, 2025 17:27 ET, then please use `s3://timeboost-auctioneer-arb1/uw2/validated-timeboost-bids/`.
+
+:::
+
 | Chain            | S3 bucket URL                                                   |
 | ---------------- | --------------------------------------------------------------- |
 | Arbitrum Sepolia | s3://timeboost-auctioneer-sepolia/ue2/validated-timeboost-bids/ |
-| Arbitrum One     | s3://timeboost-auctioneer-arb1/uw2/validated-timeboost-bids/    |
-| Arbitrum Nova    | s3://timeboost-auctioneer-nova/uw2/validated-timeboost-bids/    |
+| Arbitrum One     | s3://timeboost-auctioneer-arb1/ue2/validated-timeboost-bids/    |
+| Arbitrum Nova    | s3://timeboost-auctioneer-nova/ue2/validated-timeboost-bids/    |
 
 Note: Make sure you use `--no-sign-request` with the [AWS S3 CLI](https://docs.aws.amazon.com/cli/latest/reference/s3/).
 
 Here is an example query on how to look up and download historical bid data:
 
 ```bash
-➜  ~ aws s3 ls s3://timeboost-auctioneer-arb1/uw2/validated-timeboost-bids --recursive --summarize --human-readable --no-sign-request
+➜  ~ aws s3 ls s3://timeboost-auctioneer-arb1/ue2/validated-timeboost-bids/2025/06/10/  --no-sign-request --recursive
 
-2025-04-17 11:13:39    2.1 KiB uw2/validated-timeboost-bids/2025/04/17/0053581-0053595.csv.gzip
-2025-04-17 11:28:39    2.5 KiB uw2/validated-timeboost-bids/2025/04/17/0053596-0053610.csv.gzip
+2025-06-09 20:06:46       4872 ue2/validated-timeboost-bids/2025/06/10/0130434-0130448.csv.gzip
+2025-06-09 20:21:46       5042 ue2/validated-timeboost-bids/2025/06/10/0130449-0130463.csv.gzip
 ...
-2025-04-24 14:28:55    3.6 KiB uw2/validated-timeboost-bids/2025/04/24/0063856-0063870.csv.gzip
-2025-04-24 14:43:55    3.2 KiB uw2/validated-timeboost-bids/2025/04/24/0063871-0063885.csv.gzip
-2025-04-24 14:58:55    3.0 KiB uw2/validated-timeboost-bids/2025/04/24/0063886-0063900.csv.gzip
-
-Total Objects: 694
-   Total Size: 1.3 MiB
+2025-06-10 19:36:46       4382 ue2/validated-timeboost-bids/2025/06/10/0131844-0131858.csv.gzip
+2025-06-10 19:51:46       4395 ue2/validated-timeboost-bids/2025/06/10/0131859-0131873.csv.gzip
 
 
-➜ ~ aws s3 cp s3://timeboost-auctioneer-arb1/uw2/validated-timeboost-bids/2025/04/24/0063886-0063900.csv.gzip local.csv.gzip --no-sign-request
-download: s3://timeboost-auctioneer-arb1/uw2/validated-timeboost-bids/2025/04/24/0063886-0063900.csv.gzip to ./local.csv.gzip
+➜ ~ aws s3 cp s3://timeboost-auctioneer-arb1/ue2/validated-timeboost-bids/2025/06/10/0131844-0131858.csv.gzip local.csv.gzip --no-sign-request
+download: s3://timeboost-auctioneer-arb1/ue2/validated-timeboost-bids/2025/06/10/0131844-0131858.csv.gzip to ./local.csv.gzip
 ```
 
 ## Troubleshooting and best practices


### PR DESCRIPTION
This pr updates the instructions in our documentation so that users can get the historical bid data regardless of the region the s3 bucket is hosted in