### PR TITLE
docs: clarify L1 fees are baked into gas limit (#1267)

### DIFF
--- a/docs/how-arbitrum-works/deep-dives/gas-and-fees.mdx
+++ b/docs/how-arbitrum-works/deep-dives/gas-and-fees.mdx
@@ -1,5 +1,16 @@
 ---
 title: Gas and fees
+description: Learn how gas and fees work on Arbitrum.
+---
+
+:::info L1 Fees are "Baked In"
+Unlike other rollups (e.g., Optimism, Base), Arbitrum does **not** charge a separate L1 fee. Instead, the cost of L1 calldata is automatically calculated and included in your transaction's gas limit. This means the gas limit you see may be higher than the actual L2 gas used – the difference covers L1 security costs. You don't need to do anything manually; the network handles this internally.
+
+> **💡 Tip:** If you're comparing gas costs across chains, remember that Arbitrum's higher gas limit already includes L1 costs – it's not "wasted" gas.
+:::
+
+---
+title: Gas and fees
 description: 'Learn the fundamentals of how to calculate fees on Arbitrum, including parent chain pricing formulas and child chain gas mechanics.'
 author: pete-vielhaber
 sme: TucksonDev


### PR DESCRIPTION
Closes #1267
Summary
This PR addresses the confusion regarding Arbitrum's gas estimation by clarifying that L1 costs are already included ("baked in") to the gas limit, rather than being charged as a separate fee (unlike Optimism or Base).

Changes
Target File: docs/how-arbitrum-works/deep-dives/gas-and-fees.mdx (The core technical reference for gas pricing).

Position: Added a prominent :::info block at the very top of the page for immediate visibility.

Content: Explicitly compares Arbitrum's behavior with other L2s to provide better context for developers migrating to the ecosystem.

Technical Note
This is a clean refactor of my previous contribution. The commit history has been squashed into a single, focused commit to maintain repository standards.

