### PR TITLE
Minor Typos quickstart.mdx

### DIFF
--- a/docs/stylus/quickstart.mdx
+++ b/docs/stylus/quickstart.mdx
@@ -140,7 +140,7 @@ cargo stylus new <YOUR_PROJECT_NAME>
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.4.22 <0.9.0;
 
-contract Coutner {
+contract Counter {
 
    uint count;
 


### PR DESCRIPTION
Fixed a minor typo in the docs. 
Also, FYI in the [`Installing cargo stylus`](https://docs.arbitrum.io/stylus/quickstart#installing-cargo-stylus) section, it says:
```
rustup default 1.80
rustup target add wasm32-unknown-unknown --toolchain 1.80
```

But I couldn't install cargo stylus when on 1.80 and faced this error:
```
Error: stylus checks failed Caused by: no error payload received in response: Transport(Custom(reqwest::Error { kind: Request, url: "http://localhost:8547/", source: hyper_util::client::legacy::Error(Connect, ConnectError("tcp connect error", [::1]:8547, Os { code: 61, kind: ConnectionRefused, message: "Connection refused" })) })) Location: /Users/allarious/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cargo-stylus-0.6.1/src/check.rs:176:17
```

Had to bump up the version to 1.85 to be able to install.