### PR TITLE
chore: clarify relationship between B and gasEstimateForL1

### DIFF
--- a/docs/build-decentralized-apps/02-how-to-estimate-gas.mdx
+++ b/docs/build-decentralized-apps/02-how-to-estimate-gas.mdx
@@ -68,6 +68,8 @@ TXFEES = P * (L2G + ((L1P * L1S) / P))
 
 We'll use one resource available in Arbitrum: the [`NodeInterface`](/build-decentralized-apps/nodeinterface/02-reference.mdx).
 
+- B (Extra Buffer) ⇒ The extra buffer is the amount of gas required for posting the transaction on L1, priced in L2 gas.
+  - Call `NodeInterface.GasEstimateComponents()` and get the second element, `baseFee`.
 - P (L2 Gas Price) ⇒ Price to pay for each gas unit. It starts at @@arbOneGasFloorGwei=0.01@@ gwei on Arbitrum One (@@novaGasFloorGwei=0.01@@ gwei on Arbitrum Nova) and can increase depending on the demand for network resources.
   - Call `NodeInterface.GasEstimateComponents()` and get the third element, `baseFee`.
 - L2G (Gas used on L2) ⇒ Gas used to compute the transaction on the child chain. This does not include the _“posting on L1”_ part of the calculations. The value of L2G will depend on the transaction itself, but having the data of the transaction, we can calculate it as follows:


### PR DESCRIPTION
Thank you for contributing to our docs!

Please fill out the below to ensure your doc gets quickly approved and merged.

## Description

This just lists that `B` is the same as `gasEstimateForL1`. While this is noted lower on in the document and in the tutorial comments, this was not clear to me on a first-time reading of this page. Additionally the units of `gasEstimateForL1` were unclear.

## Document type

<!-- If this PR adds or modifies documentation, specify the document type -->

- [ ] Gentle introduction
- [ ] Quickstart
- [ ] How-to
- [ ] Concept
- [ ] FAQ
- [ ] Troubleshooting
- [x] Reference
- [ ] Third-party content
- [ ] Not applicable

## Checklist

<!-- Mark completed items with an "x" -->

- [x] I have read the [CONTRIBUTE.md](../CONTRIBUTE.md) guidelines
- [x] My changes follow the style conventions outlined in CONTRIBUTE.md
- [x] I have used sentence-case for titles and headers
- [x] I have used descriptive link text (not "here" or "this")
- [x] I have separated procedural from conceptual content where appropriate
- [ ] I have tested my changes locally with `yarn start` or `yarn build`
- [x] My code follows the existing code style and conventions
- [x] I have added/updated frontmatter for new documents
- [x] I have checked for broken links
- [ ] I have verified that my changes don't break the build
- Third-party docs only: Do you agree to the third-party content policy outlined within [CONTRIBUTE.md](../CONTRIBUTE.md)?
   - [ ] Yes
   - [x] Not applicable

## Additional Notes

<!-- Add any additional notes or context for reviewers -->

