### PR TITLE
docs: Correct redis-url forwarder path for full nodes

### DIFF
--- a/docs/run-arbitrum-node/sequencer/05-high-availability-sequencer-docs.mdx
+++ b/docs/run-arbitrum-node/sequencer/05-high-availability-sequencer-docs.mdx
@@ -151,7 +151,7 @@ helm install fullnode offchainlabs/nitro \
   --set configmap.data.parent-chain.id=<parent-chain-id> \
   --set configmap.data.parent-chain.connection.url=<parent-node-url> \
   --set configmap.data.chain.id=<child-chain-id> \
-  --set configmap.data.execution.sequencer.forwarder.redis-url=redis://<redis-url>:6379
+  --set configmap.data.execution.forwarder.redis-url=redis://<redis-url>:6379
 ```
 
 #### Mutating-only endpoint (optional)


### PR DESCRIPTION
The documentation for configuring a full node with "Send to active" (Redis discovery) contained a typo in the Helm `--set` path.

The incorrect path was:
`--set configmap.data.execution.sequencer.forwarder.redis-url`

This caused the `redis-url` parameter to be ignored, leading to a configuration paradox where the full node would either fail to start (complaining about a missing `forwarding-target`) or start but be unable to forward transactions (erroring with "publishing transactions not supported").

This commit corrects the path to the proper value, which is directly under `execution.forwarder`, not `execution.sequencer.forwarder`: `--set configmap.data.execution.forwarder.redis-url`

This ensures that full nodes can be correctly configured for dynamic sequencer discovery via Redis, as intended.