### PR TITLE
Close LLM-readiness gaps: discovery tags, Optional trim, intent doc

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -63,6 +63,12 @@ const handleInkeepEvent = (event) => {
 
 // Routes that exist in the Docusaurus build but aren't standalone, indexable pages.
 // Shared between the sitemap and llms.txt so both indexes stay in sync.
+//
+// As a result, llms.txt covers ~55% of the sitemap on purpose — the missing
+// ~228 routes are SDK auto-generated helpers, partials imported into other
+// pages, Docusaurus auto-category index pages, and hosted PDFs. None are
+// user-facing content. Don't lower this bar without checking what's leaking
+// in.
 const nonCanonicalRoutePatterns = [
   '/sdk/assetBridger/**',
   '/sdk/dataEntities/**',
@@ -205,6 +211,30 @@ const config = {
         siteTitle: 'Arbitrum Documentation',
         siteDescription:
           'Official documentation for the Arbitrum ecosystem: building apps, bridging tokens, running nodes, launching Arbitrum chains, and developing with Stylus.',
+        // Top-level section order in llms.txt — patterns listed first appear
+        // first; anything unmatched falls to the end alphabetically.
+        includeOrder: [
+          '/get-started/**',
+          '/intro/**',
+          '/build-decentralized-apps/**',
+          '/stylus/**',
+          '/stylus-by-example/**',
+          '/launch-arbitrum-chain/**',
+          '/run-arbitrum-node/**',
+          '/node-running/**',
+          '/sdk/**',
+          '/arbitrum-bridge/**',
+          '/how-arbitrum-works/**',
+          '/audit-reports*',
+          // Anything below this point becomes Optional via categoryName override.
+          '/for-devs/**',
+          '/learn-more/**',
+          '/notices/**',
+        ],
+        // Rename raw directory names to user-facing labels; group deferrable
+        // content under "Optional" per the llmstxt.org spec. The custom
+        // remark-llms-toc-tidy plugin merges the multiple ## Optional
+        // sections into a single one at the end of the TOC.
         content: {
           enableMarkdownFiles: true,
           enableLlmsFullTxt: true,
@@ -212,6 +242,31 @@ const config = {
           includeBlog: false,
           includePages: false,
           excludeRoutes: nonCanonicalRoutePatterns,
+          routeRules: [
+            { route: '/get-started/**', categoryName: 'Get started' },
+            { route: '/intro/**', categoryName: 'Introduction' },
+            {
+              route: '/build-decentralized-apps/**',
+              categoryName: 'Build apps with Solidity',
+            },
+            { route: '/stylus/**', categoryName: 'Build with Stylus' },
+            { route: '/stylus-by-example/**', categoryName: 'Stylus by example' },
+            {
+              route: '/launch-arbitrum-chain/**',
+              categoryName: 'Launch an Arbitrum chain',
+            },
+            { route: '/run-arbitrum-node/**', categoryName: 'Run an Arbitrum node' },
+            { route: '/node-running/**', categoryName: 'Node running' },
+            { route: '/sdk/**', categoryName: 'SDK reference' },
+            { route: '/arbitrum-bridge/**', categoryName: 'Arbitrum bridge' },
+            { route: '/how-arbitrum-works/**', categoryName: 'How Arbitrum works' },
+            { route: '/audit-reports', categoryName: 'Security audit reports' },
+            // Deferrable content — collapsed into a single ## Optional by
+            // remark-llms-toc-tidy.
+            { route: '/for-devs/**', categoryName: 'Optional' },
+            { route: '/learn-more/**', categoryName: 'Optional' },
+            { route: '/notices/**', categoryName: 'Optional' },
+          ],
           beforeDefaultRehypePlugins: [require('./src/plugins/rehype-llms-cleanup')],
           beforeDefaultRemarkPlugins: [
             require('./src/plugins/remark-llms-cleanup'),

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "yarn && yarn clear && docusaurus start",
     "build-glossary": "tsx scripts/build-glossary.ts",
     "build-translation": "yarn tsx ./scripts/move-untranslated-files.ts",
-    "build": "yarn && yarn clear && docusaurus build",
+    "build": "yarn && yarn clear && docusaurus build && node scripts/tidy-llms-txt.js",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/scripts/tidy-llms-txt.js
+++ b/scripts/tidy-llms-txt.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// Post-build tidy pass on build/llms.txt:
+//   1. Remove the floating root `- [Arbitrum Documentation](/index.md)` link
+//      that duplicates the H1 with no added context.
+//   2. Merge multiple "## Optional" H2 sections into a single one at the end
+//      of the file, per the llmstxt.org convention for skippable content.
+//   3. Strip ": description" from list items inside the merged Optional
+//      section. These items are explicitly skippable; bare title+URL is
+//      enough and keeps the file under the 50KB readiness threshold.
+//
+// The signalwire plugin's remark/rehype hooks operate on individual page
+// content, not on the aggregate llms.txt — so this work happens after the
+// docusaurus build completes.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const LLMS_TXT_PATH = path.join(__dirname, '..', 'build', 'llms.txt');
+const OPTIONAL_HEADING = '## Optional';
+const ROOT_INDEX_LINK_RE = /^- \[[^\]]+\]\(\/index\.md\)\s*$/m;
+
+function tidy(source) {
+  let out = source;
+
+  // 1. Drop the bare root-index link. The H1 already conveys the project name,
+  // so the duplicate entry adds nothing.
+  out = out.replace(ROOT_INDEX_LINK_RE, '').replace(/\n{3,}/g, '\n\n');
+
+  // 2. Merge "## Optional" sections.
+  // Split on H2 boundaries. Each chunk starts with a "## <Label>\n" header
+  // except possibly the first (preamble before any H2).
+  const chunks = out.split(/^(## .*)$/m);
+  // chunks: [preamble, "## A", bodyA, "## B", bodyB, ...]
+
+  const merged = { preamble: chunks[0], sections: [], optionalBodies: [] };
+  for (let i = 1; i < chunks.length; i += 2) {
+    const heading = chunks[i];
+    const body = chunks[i + 1] ?? '';
+    if (heading.trim() === OPTIONAL_HEADING) {
+      merged.optionalBodies.push(body);
+    } else {
+      merged.sections.push({ heading, body });
+    }
+  }
+
+  let result = merged.preamble;
+  for (const { heading, body } of merged.sections) {
+    result += heading + body;
+  }
+
+  if (merged.optionalBodies.length > 0) {
+    // Each Optional body already starts/ends with whitespace from the split.
+    // Trim/normalize to keep the joined output clean.
+    const combined = merged.optionalBodies
+      .map((b) => b.replace(/^\s+|\s+$/g, ''))
+      .filter(Boolean)
+      .join('\n');
+    // Drop descriptions from list items in the Optional section. Match the
+    // bullet+link prefix non-greedily, then a literal ": " and everything to
+    // EOL. The bracket-balance regex assumes link text contains no ']' chars
+    // (true in practice for our entries).
+    const stripped = combined.replace(/^(- \[[^\]]*\]\([^)]*\)): .*$/gm, '$1');
+    // Ensure the rest of the file ends with a clean newline before appending.
+    if (!result.endsWith('\n')) result += '\n';
+    if (!result.endsWith('\n\n')) result += '\n';
+    result += `${OPTIONAL_HEADING}\n\n${stripped}\n`;
+  }
+
+  return result;
+}
+
+function main() {
+  if (!fs.existsSync(LLMS_TXT_PATH)) {
+    console.error(`tidy-llms-txt: ${LLMS_TXT_PATH} not found; skipping.`);
+    return;
+  }
+  const source = fs.readFileSync(LLMS_TXT_PATH, 'utf8');
+  const tidied = tidy(source);
+  if (tidied === source) {
+    console.log('tidy-llms-txt: no changes needed.');
+    return;
+  }
+  fs.writeFileSync(LLMS_TXT_PATH, tidied);
+  console.log(`tidy-llms-txt: rewrote ${LLMS_TXT_PATH}`);
+}
+
+main();

--- a/src/theme/Layout.tsx
+++ b/src/theme/Layout.tsx
@@ -4,6 +4,13 @@ import Head from '@docusaurus/Head';
 import { useLocation } from '@docusaurus/router';
 // import { PostHogProvider } from '@site/src/components/PostHogProvider';
 
+// Mirror middleware.ts: stripped trailing slash + ".md", except the root
+// "/" maps to "/index.md" (which is where the root page's companion lives).
+const mdAlternateHref = (pathname: string): string => {
+  const stripped = pathname.replace(/\/$/, '');
+  return stripped === '' ? '/index.md' : `${stripped}.md`;
+};
+
 const pathNameToPreviewText = (pathName: string) => {
   const splitPaths = pathName.split('/').filter((x) => x);
   const probablyID = splitPaths[splitPaths.length - 1];
@@ -27,6 +34,18 @@ export default function Layout(props) {
         <meta name="twitter:title" content={previewText || 'Arbitrum Docs!'} />
         <meta name="twitter:description" content="Arbitrum Docs" />
         <meta name="twitter:image" content="https://developer.arbitrum.io/img/devdocs.png" />
+        {/*
+          LLM-discovery hints. The .md companion is served either by appending
+          `.md` to any path or by sending `Accept: text/markdown` (see
+          middleware.ts). /llms.txt is the spec-aligned site index.
+        */}
+        <link rel="alternate" type="text/markdown" href={mdAlternateHref(pathname)} />
+        <link
+          rel="alternate"
+          type="text/llms.txt"
+          href="/llms.txt"
+          title="LLM-friendly site index"
+        />
       </Head>
       <div className="sr-only" aria-hidden="true">
         For AI agents: a documentation index is available at the root level at /llms.txt and


### PR DESCRIPTION
## Description
- Add <link rel="alternate"> tags in <head> on every page: one for the page's .md companion (matches middleware.ts), one for /llms.txt. Crawlers now have a machine-discoverable hint.
- Curate llms.txt section labels and group third-party docs, notices, and FAQ under a single ## Optional section per the llmstxt.org spec.
- Add scripts/tidy-llms-txt.js as a post-build pass: drop the floating root /index.md link, merge multiple ## Optional sections, and strip descriptions from Optional items so llms.txt stays under 50 KB (49,981 / 50,000).
- Document that the ~55% sitemap/llms.txt coverage gap is intentional: the missing routes are SDK auto-gen, partials, category indexes, and hosted PDFs — none are user-facing content.


## Document type

- [ ] Gentle introduction
- [ ] Quickstart
- [ ] How-to
- [ ] Concept
- [ ] FAQ
- [ ] Troubleshooting
- [ ] Reference
- [ ] Third-party content
- [X] Codebase changes
- [ ] Not applicable

