### PR TITLE
Removed cat command and WASM build target

### DIFF
--- a/docs/stylus/quickstart.mdx
+++ b/docs/stylus/quickstart.mdx
@@ -95,27 +95,6 @@ In your terminal, run:
 cargo install --force cargo-stylus
 ```
 
-We'll add WASM ([WebAssembly](https://webassembly.org/)) as a build target by pinning a project-local Rust toolchain in `rust-toolchain.toml`.
-
-### Creating a project
-
-Let's create our first Stylus project by running:
-
-```shell
-cargo stylus new <YOUR_PROJECT_NAME>
-cd <YOUR_PROJECT_NAME>
-```
-
-Create a project-local Rust toolchain file:
-
-```shell
-cat <<'EOF' > rust-toolchain.toml
-[toolchain]
-channel = "stable"
-targets = ["wasm32-unknown-unknown"]
-EOF
-```
-
 You can verify that cargo stylus is installed by running `cargo stylus --help` in your terminal, which will return a list of helpful commands; we will use some of them in this guide:
 
 ```shell title="cargo stylus --help returns:"
@@ -140,6 +119,15 @@ Commands:
 Options:
   -h, --help     Print help
   -V, --version  Print version
+```
+
+### Creating a project
+
+Let's create our first Stylus project by running:
+
+```shell
+cargo stylus new <YOUR_PROJECT_NAME>
+cd <YOUR_PROJECT_NAME>
 ```
 
 `cargo stylus new` generates a starter template that implements a Rust version of the Solidity `Counter` smart contract example:


### PR DESCRIPTION
Thank you for contributing to our docs!

Please fill out the below to ensure your doc gets quickly approved and merged.

## Description
Edited `docs/stylus/quickstart.mdx`

`rust-toolchain.toml` is auto generated with `cargo stylus new` so the cat command step is no longer needed. Along with removing the WASM build target step since running a `cargo stylus` commands will install `wasm32-unknown-unknown` if not detected (not 100% sure but I fiddled around a lot with commands and removing the build target and it would re install it on its own without hitting errors)

Also changed the order in which the information was presented, now it says to run `cargo stylus --help` right after running `cargo install --force cargo-stylus` to check if the install was successful instead of trying to create a new project via `cargo stylus new` and then running `cargo stylus --help`

## Document type

<!-- If this PR adds or modifies documentation, specify the document type -->

- [ ] Gentle introduction
- [x] Quickstart
- [ ] How-to
- [ ] Concept
- [ ] FAQ
- [ ] Troubleshooting
- [ ] Reference
- [ ] Third-party content
- [ ] Not applicable

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] I have read the [CONTRIBUTE.md](../CONTRIBUTE.md) guidelines
- [ ] My changes follow the style conventions outlined in CONTRIBUTE.md
- [ ] I have used sentence-case for titles and headers
- [ ] I have used descriptive link text (not "here" or "this")
- [ ] I have separated procedural from conceptual content where appropriate
- [ ] I have tested my changes locally with `yarn start` or `yarn build`
- [ ] My code follows the existing code style and conventions
- [ ] I have added/updated frontmatter for new documents
- [ ] I have checked for broken links
- [ ] I have verified that my changes don't break the build
- Third-party docs only: Do you agree to the third-party content policy outlined within [CONTRIBUTE.md](../CONTRIBUTE.md)?
   - [ ] Yes
   - [ ] Not applicable

## Additional Notes

<!-- Add any additional notes or context for reviewers -->

