### PR TITLE
chore: gitignore docs/superpowers/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ yarn-error.log*
 .cursor/
 .serena/
 .claude/plans
+
+# Local-only design specs / brainstorming docs (not part of the published docs site)
+docs/superpowers/


### PR DESCRIPTION
## Description

Adds `docs/superpowers/` to `.gitignore`. This directory is used locally for design specs and brainstorming documents — the path keeps specs close to the codebase they describe, but the content is not part of the published documentation site at docs.arbitrum.io.

The new ignore rule prevents these local-only files from being accidentally staged on any branch.

## Document type

- [ ] Gentle introduction
- [ ] Quickstart
- [ ] How-to
- [ ] Concept
- [ ] FAQ
- [ ] Troubleshooting
- [ ] Reference
- [ ] Third-party content
- [x] Codebase changes
- [ ] Not applicable

## Checklist

- [ ] I have read the [CONTRIBUTE.md](../CONTRIBUTE.md) guidelines
- [ ] My changes follow the style conventions outlined in CONTRIBUTE.md
- [ ] I have used sentence-case for titles and headers
- [ ] I have used descriptive link text (not "here" or "this")
- [ ] I have separated procedural from conceptual content where appropriate
- [ ] I have tested my changes locally with `yarn start` or `yarn build`
- [x] My code follows the existing code style and conventions
- [ ] I have added/updated frontmatter for new documents
- [ ] I have checked for broken links
- [ ] I have verified that my changes don't break the build
- Third-party docs only: Do you agree to the third-party content policy outlined within [CONTRIBUTE.md](../CONTRIBUTE.md)?
  - [ ] Yes
  - [x] Not applicable

## Additional Notes

`.gitignore`-only change. No content or build behavior is affected.