### PR TITLE
Update Teku flag for subscribing to custody subnets

### DIFF
--- a/docs/partials/_client-flags.mdx
+++ b/docs/partials/_client-flags.mdx
@@ -1,9 +1,9 @@
-| Client        | Compatible with Nitro | Required Nitro Flag | Required flag for subscribing to all subnets | Required flag to serve historical blobs               |
-| ------------- | --------------------- | ------------------- | -------------------------------------------- | ----------------------------------------------------- |
-| Prysm         | ✅                    | None                | `--subscribe-all-data-subnets`               | `--blob-retention-epochs`                             |
-| Lighthouse    | ✅                    | None                | `--supernode`                                | `--prune-blobs false` or `--blob-prune-margin-epochs` |
-| Teku          | ✅                    | None                | `--p2p-subscribe-all-custody-subnets-enabled`        | None exists                                           |
-| Lodestar      | ✅                    | None                | `--supernode`                                | `--chain.archiveDataEpochs`                           |
-| Erigon Caplin | ❌                    | N/A                 | N/A                                          | N/A                                                   |
+| Client        | Compatible with Nitro | Required Nitro Flag | Required flag for subscribing to all subnets  | Required flag to serve historical blobs               |
+| ------------- | --------------------- | ------------------- | --------------------------------------------- | ----------------------------------------------------- |
+| Prysm         | ✅                    | None                | `--subscribe-all-data-subnets`                | `--blob-retention-epochs`                             |
+| Lighthouse    | ✅                    | None                | `--supernode`                                 | `--prune-blobs false` or `--blob-prune-margin-epochs` |
+| Teku          | ✅                    | None                | `--p2p-subscribe-all-custody-subnets-enabled` | None exists                                           |
+| Lodestar      | ✅                    | None                | `--supernode`                                 | `--chain.archiveDataEpochs`                           |
+| Erigon Caplin | ❌                    | N/A                 | N/A                                           | N/A                                                   |
 
 For additional information regarding specific client flags visit their docs: [Prysm](https://prysm.offchainlabs.com/docs/learn/concepts/blobs), [Lighthouse](https://lighthouse-book.sigmaprime.io/advanced_blobs.html), [Teku](https://docs.teku.consensys.io/concepts/proto-danksharding#what-are-blobs), and [Lodestar](https://chainsafe.github.io/lodestar/run/beacon-management/beacon-cli/).


### PR DESCRIPTION
Thank you for contributing to our docs!


## Description

Based on feedback from the Teku team, they've suggested we replace the flag we recommend with `p2p-subscribe-all-custody-subnets-enabled` as this new flag ensures the Teku client subscribes to every data subnet.

## Document type

<!-- If this PR adds or modifies documentation, specify the document type -->

- [ ] Gentle introduction
- [ ] Quickstart
- [X] How-to
- [ ] Concept
- [ ] FAQ
- [ ] Troubleshooting
- [X] Reference
- [ ] Third-party content
- [ ] Not applicable

## Checklist

<!-- Mark completed items with an "x" -->

- [X] I have read the [CONTRIBUTE.md](../CONTRIBUTE.md) guidelines
- [X] My changes follow the style conventions outlined in CONTRIBUTE.md
- [X] I have used sentence-case for titles and headers
- [X] I have used descriptive link text (not "here" or "this")
- [X] I have separated procedural from conceptual content where appropriate
- [X] I have tested my changes locally with `yarn start` or `yarn build`
- [X] My code follows the existing code style and conventions
- [X] I have added/updated frontmatter for new documents
- [ ] I have checked for broken links
- [ ] I have verified that my changes don't break the build
- Third-party docs only: Do you agree to the third-party content policy outlined within [CONTRIBUTE.md](../CONTRIBUTE.md)?
   - [ ] Yes
   - [X] Not applicable

## Additional Notes

<!-- Add any additional notes or context for reviewers -->

