### PR TITLE
ArbOS 61 upgrade notice  (TW-736)

### DIFF
--- a/docs/notices/arbos60-upgrade-notice.mdx
+++ b/docs/notices/arbos60-upgrade-notice.mdx
@@ -1,8 +1,34 @@
 ---
 title: 'Upgrade notice for ArbOS 60'
-description: Upgrade notices for ArbOS 60 activation on Arbitrum One, Arbitrum Nova, and Arbitrum Spolia
+description: Upgrade notices for ArbOS 60 activation on Arbitrum One, Arbitrum Nova, and Arbitrum Sepolia
 user_story: As an Arbitrum node operator, I want to keep my nodes in sync with Arbitrum One, Arbitrum Nova, and Arbitrum Sepolia after the ArbOS 60 activation.
 content_type: notice
 ---
 
-This is a stub article for the Arbos60 upgrade notice
+[ArbOS 60 "Elara"](docs/run-arbitrum-node/arbos-releases/arbos60.mdx) will be activated on the Arbitrum Sepolia, Arbitrum One, and Arbitrum Nova chains.
+
+## Actions required for node operators
+
+:::warning Action required
+
+Arbitrum node operators **must upgrade** to Nitro **`[TBD]`** ahead of ArbOS 60 activation to continue syncing the chain.
+
+- **Docker image:** `offchainlabs/nitro-node:[TBD]`
+- **Release notes:** https://github.com/OffchainLabs/nitro/releases/tag/[TBD]
+
+:::
+
+## Important dates
+
+The following dates are relevant for Arbitrum chain operators.
+
+| Date    | Network upgrade                       | Affected audience                    |
+| ------- | ------------------------------------- | ------------------------------------ |
+| `[TBD]` | Arbitrum Sepolia upgrade to ArbOS 60  | Node operators for Arbitrum Sepolia  |
+| `[TBD]` | Arbitrum One/Nova upgrade to ArbOS 60 | Node operators for Arbitrum One/Nova |
+
+## Context
+
+[ArbOS 60 "Elara"](docs/run-arbitrum-node/arbos-releases/arbos60.mdx) builds upon [ArbOS 51 "Dia"](docs/run-arbitrum-node/arbos-releases/arbos51.mdx) with the full activation of multi-dimensional constraint-based pricing, a Stylus smart contract size limit increase via a fragment-based deployment model, sanctioned address transaction filtering, a standardized alternative data availability API, and genesis configuration file generation with predeploy support.
+
+The ArbOS 60 on-chain vote was passed **`[TBD]`**.

--- a/docs/notices/arbos60-upgrade-notice.mdx
+++ b/docs/notices/arbos60-upgrade-notice.mdx
@@ -5,30 +5,36 @@ user_story: As an Arbitrum node operator, I want to keep my nodes in sync with A
 content_type: notice
 ---
 
-[ArbOS 60 "Elara"](docs/run-arbitrum-node/arbos-releases/arbos60.mdx) will be activated on the Arbitrum Sepolia, Arbitrum One, and Arbitrum Nova chains.
+ArbOS 60 "Elara" will be activated on the Arbitrum Sepolia, Arbitrum One, and Arbitrum Nova chains.
 
 ## Actions required for node operators
 
-:::warning Action required
+### Sepolia network
 
-Arbitrum node operators **must upgrade** to Nitro **`[TBD]`** ahead of ArbOS 60 activation to continue syncing the chain.
+On Monday, May 18, 2026 at 17:00 UTC, ArbOS 60 is scheduled to activate on the Arbitrum Sepolia chain.
 
-- **Docker image:** `offchainlabs/nitro-node:[TBD]`
-- **Release notes:** https://github.com/OffchainLabs/nitro/releases/tag/[TBD]
+Arbitrum Sepolia node operators must upgrade to Nitro v3.10 ahead of this activation to continue syncing the chain.
 
-:::
+- **Docker image:** [offchainlabs/nitro-node:v3.10.0-b1cf6db](https://hub.docker.com/layers/offchainlabs/nitro-node/v3.10.0-b1cf6db/images/sha256-9a15d6c581eadbfd440cc74f26fda9c27a1cddd0b77f93e395e4d29678414284)
+- **Release notes:** https://github.com/OffchainLabs/nitro/releases/tag/v3.10.0
 
 ## Important dates
 
 The following dates are relevant for Arbitrum chain operators.
 
-| Date    | Network upgrade                       | Affected audience                    |
-| ------- | ------------------------------------- | ------------------------------------ |
-| `[TBD]` | Arbitrum Sepolia upgrade to ArbOS 60  | Node operators for Arbitrum Sepolia  |
-| `[TBD]` | Arbitrum One/Nova upgrade to ArbOS 60 | Node operators for Arbitrum One/Nova |
+| Date                              | Network upgrade                      | Affected audience                       |
+| --------------------------------- | ------------------------------------ | --------------------------------------- |
+| Monday, May 18, 2026 at 17:00 UTC | Arbitrum Sepolia upgrade to ArbOS 60 | Node operators running Arbitrum Sepolia |
 
 ## Context
 
-[ArbOS 60 "Elara"](docs/run-arbitrum-node/arbos-releases/arbos60.mdx) builds upon [ArbOS 51 "Dia"](docs/run-arbitrum-node/arbos-releases/arbos51.mdx) with the full activation of multi-dimensional constraint-based pricing, a Stylus smart contract size limit increase via a fragment-based deployment model, sanctioned address transaction filtering, a standardized alternative data availability API, and genesis configuration file generation with predeploy support.
+ArbOS 60 "Elara" builds upon [ArbOS 51 "Dia"](docs/run-arbitrum-node/arbos-releases/arbos51.mdx), it introduces a set of protocol upgrades to Arbitrum One and Nova, including support for Dynamic Pricing (multidimensional gas pricing), increased Stylus contract size limits, and new mechanisms for managing minimum base fees.
 
-The ArbOS 60 on-chain vote was passed **`[TBD]`**.
+<VanillaAdmonition>
+  While Dynamic Pricing is included in this release, it will remain disabled at the time of
+  activation. This is because ongoing analyses - led by Offchain Labs in collaboration with Entropy
+  Advisors- have not yet finalized the appropriate gas target parameters required for safe and
+  effective enablement.
+</VanillaAdmonition>
+
+The ArbOS 60 governance temperature check has already passed successfully. Upstream governance for ArbOS 60 follows the standard process, including Snapshot temperature checks and an on-chain vote prior to activation on Arbitrum One and Nova.

--- a/docs/notices/arbos61-upgrade-notice.mdx
+++ b/docs/notices/arbos61-upgrade-notice.mdx
@@ -1,0 +1,40 @@
+---
+title: 'Upgrade notice for ArbOS 61'
+description: Upgrade notices for ArbOS 61 activation on Arbitrum One, Arbitrum Nova, and Arbitrum Sepolia
+user_story: As an Arbitrum node operator, I want to keep my nodes in sync with Arbitrum One, Arbitrum Nova, and Arbitrum Sepolia after the ArbOS 61 activation.
+content_type: notice
+---
+
+ArbOS 61 "Elara" will be activated on the Arbitrum Sepolia, Arbitrum One, and Arbitrum Nova chains.
+
+## Actions required for node operators
+
+### Sepolia network
+
+On Monday, May 18, 2026 at 17:00 UTC, ArbOS 61 is scheduled to activate on the Arbitrum Sepolia chain.
+
+Arbitrum Sepolia node operators must upgrade to Nitro v3.10 ahead of this activation to continue syncing the chain.
+
+- **Docker image:** [offchainlabs/nitro-node:v3.10.0-b1cf6db](https://hub.docker.com/layers/offchainlabs/nitro-node/v3.10.0-b1cf6db/images/sha256-9a15d6c581eadbfd440cc74f26fda9c27a1cddd0b77f93e395e4d29678414284)
+- **Release notes:** https://github.com/OffchainLabs/nitro/releases/tag/v3.10.0
+
+## Important dates
+
+The following dates are relevant for Arbitrum chain operators.
+
+| Date                              | Network upgrade                      | Affected audience                       |
+| --------------------------------- | ------------------------------------ | --------------------------------------- |
+| Monday, May 18, 2026 at 17:00 UTC | Arbitrum Sepolia upgrade to ArbOS 61 | Node operators running Arbitrum Sepolia |
+
+## Context
+
+ArbOS 61 "Elara" builds upon [ArbOS 51 "Dia"](docs/run-arbitrum-node/arbos-releases/arbos51.mdx), it introduces a set of protocol upgrades to Arbitrum One and Nova, including support for Dynamic Pricing (multidimensional gas pricing), increased Stylus contract size limits, and new mechanisms for managing minimum base fees.
+
+<VanillaAdmonition>
+  While Dynamic Pricing is included in this release, it will remain disabled at the time of
+  activation. This is because ongoing analyses - led by Offchain Labs in collaboration with Entropy
+  Advisors- have not yet finalized the appropriate gas target parameters required for safe and
+  effective enablement.
+</VanillaAdmonition>
+
+The ArbOS 61 governance temperature check has already passed successfully. Upstream governance for ArbOS 61 follows the standard process, including Snapshot temperature checks and an on-chain vote prior to activation on Arbitrum One and Nova.

--- a/sidebars.js
+++ b/sidebars.js
@@ -1924,6 +1924,11 @@ const sidebars = {
   noticeSidebar: [
     {
       type: 'doc',
+      id: 'notices/arbos61-upgrade-notice',
+      label: 'Upgrade notice for ArbOS 61',
+    },
+    {
+      type: 'doc',
       id: 'notices/arbos60-upgrade-notice',
       label: 'Upgrade notice for ArbOS 60',
     },


### PR DESCRIPTION
## Description

Expands the ArbOS 60 upgrade notice from a one-line stub to the full structure matching `arbos51-upgrade-notice.mdx`. All version- and date-sensitive fields use `[TBD]` placeholders — per Derek's scratchpad, shipping placeholders before the DAO vote outcome is explicitly acceptable.

Structure:

- Intro paragraph
- Actions required admonition (Nitro version, Docker image, release notes — all `[TBD]`)
- Important dates table (Sepolia + One/Nova, dates `[TBD]`)
- Context paragraph summarizing the 5 feature areas

- Linear: [TW-736](https://linear.app/offchain-labs/issue/TW-736)
- Notion drafting page: https://www.notion.so/arbitrum/30d01a3f59f880ac91dbfcc89602eab9
- Template: `docs/notices/arbos51-upgrade-notice.mdx`

## Document type

- [ ] Gentle introduction
- [ ] Quickstart
- [ ] How-to
- [ ] Concept
- [ ] FAQ
- [ ] Troubleshooting
- [ ] Reference
- [ ] Third-party content
- [x] Not applicable (notice)

## Checklist

- [x] I have read the [CONTRIBUTE.md](../CONTRIBUTE.md) guidelines
- [x] My changes follow the style conventions outlined in CONTRIBUTE.md
- [x] I have used sentence-case for titles and headers
- [x] I have used descriptive link text (not \"here\" or \"this\")
- [x] I have separated procedural from conceptual content where appropriate
- [ ] I have tested my changes locally — Vercel preview will verify build
- [x] My code follows the existing code style and conventions
- [x] I have added/updated frontmatter for new documents
- [x] I have checked for broken links — relative paths match existing arbos51 notice pattern
- [ ] I have verified that my changes don't break the build — pending Vercel preview
- Third-party docs only:
  - [ ] Yes
  - [x] Not applicable

## Additional Notes

- **DRAFT** — all `[TBD]` markers to be filled when DAO vote outcome + activation dates are known.
- Targets \`Arbos60\` staging branch, not \`master\`.
- File is already registered in \`sidebars.js:1927\` on \`Arbos60\`, so no sidebar changes needed.
- Once Nitro version, Docker tag, release-notes URL, and activation dates are finalized, update this PR and mark ready for review.