### PR TITLE
remove orbit chain client param from prepare functions

### DIFF
--- a/docs/launch-arbitrum-chain/03-deploy-an-arbitrum-chain/05-deploying-token-bridge.mdx
+++ b/docs/launch-arbitrum-chain/03-deploy-an-arbitrum-chain/05-deploying-token-bridge.mdx
@@ -155,7 +155,6 @@ const txRequest = await createTokenBridgePrepareTransactionRequest({
     rollupOwner: rollupOwner.address,
   },
   parentChainPublicClient,
-  orbitChainPublicClient,
   account: rollupOwner.address,
 });
 
@@ -250,7 +249,6 @@ const orbitChainPublicClient = createPublicClient({
 const setWethGatewayTxRequest = await createTokenBridgePrepareSetWethGatewayTransactionRequest({
   rollup: coreContracts.rollup,
   parentChainPublicClient,
-  orbitChainPublicClient,
   account: rollupOwner.address,
 });
 

--- a/docs/launch-arbitrum-chain/03-deploy-an-arbitrum-chain/deploy-your-first-rollup.mdx
+++ b/docs/launch-arbitrum-chain/03-deploy-an-arbitrum-chain/deploy-your-first-rollup.mdx
@@ -320,7 +320,6 @@ async function main() {
       rollupOwner: rollupOwner.address,
     },
     parentChainPublicClient,
-    chainPublicClient,
     account: rollupOwner.address,
   });
 
@@ -345,7 +344,6 @@ async function main() {
   const setWethTxRequest = await createTokenBridgePrepareSetWethGatewayTransactionRequest({
     rollup: coreContracts.rollup,
     parentChainPublicClient,
-    chainPublicClient,
     account: rollupOwner.address,
   });
   const setWethTxHash = await parentChainPublicClient.sendRawTransaction({

--- a/docs/launch-arbitrum-chain/03-deploy-an-arbitrum-chain/run-testnet-infrastructure-first-rollup.mdx
+++ b/docs/launch-arbitrum-chain/03-deploy-an-arbitrum-chain/run-testnet-infrastructure-first-rollup.mdx
@@ -459,7 +459,6 @@ async function main() {
   const txRequest = await createTokenBridgePrepareTransactionRequest({
     params: { rollup: coreContracts.rollup, rollupOwner: rollupOwner.address },
     parentChainPublicClient,
-    chainPublicClient,
     account: rollupOwner.address,
   });
 
@@ -484,7 +483,6 @@ async function main() {
   const setWethTxRequest = await createTokenBridgePrepareSetWethGatewayTransactionRequest({
     rollup: coreContracts.rollup,
     parentChainPublicClient,
-    chainPublicClient,
     account: rollupOwner.address,
   });
   const setWethTxHash = await parentChainPublicClient.sendRawTransaction({


### PR DESCRIPTION
## Description

remove orbit chain client param from prepare functions

createTokenBridgePrepareTransactionRequest and
createTokenBridgePrepareSetWethGatewayTransactionRequest no longer accept an orbit chain public client parameter. Retryable gas is now estimated from parent chain state only.


## Checklist

<!-- Mark completed items with an "x" -->

- [x] I have read the [CONTRIBUTE.md](../CONTRIBUTE.md) guidelines
- [x] My changes follow the style conventions outlined in CONTRIBUTE.md
- [x] I have used sentence-case for titles and headers
- [x] I have used descriptive link text (not "here" or "this")
- [x] I have separated procedural from conceptual content where appropriate
- [x] I have tested my changes locally with `yarn start` or `yarn build`
- [x] My code follows the existing code style and conventions
- [x] I have added/updated frontmatter for new documents
- [x] I have checked for broken links
- [x] I have verified that my changes don't break the build
- Third-party docs only: Do you agree to the third-party content policy outlined within [CONTRIBUTE.md](../CONTRIBUTE.md)?
   - [ ] Yes
   - [x] Not applicable

## Additional Notes

Blocked by https://github.com/OffchainLabs/arbitrum-chain-sdk/pull/662