### PR TITLE
docs: 3.9.9-broken-links-descriptions

### DIFF
--- a/docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbDebug.mdx
+++ b/docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbDebug.mdx
@@ -237,7 +237,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.9.9/precompiles/ArbDebug.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.9.9/precompiles/ArbDebug.go#L19"
           target="_blank"
         >
           Implementation

--- a/docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwner.mdx
+++ b/docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwner.mdx
@@ -116,7 +116,11 @@
           Implementation
         </a>
       </td>
-      <td>future.</td>
+      <td>
+        SetNativeTokenManagementFrom sets a time in epoch seconds when the native token management
+        becomes enabled. Setting it to 0 disables the feature. If the feature is disabled, then the
+        time must be at least 7 days in the future.
+      </td>
     </tr>
     <tr>
       <td>
@@ -844,7 +848,9 @@
           Implementation
         </a>
       </td>
-      <td>decompression.</td>
+      <td>
+        SetMaxWasmSize sets the maximum size the wasm code can be in bytes after decompression.
+      </td>
     </tr>
     <tr>
       <td>
@@ -1042,7 +1048,9 @@
           Implementation
         </a>
       </td>
-      <td>(EIP-7623)</td>
+      <td>
+        SetCalldataPriceIncrease sets the increased calldata price feature on or off (EIP-7623)
+      </td>
     </tr>
     <tr>
       <td>
@@ -1143,7 +1151,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.9.9/precompiles/ArbOwner.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.9.9/precompiles/ArbOwner.go#L27"
           target="_blank"
         >
           Implementation

--- a/docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwnerPublic.mdx
+++ b/docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbOwnerPublic.mdx
@@ -94,7 +94,10 @@
           Implementation
         </a>
       </td>
-      <td>native token management becomes enabled</td>
+      <td>
+        GetNativeTokenMangementFrom returns the time in epoch seconds when the native token
+        management becomes enabled
+      </td>
     </tr>
     <tr>
       <td>
@@ -273,7 +276,10 @@
           Implementation
         </a>
       </td>
-      <td>(EIP-7623) is enabled</td>
+      <td>
+        IsCalldataPriceIncreaseEnabled checks if the increased calldata price feature (EIP-7623) is
+        enabled
+      </td>
     </tr>
   </tbody>
 </table>

--- a/docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbRetryableTx.mdx
+++ b/docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbRetryableTx.mdx
@@ -217,7 +217,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.9.9/precompiles/ArbRetryableTx.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.9.9/precompiles/ArbRetryableTx.go#L22"
           target="_blank"
         >
           Implementation
@@ -305,7 +305,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.9.9/precompiles/ArbRetryableTx.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.9.9/precompiles/ArbRetryableTx.go#L32"
           target="_blank"
         >
           Implementation

--- a/docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbSys.mdx
+++ b/docs/for-devs/dev-tools-and-resources/partials/precompile-tables/_ArbSys.mdx
@@ -326,7 +326,7 @@
       </td>
       <td>
         <a
-          href="https://github.com/OffchainLabs/nitro/blob/v3.9.9/precompiles/ArbSys.go#L0"
+          href="https://github.com/OffchainLabs/nitro/blob/v3.9.9/precompiles/ArbSys.go#L30"
           target="_blank"
         >
           Implementation


### PR DESCRIPTION
- Fixing a few broken links, and half descriptions that were pulled in