### PR TITLE
docs: redirect-sdk-introduction

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1567,7 +1567,6 @@
       "destination": "/sdk/reference/utils/types",
       "permanent": false
     },
-    { "source": "/(sdk/?)", "destination": "/sdk/", "permanent": false },
     {
       "source": "/(sdk/assetBridger_erc20Bridger/?)",
       "destination": "/sdk/reference/assetBridger/erc20Bridger",


### PR DESCRIPTION
- vercel.json had three instances of this URL
- removed and created a new redirect for sdk/introduction to /sdk