### PR TITLE
add llm.txt to main page's header

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2414,7 +2414,13 @@
   "headers": [
     {
       "source": "/",
-      "headers": [{ "key": "Vary", "value": "Accept" }]
+      "headers": [
+        { "key": "Vary", "value": "Accept" },
+        {
+          "key": "Link",
+          "value": "</llms.txt>; rel=\"service-doc\"; type=\"text/plain\"; title=\"LLM-friendly site index\", </sitemap.xml>; rel=\"sitemap\"; type=\"application/xml\""
+        }
+      ]
     },
     {
       "source": "/:path+",


### PR DESCRIPTION
## Description

Adds a `Link` response header to the docs homepage so agents can discover useful resources from the root URL.

Edits the homepage entry in `vercel.json` to emit:

```
Link: </llms.txt>; rel="service-doc"; type="text/plain"; title="LLM-friendly site index",
      </sitemap.xml>; rel="sitemap"; type="application/xml"
```

Both target files are already produced by the existing build (`@signalwire/docusaurus-plugin-llms-txt` generates `/llms.txt`; the default Docusaurus sitemap plugin generates `/sitemap.xml`). The existing `Vary: Accept` header on the homepage is preserved. Scope is limited to `source: "/"` — the `/:path+` entry is unchanged.

Header format follows RFC 8288; relation names (`service-doc`, `sitemap`) are IANA-registered.

This complements the existing agent affordance in `middleware.ts`, which already serves a `.md` variant of each doc URL when the client sends `Accept: text/markdown`.

## Document type

- [ ] Gentle introduction
- [ ] Quickstart
- [ ] How-to
- [ ] Concept
- [ ] FAQ
- [ ] Troubleshooting
- [ ] Reference
- [ ] Third-party content
- [x] Codebase changes
- [ ] Not applicable

## Checklist

- [ ] I have read the [CONTRIBUTE.md](../CONTRIBUTE.md) guidelines
- [ ] My changes follow the style conventions outlined in CONTRIBUTE.md
- [ ] I have used sentence-case for titles and headers
- [ ] I have used descriptive link text (not "here" or "this")
- [ ] I have separated procedural from conceptual content where appropriate
- [ ] I have tested my changes locally with `yarn start` or `yarn build`
- [x] My code follows the existing code style and conventions
- [ ] I have added/updated frontmatter for new documents
- [ ] I have checked for broken links
- [ ] I have verified that my changes don't break the build
- Third-party docs only: Do you agree to the third-party content policy outlined within [CONTRIBUTE.md](../CONTRIBUTE.md)?
  - [ ] Yes
  - [x] Not applicable

## Additional Notes

Config-only change — no MDX content edited, so doc-style checklist items are not applicable.

Local validation so far: `node -e "JSON.parse(require('fs').readFileSync('vercel.json','utf8'))"` passes. A full `yarn build` has not been run on this branch; recommend verifying the header on the Vercel preview URL:

```
curl -sI <preview-url>/ | grep -i ^link
```