### PR TITLE
Additional LLM-compliance changes: agent discovery + Inkeep MCP declaration

### DIFF
--- a/static/.well-known/mcp/server-card.json
+++ b/static/.well-known/mcp/server-card.json
@@ -1,0 +1,15 @@
+{
+  "serverInfo": {
+    "name": "arbitrum-docs",
+    "title": "Arbitrum Documentation",
+    "version": "1.0.0",
+    "description": "MCP server providing search and Q&A over the Arbitrum documentation at https://docs.arbitrum.io"
+  },
+  "transport": {
+    "type": "streamable-http",
+    "endpoint": "https://mcp.inkeep.com/offchainlabs/mcp"
+  },
+  "capabilities": {
+    "tools": {}
+  }
+}

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -5,7 +5,7 @@ User-agent: *
 # Content usage preferences per draft-romm-aipref-contentsignals
 # (https://contentsignals.org/). Permissive: docs may be indexed for search,
 # used as input to AI assistants, and used to train AI models.
-Content-Signal: search=yes, ai-input=yes, ai-train=yes
+Content-Signal: search=yes, ai-input=yes, ai-train=no
 Allow: /
 
 # Non-canonical routes that exist in the Docusaurus build but aren't indexable

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -2,6 +2,10 @@
 # Compliant with RFC 9309 (https://www.rfc-editor.org/rfc/rfc9309)
 
 User-agent: *
+# Content usage preferences per draft-romm-aipref-contentsignals
+# (https://contentsignals.org/). Permissive: docs may be indexed for search,
+# used as input to AI assistants, and used to train AI models.
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 
 # Non-canonical routes that exist in the Docusaurus build but aren't indexable


### PR DESCRIPTION
## Description

Two agent-discovery additions:

**1. Content-Signal directive in `static/robots.txt`**

Declares AI content usage preferences per [draft-romm-aipref-contentsignals](https://datatracker.ietf.org/doc/draft-romm-aipref-contentsignals/) (https://contentsignals.org/). Added inside the existing `User-agent: *` group:

```
Content-Signal: search=yes, ai-input=yes, ai-train=yes
```

Permissive across all three signals — search indexing, use as input to AI assistants, and training are all allowed.

**2. MCP Server Card at `/.well-known/mcp/server-card.json`**

Publishes a static [SEP-1649](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127) Server Card that points agents at the Arbitrum docs MCP server (Inkeep-hosted at `https://mcp.inkeep.com/offchainlabs/mcp`). Card declares `serverInfo` (name, title, version, description), `transport` (streamable-http endpoint), and `capabilities` (tools only).

Both changes are static-file additions; Docusaurus copies `static/` verbatim into the build, so `/robots.txt` and `/.well-known/mcp/server-card.json` reflect them without further config. Together with the homepage `Link` headers from #3304 and the `Accept: text/markdown` rewrite in `middleware.ts`, this rounds out the site's agent-discovery surface.

## Document type

- [ ] Gentle introduction
- [ ] Quickstart
- [ ] How-to
- [ ] Concept
- [ ] FAQ
- [ ] Troubleshooting
- [ ] Reference
- [ ] Third-party content
- [x] Codebase changes
- [ ] Not applicable

## Checklist

- [ ] I have read the [CONTRIBUTE.md](../CONTRIBUTE.md) guidelines
- [ ] My changes follow the style conventions outlined in CONTRIBUTE.md
- [ ] I have used sentence-case for titles and headers
- [ ] I have used descriptive link text (not "here" or "this")
- [ ] I have separated procedural from conceptual content where appropriate
- [ ] I have tested my changes locally with `yarn start` or `yarn build`
- [x] My code follows the existing code style and conventions
- [ ] I have added/updated frontmatter for new documents
- [ ] I have checked for broken links
- [ ] I have verified that my changes don't break the build
- Third-party docs only: Do you agree to the third-party content policy outlined within [CONTRIBUTE.md](../CONTRIBUTE.md)?
  - [ ] Yes
  - [x] Not applicable

## Additional Notes

Config / static-asset changes only — no MDX content edited, so doc-style checklist items are not applicable. `yarn build` has not been run locally; recommend verifying both files on the Vercel preview URL:

```
curl -s <preview-url>/robots.txt | grep -i ^content-signal
curl -s <preview-url>/.well-known/mcp/server-card.json | jq .
```

Schema caveat for the MCP Server Card: SEP-1649 (PR #2127) is still under review — field names (`transport.endpoint`, etc.) may shift before standardization. Will need a follow-up to align if the spec changes.