### PR TITLE
Clean up node providers

### DIFF
--- a/docs/partials/_reference-third-party-rpc-endpoints-partial.mdx
+++ b/docs/partials/_reference-third-party-rpc-endpoints-partial.mdx
@@ -27,10 +27,8 @@ Complete [this form](@@portalApplicationForm=https://docs.google.com/forms/d/e/1
 | [Chainbase](https://docs.chainbase.com/introduction/about)                  | ✅       |           |              | ✅         |                                |
 | [Chainnodes](https://www.chainnodes.org/chains/arbitrum)                    | ✅       |           |              |            |                                |
 | [Chainstack](https://chainstack.com/build-better-with-arbitrum/)            | ✅       |           |              | ✅         | Available on paid plans        |
-| [DataHub](https://datahub.figment.io/)                                      | ✅       |           |              |            |                                |
 | [dRPC](https://drpc.org/public-endpoints/arbitrum)                          | ✅       | ✅        | ✅           | ✅         |                                |
 | [GetBlock](https://getblock.io/nodes/arb/)                                  | ✅       |           |              | ✅         |                                |
-| [Grove](https://grove.city)                                                 | ✅       |           |              |            |                                |
 | [Infura](https://www.infura.io/networks/ethereum/arbitrum)                  | ✅       |           | ✅           | ✅         | Enabled on request             |
 | [Lava](https://docs.lavanet.xyz/iprpc#arbitrum)                             | ✅       | ✅        |              |            |                                |
 | [Moralis](https://docs.moralis.io/reference/introduction)                   | ✅       |           |              |            |                                |


### PR DESCRIPTION

## Description

This PR removes RPC offerings that have pivoted or don't provide for Arbitrum.
Meant to fix the errors mentioned in https://github.com/OffchainLabs/arbitrum-docs/issues/2933

## Document type


- [ ] Gentle introduction
- [ ] Quickstart
- [ ] How-to
- [ ] Concept
- [ ] FAQ
- [ ] Troubleshooting
- [ ] Reference
- [ ] Third-party content
- [X] Not applicable


