### PR TITLE
fix(analytics): wire Inkeep widget events into PostHog

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,60 +7,6 @@ import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import { inkeepBaseSettings, inkeepModalSettings, inkeepExampleQuestions } from './inkeep.js';
 
-// Inkeep analytics event handler - forwards events to PostHog
-const handleInkeepEvent = (event) => {
-  // Only run on client side where PostHog is available
-  if (typeof window === 'undefined' || !window.posthog) {
-    return;
-  }
-
-  const { eventName, properties } = event;
-
-  // Events we want to track in PostHog
-  const trackedEvents = [
-    // Chat events
-    'assistant_message_received',
-    'user_message_submitted',
-    'assistant_positive_feedback_submitted',
-    'assistant_negative_feedback_submitted',
-    'assistant_source_item_clicked',
-    'chat_share_button_clicked',
-    // Search events
-    'search_query_submitted',
-    'search_result_clicked',
-    'search_query_response_received',
-  ];
-
-  if (trackedEvents.includes(eventName)) {
-    // Extract relevant properties to avoid sending excessive data
-    const eventProperties = {
-      component_type: properties?.componentType,
-      widget_version: properties?.widgetLibraryVersion,
-    };
-
-    // Add event-specific properties
-    if (eventName.includes('search')) {
-      eventProperties.search_query = properties?.searchQuery;
-      if (properties?.totalResults !== undefined) {
-        eventProperties.total_results = properties.totalResults;
-      }
-      if (properties?.title) {
-        eventProperties.result_title = properties.title;
-      }
-    }
-
-    if (eventName.includes('feedback')) {
-      eventProperties.feedback_reasons = properties?.reasons;
-    }
-
-    if (eventName === 'assistant_source_item_clicked') {
-      eventProperties.source_link = properties?.link;
-    }
-
-    window.posthog.capture(`inkeep_${eventName}`, eventProperties);
-  }
-};
-
 // Routes that exist in the Docusaurus build but aren't standalone, indexable pages.
 // Shared between the sitemap and llms.txt so both indexes stay in sync.
 const nonCanonicalRoutePatterns = [

--- a/inkeep.js
+++ b/inkeep.js
@@ -1,8 +1,64 @@
 // Shared Inkeep configuration
+
+// Forwards analytics events from the Inkeep widget into PostHog.
+// Called once per event fired by @inkeep/cxkit-docusaurus.
+const handleInkeepEvent = (event) => {
+  // Only run on client where PostHog is available
+  if (typeof window === 'undefined' || !window.posthog) {
+    return;
+  }
+
+  const { eventName, properties } = event;
+
+  // Events we want to track in PostHog
+  const trackedEvents = [
+    // Chat events
+    'assistant_message_received',
+    'user_message_submitted',
+    'assistant_positive_feedback_submitted',
+    'assistant_negative_feedback_submitted',
+    'assistant_source_item_clicked',
+    'chat_share_button_clicked',
+    // Search events
+    'search_query_submitted',
+    'search_result_clicked',
+    'search_query_response_received',
+  ];
+
+  if (!trackedEvents.includes(eventName)) return;
+
+  // Extract relevant properties to avoid sending excessive data
+  const eventProperties = {
+    component_type: properties?.componentType,
+    widget_version: properties?.widgetLibraryVersion,
+  };
+
+  if (eventName.includes('search')) {
+    eventProperties.search_query = properties?.searchQuery;
+    if (properties?.totalResults !== undefined) {
+      eventProperties.total_results = properties.totalResults;
+    }
+    if (properties?.title) {
+      eventProperties.result_title = properties.title;
+    }
+  }
+
+  if (eventName.includes('feedback')) {
+    eventProperties.feedback_reasons = properties?.reasons;
+  }
+
+  if (eventName === 'assistant_source_item_clicked') {
+    eventProperties.source_link = properties?.link;
+  }
+
+  window.posthog.capture(`inkeep_${eventName}`, eventProperties);
+};
+
 const inkeepBaseSettings = {
   apiKey: process.env.INKEEP_API_KEY,
   primaryBrandColor: '#213147',
   organizationDisplayName: 'Arbitrum',
+  onEvent: handleInkeepEvent,
   theme: {
     syntaxHighlighter: {
       lightTheme: require('prism-react-renderer/themes/github'),


### PR DESCRIPTION
## Description

The Inkeep widget's analytics \`onEvent\` callback was defined in \`docusaurus.config.js\` but never passed to the Inkeep plugin. Per \`@inkeep/cxkit-types/dist/index.d.ts:676\`, the hook is \`onEvent?: (event: InkeepCallbackEvent) => void\` on the widget's base settings.

As a result, no \`inkeep_*\` events have ever reached PostHog. Verified empirically: PostHog \`event_definitions\` for project 27077 returns only 10 distinct event types — none beginning with the \`inkeep_\` prefix.

### Fix

Move \`handleInkeepEvent\` into \`inkeep.js\` and attach it as \`inkeepBaseSettings.onEvent\` so both \`SearchBar\` and \`ChatButton\` inherit it (they already share \`inkeepBaseSettings\` in \`docusaurus.config.js\`).

### Events that will start flowing

| Event | Properties |
|---|---|
| \`inkeep_user_message_submitted\` | component_type, widget_version |
| \`inkeep_assistant_message_received\` | component_type, widget_version |
| \`inkeep_assistant_positive_feedback_submitted\` | + feedback_reasons |
| \`inkeep_assistant_negative_feedback_submitted\` | + feedback_reasons |
| \`inkeep_assistant_source_item_clicked\` | + source_link |
| \`inkeep_chat_share_button_clicked\` | (base only) |
| \`inkeep_search_query_submitted\` | + search_query |
| \`inkeep_search_result_clicked\` | + search_query, result_title |
| \`inkeep_search_query_response_received\` | + search_query, total_results |

Chat message bodies are intentionally not forwarded (privacy posture — verbose user input may contain PII). Search-query text is forwarded; queries are typically short and rarely PII.

## Document type

- [ ] Gentle introduction
- [ ] Quickstart
- [ ] How-to
- [ ] Concept
- [ ] FAQ
- [ ] Troubleshooting
- [ ] Reference
- [ ] Third-party content
- [x] Codebase changes
- [ ] Not applicable

## Checklist

- [ ] I have read the [CONTRIBUTE.md](../CONTRIBUTE.md) guidelines
- [ ] My changes follow the style conventions outlined in CONTRIBUTE.md
- [ ] I have used sentence-case for titles and headers
- [ ] I have used descriptive link text (not "here" or "this")
- [ ] I have separated procedural from conceptual content where appropriate
- [ ] I have tested my changes locally with \`yarn start\` or \`yarn build\`
- [x] My code follows the existing code style and conventions
- [ ] I have added/updated frontmatter for new documents
- [ ] I have checked for broken links
- [x] I have verified that my changes don't break the build
- Third-party docs only: Do you agree to the third-party content policy outlined within [CONTRIBUTE.md](../CONTRIBUTE.md)?
  - [ ] Yes
  - [x] Not applicable

## Additional Notes

\`yarn build\` ran clean (65s). Browser-level verification is straightforward on the Vercel preview URL once it deploys:

1. DevTools → Network → filter \`/i/v0/e/\`
2. Trigger an Inkeep search (search bar) — expect POST with \`event: inkeep_search_query_submitted\`
3. Trigger a chat question + thumbs-down — expect POSTs for \`inkeep_user_message_submitted\`, \`inkeep_assistant_message_received\`, \`inkeep_assistant_negative_feedback_submitted\`
4. Confirm in PostHog Live Events at us.posthog.com/project/27077/activity/explore