### PR TITLE
Improve LLM/AI agent access to docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -61,6 +61,22 @@ const handleInkeepEvent = (event) => {
   }
 };
 
+// Routes that exist in the Docusaurus build but aren't standalone, indexable pages.
+// Shared between the sitemap and llms.txt so both indexes stay in sync.
+const nonCanonicalRoutePatterns = [
+  '/sdk/assetBridger/**',
+  '/sdk/dataEntities/**',
+  '/sdk/inbox/**',
+  '/sdk/message/**',
+  '/sdk/utils/**',
+  '/hosted-pdfs/**',
+  // Partials are imported into other pages, not standalone content.
+  // Docusaurus generates routes for them anyway.
+  '**/_*', // Docusaurus partial convention
+  '**/partials/**', // non-underscored partials in this repo's partials/ dirs
+  '/category/**', // auto-generated category index pages
+];
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Arbitrum Docs',
@@ -140,6 +156,9 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/custom.scss'),
         },
+        sitemap: {
+          ignorePatterns: nonCanonicalRoutePatterns,
+        },
       }),
     ],
   ],
@@ -192,20 +211,7 @@ const config = {
           includeDocs: true,
           includeBlog: false,
           includePages: false,
-          excludeRoutes: [
-            '/sdk/assetBridger/**',
-            '/sdk/dataEntities/**',
-            '/sdk/inbox/**',
-            '/sdk/message/**',
-            '/sdk/utils/**',
-            '/hosted-pdfs/**',
-            // Internal building blocks (imported into other pages),
-            // not standalone content. Docusaurus generates routes for
-            // them anyway, but they shouldn't appear in llms.txt.
-            '**/_*', // Docusaurus partial convention
-            '**/partials/**', // non-underscored partials in this repo's partials/ dirs
-            '/category/**', // auto-generated category index pages
-          ],
+          excludeRoutes: nonCanonicalRoutePatterns,
           beforeDefaultRehypePlugins: [require('./src/plugins/rehype-llms-cleanup')],
           beforeDefaultRemarkPlugins: [require('./src/plugins/remark-llms-cleanup')],
         },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -213,7 +213,10 @@ const config = {
           includePages: false,
           excludeRoutes: nonCanonicalRoutePatterns,
           beforeDefaultRehypePlugins: [require('./src/plugins/rehype-llms-cleanup')],
-          beforeDefaultRemarkPlugins: [require('./src/plugins/remark-llms-cleanup')],
+          beforeDefaultRemarkPlugins: [
+            require('./src/plugins/remark-llms-cleanup'),
+            require('./src/plugins/remark-llms-page-header'),
+          ],
         },
       },
     ],

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,19 @@
+import { rewrite, next } from '@vercel/edge';
+
+// Runs before Vercel's filesystem lookup, so we can serve the .md variant of a
+// doc page when an agent requests `Accept: text/markdown`. The matcher excludes
+// paths containing a dot (static assets, sitemap.xml, direct .md requests, etc.)
+// so the rewrite only applies to clean-URL doc paths.
+export const config = {
+  matcher: '/((?!.*\\.).*)',
+};
+
+export default function middleware(request: Request) {
+  const accept = request.headers.get('accept') ?? '';
+  if (!accept.includes('text/markdown')) return next();
+
+  const url = new URL(request.url);
+  const path = url.pathname.replace(/\/$/, '');
+  url.pathname = path === '' ? '/index.md' : `${path}.md`;
+  return rewrite(url);
+}

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/mdx": "^2.0.11",
     "@types/prismjs": "^1.26.5",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "@vercel/edge": "1.3.1",
     "classnames": "^2.5.1",
     "clsx": "^2.1.1",
     "d3": "^7.9.0",

--- a/src/plugins/remark-llms-page-header.js
+++ b/src/plugins/remark-llms-page-header.js
@@ -1,0 +1,22 @@
+const INDEX_URL = 'https://docs.arbitrum.io/llms.txt';
+
+module.exports = function remarkLlmsPageHeader() {
+  return (tree) => {
+    tree.children.unshift({
+      type: 'blockquote',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', value: 'For a complete page index, fetch ' },
+            {
+              type: 'link',
+              url: INDEX_URL,
+              children: [{ type: 'text', value: INDEX_URL }],
+            },
+          ],
+        },
+      ],
+    });
+  };
+};

--- a/src/theme/Layout.tsx
+++ b/src/theme/Layout.tsx
@@ -28,6 +28,10 @@ export default function Layout(props) {
         <meta name="twitter:description" content="Arbitrum Docs" />
         <meta name="twitter:image" content="https://developer.arbitrum.io/img/devdocs.png" />
       </Head>
+      <div className="sr-only" aria-hidden="true">
+        For AI agents: a documentation index is available at the root level at /llms.txt and
+        /llms-full.txt. Append .md to any URL for the markdown version of that page.
+      </div>
       {/* <PostHogProvider> */}
       <OriginalLayout {...props} />
       {/* </PostHogProvider> */}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,13 @@
       "@site/*": ["./*"]
     }
   },
-  "exclude": ["submodules", "stylus-by-example", "node_modules", "build", ".docusaurus", "*.js"]
+  "exclude": [
+    "submodules",
+    "stylus-by-example",
+    "node_modules",
+    "build",
+    ".docusaurus",
+    "*.js",
+    "middleware.ts"
+  ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -2411,18 +2411,6 @@
       "permanent": false
     }
   ],
-  "rewrites": [
-    {
-      "source": "/",
-      "has": [{ "type": "header", "key": "accept", "value": ".*text/markdown.*" }],
-      "destination": "/index.md"
-    },
-    {
-      "source": "/:path+",
-      "has": [{ "type": "header", "key": "accept", "value": ".*text/markdown.*" }],
-      "destination": "/:path.md"
-    }
-  ],
   "headers": [
     {
       "source": "/",

--- a/vercel.json
+++ b/vercel.json
@@ -2410,5 +2410,27 @@
       "destination": "/how-arbitrum-works/deep-dives/transaction-lifecycle",
       "permanent": false
     }
+  ],
+  "rewrites": [
+    {
+      "source": "/",
+      "has": [{ "type": "header", "key": "accept", "value": ".*text/markdown.*" }],
+      "destination": "/index.md"
+    },
+    {
+      "source": "/:path([^.]+)",
+      "has": [{ "type": "header", "key": "accept", "value": ".*text/markdown.*" }],
+      "destination": "/:path.md"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/",
+      "headers": [{ "key": "Vary", "value": "Accept" }]
+    },
+    {
+      "source": "/:path([^.]+)",
+      "headers": [{ "key": "Vary", "value": "Accept" }]
+    }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -2418,7 +2418,7 @@
       "destination": "/index.md"
     },
     {
-      "source": "/:path([^.]+)+",
+      "source": "/:path+",
       "has": [{ "type": "header", "key": "accept", "value": ".*text/markdown.*" }],
       "destination": "/:path.md"
     }
@@ -2429,7 +2429,7 @@
       "headers": [{ "key": "Vary", "value": "Accept" }]
     },
     {
-      "source": "/:path([^.]+)+",
+      "source": "/:path+",
       "headers": [{ "key": "Vary", "value": "Accept" }]
     }
   ]

--- a/vercel.json
+++ b/vercel.json
@@ -2418,7 +2418,7 @@
       "destination": "/index.md"
     },
     {
-      "source": "/:path([^.]+)",
+      "source": "/:path([^.]+)+",
       "has": [{ "type": "header", "key": "accept", "value": ".*text/markdown.*" }],
       "destination": "/:path.md"
     }
@@ -2429,7 +2429,7 @@
       "headers": [{ "key": "Vary", "value": "Accept" }]
     },
     {
-      "source": "/:path([^.]+)",
+      "source": "/:path([^.]+)+",
       "headers": [{ "key": "Vary", "value": "Accept" }]
     }
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -6125,6 +6125,11 @@
     d3-selection "^3.0.0"
     d3-transition "^3.0.1"
 
+"@vercel/edge@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@vercel/edge/-/edge-1.3.1.tgz#e650acafcbb82603161685a55dda459368e1800a"
+  integrity sha512-k0tKWeYEWOv6qU6+Z8+hv2Nt/u3vFHRZdB0uvwE0DxoddU/5kWX/Chu8F6ojvqmRlnZwuX/7kyZFVeCP6DxqBg==
+
 "@webassemblyjs/ast@1.12.1", "@webassemblyjs/ast@^1.12.1":
   version "1.12.1"
   resolved "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz"


### PR DESCRIPTION
## Summary

- **Tighten sitemap** so it indexes the same canonical pages as `llms.txt` — partials, auto-generated category pages, and SDK API internals are now excluded from both indexes via a shared pattern list. Drops sitemap entries from 503 to 275.
- **Surface `llms.txt` to AI agents on every page**: a screen-reader-only div in the layout points to `/llms.txt`, `/llms-full.txt`, and the `.md` variant of any URL. A remark plugin prepends a `> For a complete page index, fetch <https://docs.arbitrum.io/llms.txt>` blockquote to every per-page `.md` and every section in `llms-full.txt`.
- **Content negotiation via Vercel**: requests with `Accept: text/markdown` are rewritten to the `.md` file (`/foo` → `/foo.md`, `/` → `/index.md`). Paths containing dots pass through unchanged so static assets and direct `.md` requests aren't affected. `Vary: Accept` is set on the same routes so CDN/browser caches don't conflate the two representations.

## Test plan

- [ ] On a preview deploy, fetch a doc page with `curl -H 'Accept: text/markdown' <url>` and confirm it returns the markdown body
- [ ] Same request without that header returns the HTML page
- [ ] Each preview-deploy doc page contains `For a complete page index` in the markdown output (`curl <url>.md | head -3`)
- [ ] Sitemap at `<url>/sitemap.xml` no longer contains `/partials/`, `/category/`, or `/sdk/(assetBridger|dataEntities|inbox|message|utils)/` entries
- [ ] View page source on a deployed page and confirm the `sr-only` notice div is present and not visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)