### PR TITLE
Add doc-restructure codemod tooling and client redirects

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Run doc-restructure codemod tests
+        run: yarn test:codemod
+
       - name: Check for deleted markdown files
         run: yarn tsx scripts/check-markdown.ts --ci

--- a/README.md
+++ b/README.md
@@ -130,14 +130,34 @@ This part will update the glossary.
 
 ### Restructuring docs (moving or renaming pages)
 
-The following workflow handles internal links, sidebar entries, and external URLs in one step.
+The tooling handles internal links, the moved file's own relative links, sidebar entries,
+redirects, and quicklook glossary data so a move costs minutes instead of hours.
 
 `redirects.config.js` is the single source of truth for internal redirects. It is consumed by the
 `@docusaurus/plugin-client-redirects` plugin (in-app redirects) and mirrored into `vercel.json` for
 the edge by `yarn sync-redirects`.
 
-Let's assume you want to move `docs/launch-arbitrum-chain/05-customize-your-chain/customize-stf.mdx`
-to `docs/launch-arbitrum-chain/customize-stf.mdx`.
+#### One command (recommended)
+
+`yarn restructure <from> <to>` runs the whole sequence in the order that keeps the edge consistent:
+it moves the file and rewrites references, then runs `yarn build` as a verification gate,
+regenerates the glossary only if a glossary term was affected, and finally mirrors the redirect
+into `vercel.json`. If the build fails, it aborts **before** touching `vercel.json`.
+
+```shell
+# preview only — no files are changed
+yarn restructure docs/launch-arbitrum-chain/05-customize-your-chain/customize-stf.mdx docs/launch-arbitrum-chain/customize-stf.mdx --dry-run
+
+# perform the move end to end
+yarn restructure docs/launch-arbitrum-chain/05-customize-your-chain/customize-stf.mdx docs/launch-arbitrum-chain/customize-stf.mdx
+```
+
+Then commit your changes and open a PR.
+
+#### Step by step (for batch moves or granular control)
+
+Use the individual commands when you want to inspect the blast radius first, or move several files
+before building once (build and sync a single time, after all the moves).
 
 1. Size the blast radius — list every internal link that points at the page (accepts a path or a glob):
 
@@ -164,23 +184,28 @@ yarn move-doc docs/launch-arbitrum-chain/05-customize-your-chain/customize-stf.m
 yarn build
 ```
 
-5. Mirror the redirect into `vercel.json` for the edge:
+5. If the move affected a glossary term, regenerate the quicklook data:
+
+```shell
+yarn build-glossary
+```
+
+6. Mirror the redirect into `vercel.json` for the edge:
 
 ```shell
 yarn sync-redirects
 ```
 
-6. Commit your changes and open a PR.
+7. Commit your changes and open a PR.
 
 Notes:
 
-- Links whose URL is built from a JavaScript expression (e.g. `<Link to={someVar}>`) cannot be
-  rewritten automatically; `move-doc` lists them so you can update them by hand.
-- `yarn move-doc` does not run the build for you — run `yarn build` (step 4) to confirm.
-- If the moved page is referenced by a glossary term (quicklook), also run `yarn build-glossary`
-  to regenerate `static/glossary.json`. Quicklook tooltips are rendered from that file at runtime,
-  so `yarn build` will not flag a stale glossary link — `move-doc` prints a reminder when it
-  rewrites glossary content.
+- Links whose URL is built from a JavaScript expression (e.g. `<Link to={someVar}>`), and relative
+  links inside partials (a partial has no fixed URL), cannot be rewritten automatically; `move-doc`
+  lists both so you can update them by hand.
+- `yarn move-doc` does not run the build — `yarn restructure` does. With the manual steps, run
+  `yarn build` yourself, plus `yarn build-glossary` if a glossary term changed: quicklook tooltips
+  render from `static/glossary.json` at runtime, which `yarn build` does not validate.
 
 ### Formatting
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ Notes:
 - Links whose URL is built from a JavaScript expression (e.g. `<Link to={someVar}>`) cannot be
   rewritten automatically; `move-doc` lists them so you can update them by hand.
 - `yarn move-doc` does not run the build for you — run `yarn build` (step 4) to confirm.
+- If the moved page is referenced by a glossary term (quicklook), also run `yarn build-glossary`
+  to regenerate `static/glossary.json`. Quicklook tooltips are rendered from that file at runtime,
+  so `yarn build` will not flag a stale glossary link — `move-doc` prints a reminder when it
+  rewrites glossary content.
 
 ### Formatting
 

--- a/README.md
+++ b/README.md
@@ -171,8 +171,9 @@ yarn inventory-links docs/launch-arbitrum-chain/05-customize-your-chain/customiz
 yarn move-doc docs/launch-arbitrum-chain/05-customize-your-chain/customize-stf.mdx docs/launch-arbitrum-chain/customize-stf.mdx --dry-run
 ```
 
-3. Perform the move. This moves the file, rewrites every reference to it (and the moved file's own
-   relative links), updates the doc id in `sidebars.js`, and appends a redirect to `redirects.config.js`:
+3. Perform the move. This moves the file with `git mv` (staging it as a rename so `git log --follow`
+   keeps the page's history), rewrites every reference to it (and the moved file's own relative
+   links), updates the doc id in `sidebars.js`, and appends a redirect to `redirects.config.js`:
 
 ```shell
 yarn move-doc docs/launch-arbitrum-chain/05-customize-your-chain/customize-stf.mdx docs/launch-arbitrum-chain/customize-stf.mdx
@@ -206,6 +207,13 @@ Notes:
 - `yarn move-doc` does not run the build — `yarn restructure` does. With the manual steps, run
   `yarn build` yourself, plus `yarn build-glossary` if a glossary term changed: quicklook tooltips
   render from `static/glossary.json` at runtime, which `yarn build` does not validate.
+- The move uses `git mv`, so the rename is staged for you (the link-rewrite shows as a follow-on
+  modification). If the source isn't tracked or you're outside a git work tree, it falls back to a
+  plain filesystem move and warns that the move is unstaged.
+- The doc id in `sidebars.js` is updated in place — the entry is **not** relocated. A page's URL
+  comes from its file path and slug, not its sidebar position, so reorganizing the sidebar by hand
+  (shifting a section elsewhere, reordering items) needs no tooling and no redirects: just edit
+  `sidebars.js` and run `yarn build`, which validates that every entry resolves to a real doc.
 
 ### Formatting
 

--- a/README.md
+++ b/README.md
@@ -130,8 +130,7 @@ This part will update the glossary.
 
 ### Restructuring docs (moving or renaming pages)
 
-Moving a doc breaks internal links, sidebar entries, and external URLs. These commands handle all
-of that in one step, so a restructure costs minutes instead of hours.
+The following workflow handles internal links, sidebar entries, and external URLs in one step.
 
 `redirects.config.js` is the single source of truth for internal redirects. It is consumed by the
 `@docusaurus/plugin-client-redirects` plugin (in-app redirects) and mirrored into `vercel.json` for

--- a/README.md
+++ b/README.md
@@ -128,6 +128,57 @@ This part will update the glossary.
 
 4. Commit your changes and open a PR.
 
+### Restructuring docs (moving or renaming pages)
+
+Moving a doc breaks internal links, sidebar entries, and external URLs. These commands handle all
+of that in one step, so a restructure costs minutes instead of hours.
+
+`redirects.config.js` is the single source of truth for internal redirects. It is consumed by the
+`@docusaurus/plugin-client-redirects` plugin (in-app redirects) and mirrored into `vercel.json` for
+the edge by `yarn sync-redirects`.
+
+Let's assume you want to move `docs/launch-arbitrum-chain/05-customize-your-chain/customize-stf.mdx`
+to `docs/launch-arbitrum-chain/customize-stf.mdx`.
+
+1. Size the blast radius — list every internal link that points at the page (accepts a path or a glob):
+
+```shell
+yarn inventory-links docs/launch-arbitrum-chain/05-customize-your-chain/customize-stf.mdx
+```
+
+2. Preview the move without changing any files:
+
+```shell
+yarn move-doc docs/launch-arbitrum-chain/05-customize-your-chain/customize-stf.mdx docs/launch-arbitrum-chain/customize-stf.mdx --dry-run
+```
+
+3. Perform the move. This moves the file, rewrites every reference to it (and the moved file's own
+   relative links), updates the doc id in `sidebars.js`, and appends a redirect to `redirects.config.js`:
+
+```shell
+yarn move-doc docs/launch-arbitrum-chain/05-customize-your-chain/customize-stf.mdx docs/launch-arbitrum-chain/customize-stf.mdx
+```
+
+4. Verify links resolve. The build fails on any broken internal link:
+
+```shell
+yarn build
+```
+
+5. Mirror the redirect into `vercel.json` for the edge:
+
+```shell
+yarn sync-redirects
+```
+
+6. Commit your changes and open a PR.
+
+Notes:
+
+- Links whose URL is built from a JavaScript expression (e.g. `<Link to={someVar}>`) cannot be
+  rewritten automatically; `move-doc` lists them so you can update them by hand.
+- `yarn move-doc` does not run the build for you — run `yarn build` (step 4) to confirm.
+
 ### Formatting
 
 1. Run `yarn format` from the root directory.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,6 +7,7 @@ const { themes: prismThemes } = require('prism-react-renderer');
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import { inkeepBaseSettings, inkeepModalSettings, inkeepExampleQuestions } from './inkeep.js';
+import { redirects } from './redirects.config.js';
 
 // Routes that exist in the Docusaurus build but aren't standalone, indexable pages.
 // Shared between the sitemap and llms.txt so both indexes stay in sync.
@@ -110,6 +111,13 @@ const config = {
     ],
   ],
   plugins: [
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        // Source of truth: redirects.config.ts (also mirrored to vercel.json via `yarn sync-redirects`).
+        redirects,
+      },
+    ],
     [
       '@inkeep/cxkit-docusaurus',
       {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "check-lunr-exclude": "tsx scripts/check-lunr-exclude-hide-from-search.ts",
     "inventory-links": "tsx scripts/inventory-links.ts",
     "move-doc": "tsx scripts/move-doc.ts",
+    "restructure": "tsx scripts/restructure.ts",
     "sync-redirects": "tsx scripts/sync-vercel-redirects.ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "format:check": "prettier --check --config \"./.prettierrc.js\" -- \"./*.{js,json}\" \"src/**/*.{tsx,ts,scss,json,js}\" \"docs/**/*.{md,mdx}\"",
     "typecheck": "tsc",
     "test:llms-tracking": "tsx --test lib/llms-tracking.test.ts",
+    "test:codemod": "tsx --test scripts/lib/__tests__/*.test.ts",
     "check-releases": "ts-node scripts/check-releases.ts",
     "check-markdown": "tsx scripts/check-markdown.ts",
     "notion:update": "tsx scripts/notion-update.ts",
@@ -37,11 +38,15 @@
     "audit-docs:report-only": "tsx scripts/audit-docs.ts",
     "fetch-edge-challenge-data": "node scripts/fetch-edge-challenge-data.mjs",
     "check-globalvars": "tsx scripts/check-globalvars-updates.ts",
-    "check-lunr-exclude": "tsx scripts/check-lunr-exclude-hide-from-search.ts"
+    "check-lunr-exclude": "tsx scripts/check-lunr-exclude-hide-from-search.ts",
+    "inventory-links": "tsx scripts/inventory-links.ts",
+    "move-doc": "tsx scripts/move-doc.ts",
+    "sync-redirects": "tsx scripts/sync-vercel-redirects.ts"
   },
   "dependencies": {
     "@arbitrum/sdk": "^4.0.5",
     "@docusaurus/core": "^3.10.1",
+    "@docusaurus/plugin-client-redirects": "^3.10.1",
     "@docusaurus/preset-classic": "^3.10.1",
     "@docusaurus/theme-common": "^3.10.1",
     "@docusaurus/theme-live-codeblock": "^3.10.1",
@@ -102,10 +107,16 @@
     "markdown-link-extractor": "^4.0.3",
     "markdownlint-cli": "^0.48.0",
     "prettier": "^2.8.3",
+    "remark-mdx": "^3.1.1",
+    "remark-parse": "^11.0.0",
     "semver": "^7.8.1",
     "styled-components": "^6.4.2",
+    "to-vfile": "^8.0.0",
     "tsx": "^4.22.3",
-    "typescript": "^5.1"
+    "typescript": "^5.1",
+    "unified": "^11.0.5",
+    "unist-util-visit": "^5.1.0",
+    "vfile": "^6.0.3"
   },
   "resolutions": {
     "elliptic": "^6.6.1",

--- a/redirects.config.d.ts
+++ b/redirects.config.d.ts
@@ -1,0 +1,6 @@
+export interface DocRedirect {
+  from: string;
+  to: string;
+}
+
+export declare const redirects: DocRedirect[];

--- a/redirects.config.js
+++ b/redirects.config.js
@@ -1,0 +1,14 @@
+/**
+ * Internal doc redirects: old URL -> new URL.
+ *
+ * Entries between the AUTO-GENERATED markers are maintained by `yarn move-doc`. Consumed by
+ * `@docusaurus/plugin-client-redirects` (in-app) and `yarn sync-redirects` (which mirrors them
+ * into vercel.json for the edge). Types live in redirects.config.d.ts.
+ *
+ * This is a `.js` module (not `.ts`) so it resolves natively in both the Docusaurus config and
+ * webpack's build-dependency cache; `redirects.config.d.ts` supplies the types for the tooling.
+ */
+export const redirects = [
+  // AUTO-GENERATED REDIRECTS START
+  // AUTO-GENERATED REDIRECTS END
+];

--- a/scripts/inventory-links.ts
+++ b/scripts/inventory-links.ts
@@ -1,0 +1,110 @@
+/**
+ * inventory-links — print the blast radius for a doc path before a restructure.
+ *
+ * Usage:
+ *   yarn inventory-links <path-or-glob>
+ *
+ * Lists every internal link in the docs tree that resolves to the given file(s), grouped by
+ * the file that contains the link, with line numbers and the surface (markdown link, JSX
+ * attribute, or partial import). Run this before `move-doc` to confirm the count matches
+ * expectations.
+ */
+
+import path from 'node:path';
+import { glob } from 'glob';
+
+import { buildDocsIndex, scanLinks, isPartial, type LinkRecord } from './lib/docs-link-index';
+
+function surfaceLabel(record: LinkRecord): string {
+  const { ref } = record;
+  if (ref.surface === 'markdown') return 'link';
+  if (ref.surface === 'esm-import') return 'import';
+  return `<${ref.elementName ?? 'jsx'} ${ref.attrName ?? ''}>`.trim();
+}
+
+async function main(): Promise<void> {
+  const arg = process.argv[2];
+  if (!arg) {
+    console.error('usage: yarn inventory-links <path-or-glob>');
+    process.exit(1);
+  }
+
+  const repoRoot = process.cwd();
+  const matched = await glob(arg, { cwd: repoRoot, absolute: true, nodir: true });
+  const targets = matched.filter((file) => /\.mdx?$/.test(file)).map((file) => path.resolve(file));
+
+  if (targets.length === 0) {
+    console.error(`no .md/.mdx files matched: ${arg}`);
+    process.exit(1);
+  }
+
+  const index = await buildDocsIndex(repoRoot);
+  const { records, unparsed } = scanLinks(index);
+
+  const byTarget = new Map<string, LinkRecord[]>();
+  for (const record of records) {
+    if (!record.toFile) continue;
+    const bucket = byTarget.get(record.toFile);
+    if (bucket) bucket.push(record);
+    else byTarget.set(record.toFile, [record]);
+  }
+
+  const expressionLinks = records.filter((record) => record.ref.skipped === 'expression');
+
+  for (const target of targets) {
+    const url = index.fileToUrl.get(target);
+    const descriptor = isPartial(target) ? '(partial — imported, not routed)' : url ?? '(no route)';
+    const hits = (byTarget.get(target) ?? []).slice().sort((a, b) => {
+      if (a.fromFile !== b.fromFile) return a.fromFile < b.fromFile ? -1 : 1;
+      return (a.line ?? 0) - (b.line ?? 0);
+    });
+
+    console.log(`\nTarget: ${path.relative(repoRoot, target)}  →  ${descriptor}`);
+
+    if (hits.length === 0) {
+      console.log('  No internal references found.');
+      continue;
+    }
+
+    const fileCount = new Set(hits.map((hit) => hit.fromFile)).size;
+    console.log(
+      `  ${hits.length} reference${hits.length === 1 ? '' : 's'} across ${fileCount} file${
+        fileCount === 1 ? '' : 's'
+      }:`,
+    );
+
+    let currentFile = '';
+    for (const hit of hits) {
+      if (hit.fromFile !== currentFile) {
+        currentFile = hit.fromFile;
+        console.log(`\n  ${path.relative(repoRoot, hit.fromFile)}`);
+      }
+      const where = hit.line === null ? '   ?' : `L${hit.line}`.padStart(6);
+      console.log(`  ${where}  ${surfaceLabel(hit).padEnd(12)} ${hit.ref.rawUrl}`);
+    }
+  }
+
+  if (expressionLinks.length > 0) {
+    console.log(
+      `\nNote: ${expressionLinks.length} expression-valued <… to={…}/href={…}> link${
+        expressionLinks.length === 1 ? '' : 's'
+      } in the tree cannot be resolved statically and need manual review during any restructure.`,
+    );
+  }
+
+  if (unparsed.length > 0) {
+    console.warn(
+      `\nWarning: ${unparsed.length} file${
+        unparsed.length === 1 ? '' : 's'
+      } could not be parsed; their links were not analyzed:`,
+    );
+    for (const { file, reason } of unparsed) {
+      console.warn(`  ${path.relative(repoRoot, file)} — ${reason.split('\n')[0]}`);
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/lib/__tests__/docs-link-index.test.ts
+++ b/scripts/lib/__tests__/docs-link-index.test.ts
@@ -1,0 +1,68 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { detectLinkStyle, splitSuffix, renderRef, type DocsIndex } from '../docs-link-index';
+
+const stubIndex: DocsIndex = {
+  repoRoot: '/repo',
+  docsRoot: '/repo/docs',
+  files: [],
+  fileToUrl: new Map(),
+  urlToFile: new Map(),
+};
+
+test('detectLinkStyle classifies each written form', () => {
+  assert.equal(detectLinkStyle('@site/docs/x.mdx'), 'atSite');
+  assert.equal(detectLinkStyle('/x/y.mdx'), 'fileAbs');
+  assert.equal(detectLinkStyle('../x.mdx'), 'fileRel');
+  assert.equal(detectLinkStyle('./x.md'), 'fileRel');
+  assert.equal(detectLinkStyle('/x/y'), 'urlAbs');
+  assert.equal(detectLinkStyle('../y'), 'urlRel');
+});
+
+test('splitSuffix separates anchor and query', () => {
+  assert.deepEqual(splitSuffix('/a/b#c'), { pathPart: '/a/b', suffix: '#c' });
+  assert.deepEqual(splitSuffix('/a/b?q=1'), { pathPart: '/a/b', suffix: '?q=1' });
+  assert.deepEqual(splitSuffix('/a/b'), { pathPart: '/a/b', suffix: '' });
+});
+
+test('renderRef reproduces each style pointing at the moved target', () => {
+  const target = { abs: '/repo/docs/c/b.mdx', url: '/c/b' };
+
+  assert.equal(
+    renderRef('atSite', target, { abs: '/repo/docs/a/x.mdx', url: '/a/x' }, stubIndex),
+    '@site/docs/c/b.mdx',
+  );
+  assert.equal(
+    renderRef('fileAbs', target, { abs: '/repo/docs/a/x.mdx', url: '/a/x' }, stubIndex),
+    '/c/b.mdx',
+  );
+  assert.equal(
+    renderRef('fileRel', target, { abs: '/repo/docs/a/x.mdx', url: '/a/x' }, stubIndex),
+    '../c/b.mdx',
+  );
+  assert.equal(
+    renderRef('urlAbs', target, { abs: '/repo/docs/a/x.mdx', url: '/a/x' }, stubIndex),
+    '/c/b',
+  );
+  assert.equal(
+    renderRef('urlRel', target, { abs: '/repo/docs/a/x.mdx', url: '/a/x' }, stubIndex),
+    '../c/b',
+  );
+});
+
+test('renderRef prefixes ./ for a same-directory file link', () => {
+  const target = { abs: '/repo/docs/a/b.mdx', url: '/a/b' };
+  assert.equal(
+    renderRef('fileRel', target, { abs: '/repo/docs/a/x.mdx', url: '/a/x' }, stubIndex),
+    './b.mdx',
+  );
+});
+
+test('renderRef returns null for a url-relative link with no container url', () => {
+  const target = { abs: '/repo/docs/c/b.mdx', url: '/c/b' };
+  assert.equal(
+    renderRef('urlRel', target, { abs: '/repo/docs/partials/_p.mdx', url: null }, stubIndex),
+    null,
+  );
+});

--- a/scripts/lib/__tests__/docs-link-index.test.ts
+++ b/scripts/lib/__tests__/docs-link-index.test.ts
@@ -18,6 +18,8 @@ test('detectLinkStyle classifies each written form', () => {
   assert.equal(detectLinkStyle('./x.md'), 'fileRel');
   assert.equal(detectLinkStyle('/x/y'), 'urlAbs');
   assert.equal(detectLinkStyle('../y'), 'urlRel');
+  // A bare relative file link is classified fileRel; renderRef normalizes it to `./page.mdx`.
+  assert.equal(detectLinkStyle('page.mdx'), 'fileRel');
 });
 
 test('splitSuffix separates anchor and query', () => {

--- a/scripts/lib/__tests__/fixtures/links-sample.mdx
+++ b/scripts/lib/__tests__/fixtures/links-sample.mdx
@@ -1,0 +1,20 @@
+---
+title: 'Sample'
+description: 'Has < and { characters that would break strict MDX parsing'
+---
+
+import Partial from '@site/docs/partials/_foo.mdx';
+import Other from '../partials/_bar.mdx';
+
+A [markdown link](/how-arbitrum-works/foo) and a [titled one](/get-started/quickstart 'Tooltip').
+
+An [anchor link](/sdk/intro#section) plus an [external](https://example.com).
+
+<Link to="/build-decentralized-apps/intro">build</Link>
+
+<a href="/run-arbitrum-node/overview">node</a>
+
+A computed <Link to={'/computed'}>link</Link> we cannot rewrite.
+
+<Partial />
+<Other />

--- a/scripts/lib/__tests__/mdx-link-codemod.test.ts
+++ b/scripts/lib/__tests__/mdx-link-codemod.test.ts
@@ -47,12 +47,34 @@ test('resolveDocUrl: relative slug resolves against the doc directory', () => {
   assert.equal(resolveDocUrl('docs/a/b/c.mdx', { slug: 'renamed' }), '/a/b/renamed');
 });
 
+test('resolveDocUrl: id frontmatter replaces the final URL segment', () => {
+  assert.equal(
+    resolveDocUrl('docs/build-decentralized-apps/oracles/01-overview.mdx', {
+      id: 'overview-oracles',
+    }),
+    '/build-decentralized-apps/oracles/overview-oracles',
+  );
+});
+
+test('resolveDocUrl: slug takes precedence over id', () => {
+  assert.equal(resolveDocUrl('docs/a/b/c.mdx', { slug: '/custom', id: 'ignored' }), '/custom');
+});
+
 test('resolveDocId strips numeric prefixes and extension, keeps index', () => {
   assert.equal(
     resolveDocId('docs/02-how-arbitrum-works/01-inside-arbitrum-nitro.mdx'),
     'how-arbitrum-works/inside-arbitrum-nitro',
   );
   assert.equal(resolveDocId('docs/foo/index.mdx'), 'foo/index');
+});
+
+test('resolveDocId: id frontmatter replaces the final id segment', () => {
+  assert.equal(
+    resolveDocId('docs/build-decentralized-apps/oracles/01-overview.mdx', {
+      id: 'overview-oracles',
+    }),
+    'build-decentralized-apps/oracles/overview-oracles',
+  );
 });
 
 test('extractLinkRefs locates every URL token exactly', () => {

--- a/scripts/lib/__tests__/mdx-link-codemod.test.ts
+++ b/scripts/lib/__tests__/mdx-link-codemod.test.ts
@@ -1,0 +1,131 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import {
+  resolveDocUrl,
+  resolveDocId,
+  extractLinkRefs,
+  applyRewrites,
+  isExternalOrFragment,
+} from '../mdx-link-codemod';
+
+const fixture = readFileSync(
+  path.join(import.meta.dirname, 'fixtures', 'links-sample.mdx'),
+  'utf8',
+);
+
+test('resolveDocUrl strips numeric prefixes from every segment', () => {
+  assert.equal(resolveDocUrl('docs/02-how-arbitrum-works/03-foo.mdx'), '/how-arbitrum-works/foo');
+});
+
+test('resolveDocUrl resolves index and README to the folder root', () => {
+  assert.equal(resolveDocUrl('docs/intro/index.mdx'), '/intro');
+  assert.equal(resolveDocUrl('docs/get-started/README.md'), '/get-started');
+});
+
+test('resolveDocUrl maps the docs root index to /', () => {
+  assert.equal(resolveDocUrl('docs/index.mdx'), '/');
+});
+
+test('resolveDocUrl accepts absolute filesystem paths', () => {
+  assert.equal(
+    resolveDocUrl('/Users/x/repo/docs/get-started/quickstart.mdx'),
+    '/get-started/quickstart',
+  );
+});
+
+test('resolveDocUrl: absolute slug overrides the path entirely', () => {
+  assert.equal(
+    resolveDocUrl('docs/02-how-arbitrum-works/03-foo.mdx', { slug: '/custom/url' }),
+    '/custom/url',
+  );
+});
+
+test('resolveDocUrl: relative slug resolves against the doc directory', () => {
+  assert.equal(resolveDocUrl('docs/a/b/c.mdx', { slug: 'renamed' }), '/a/b/renamed');
+});
+
+test('resolveDocId strips numeric prefixes and extension, keeps index', () => {
+  assert.equal(
+    resolveDocId('docs/02-how-arbitrum-works/01-inside-arbitrum-nitro.mdx'),
+    'how-arbitrum-works/inside-arbitrum-nitro',
+  );
+  assert.equal(resolveDocId('docs/foo/index.mdx'), 'foo/index');
+});
+
+test('extractLinkRefs locates every URL token exactly', () => {
+  const refs = extractLinkRefs(fixture);
+  // Every non-skipped range must slice back to exactly the raw URL — the invariant
+  // that makes splice-based rewrites surgical.
+  for (const ref of refs) {
+    if (ref.range) {
+      assert.equal(fixture.slice(ref.range[0], ref.range[1]), ref.rawUrl, JSON.stringify(ref));
+    }
+  }
+});
+
+test('extractLinkRefs finds all four surfaces', () => {
+  const refs = extractLinkRefs(fixture);
+  const urls = refs.map((r) => r.rawUrl);
+
+  // markdown links (including titled and anchored)
+  assert.ok(urls.includes('/how-arbitrum-works/foo'));
+  assert.ok(urls.includes('/get-started/quickstart')); // title is excluded from the range
+  assert.ok(urls.includes('/sdk/intro#section')); // anchor kept in raw url
+  assert.ok(urls.includes('https://example.com'));
+
+  // JSX attributes
+  const link = refs.find(
+    (r) => r.surface === 'jsx-attr' && r.rawUrl === '/build-decentralized-apps/intro',
+  );
+  assert.ok(link && link.elementName === 'Link' && link.attrName === 'to');
+  const anchor = refs.find(
+    (r) => r.surface === 'jsx-attr' && r.rawUrl === '/run-arbitrum-node/overview',
+  );
+  assert.ok(anchor && anchor.elementName === 'a' && anchor.attrName === 'href');
+
+  // ESM imports (both specifiers in one consecutive-import block)
+  const esm = refs.filter((r) => r.surface === 'esm-import').map((r) => r.rawUrl);
+  assert.deepEqual(esm.sort(), ['../partials/_bar.mdx', '@site/docs/partials/_foo.mdx']);
+});
+
+test('extractLinkRefs flags expression-valued attributes for manual review', () => {
+  const refs = extractLinkRefs(fixture);
+  const computed = refs.find((r) => r.skipped === 'expression');
+  assert.ok(computed, 'expected the {expression} Link to be flagged');
+  assert.equal(computed?.range, null);
+});
+
+test('isExternalOrFragment classifies non-doc destinations', () => {
+  assert.equal(isExternalOrFragment('https://example.com'), true);
+  assert.equal(isExternalOrFragment('mailto:x@y.com'), true);
+  assert.equal(isExternalOrFragment('#section'), true);
+  assert.equal(isExternalOrFragment('//cdn.example.com/x'), true);
+  assert.equal(isExternalOrFragment('/how-arbitrum-works/foo'), false);
+  assert.equal(isExternalOrFragment('../partials/_bar.mdx'), false);
+});
+
+test('applyRewrites splices only the targeted ranges', () => {
+  const refs = extractLinkRefs(fixture);
+  const md = refs.find((r) => r.rawUrl === '/how-arbitrum-works/foo')!;
+  const esm = refs.find((r) => r.rawUrl === '@site/docs/partials/_foo.mdx')!;
+
+  const output = applyRewrites(fixture, [
+    { range: md.range!, newText: '/how-it-works/foo' },
+    { range: esm.range!, newText: '@site/docs/shared/_foo.mdx' },
+  ]);
+
+  assert.ok(output.includes('[markdown link](/how-it-works/foo)'));
+  assert.ok(output.includes("import Partial from '@site/docs/shared/_foo.mdx';"));
+  // Untouched links are byte-identical.
+  assert.ok(output.includes('<a href="/run-arbitrum-node/overview">node</a>'));
+  // Same length delta as the two replacements, nothing else moved.
+  const expectedDelta =
+    '/how-it-works/foo'.length -
+    '/how-arbitrum-works/foo'.length +
+    '@site/docs/shared/_foo.mdx'.length -
+    '@site/docs/partials/_foo.mdx'.length;
+  assert.equal(output.length, fixture.length + expectedDelta);
+});

--- a/scripts/lib/__tests__/mdx-link-codemod.test.ts
+++ b/scripts/lib/__tests__/mdx-link-codemod.test.ts
@@ -74,7 +74,9 @@ test('extractLinkRefs finds all four surfaces', () => {
   assert.ok(urls.includes('/how-arbitrum-works/foo'));
   assert.ok(urls.includes('/get-started/quickstart')); // title is excluded from the range
   assert.ok(urls.includes('/sdk/intro#section')); // anchor kept in raw url
-  assert.ok(urls.includes('https://example.com'));
+  // Exact-match rather than `.includes('https://example.com')`: this is array membership in a
+  // test, not URL validation, but the substring form trips CodeQL's incomplete-url-sanitization rule.
+  assert.ok(urls.some((u) => u === 'https://example.com'));
 
   // JSX attributes
   const link = refs.find(

--- a/scripts/lib/docs-link-index.ts
+++ b/scripts/lib/docs-link-index.ts
@@ -136,7 +136,11 @@ function toPosix(p: string): string {
   return p.replace(/\\/g, '/');
 }
 
-/** Ensure a relative path is explicitly relative (`./x`, not `x`). */
+/**
+ * Ensure a relative path is explicitly relative (`./x`, not `x`). Note this normalizes a
+ * bare relative link (`page.mdx`) to `./page.mdx` on rewrite — a deliberate, harmless change
+ * that keeps the form unambiguous; bare relative links are not used in this repo's docs.
+ */
 function dotSlash(rel: string): string {
   return rel.startsWith('.') ? rel : './' + rel;
 }

--- a/scripts/lib/docs-link-index.ts
+++ b/scripts/lib/docs-link-index.ts
@@ -1,0 +1,260 @@
+/**
+ * Docs link index — the filesystem layer the codemod CLIs share.
+ *
+ * Builds a bidirectional map between doc file paths and the site URLs Docusaurus serves
+ * them at, then resolves every link occurrence in the tree to the file it points at. This
+ * is what lets `inventory-links` size a restructure's blast radius and `move-doc` find the
+ * references it must rewrite.
+ *
+ * The pure parsing/splicing primitives live in `mdx-link-codemod`; everything that touches
+ * the filesystem lives here.
+ */
+
+import { glob } from 'glob';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import matter from 'gray-matter';
+
+import {
+  resolveDocUrl,
+  extractLinkRefs,
+  isExternalOrFragment,
+  normalizeUrl,
+  type LinkRef,
+} from './mdx-link-codemod';
+
+/** A doc file loaded from disk, with its frontmatter-derived site URL (null for partials). */
+export interface DocFile {
+  /** Absolute path. */
+  abs: string;
+  /** Path relative to the repo root, e.g. `docs/foo/bar.mdx`. */
+  rel: string;
+  content: string;
+  isPartial: boolean;
+  /** Site URL, or `null` for partials (imported, not routed) and excluded files. */
+  url: string | null;
+}
+
+/** The resolved index for a docs tree. */
+export interface DocsIndex {
+  repoRoot: string;
+  docsRoot: string;
+  files: DocFile[];
+  /** Absolute file path → site URL (routable files only). */
+  fileToUrl: Map<string, string>;
+  /** Site URL → absolute file path (routable files only). */
+  urlToFile: Map<string, string>;
+}
+
+/** One link occurrence, resolved to the file it targets. */
+export interface LinkRecord {
+  /** Absolute path of the file containing the link. */
+  fromFile: string;
+  ref: LinkRef;
+  /** Absolute path the link resolves to, or `null` if external or unresolvable. */
+  toFile: string | null;
+  /** 1-based line of the link in `fromFile`, or `null` when the URL token was not located. */
+  line: number | null;
+}
+
+/** A file the parser could not read, so its links were not analyzed. */
+export interface UnparsedFile {
+  file: string;
+  reason: string;
+}
+
+/** The result of scanning the tree: resolved links plus any files that failed to parse. */
+export interface ScanResult {
+  records: LinkRecord[];
+  unparsed: UnparsedFile[];
+}
+
+const DOC_GLOB = '**/*.{md,mdx}';
+// Mirrors `docs.exclude` in docusaurus.config.js (`**/api/**`); PDFs are not md/mdx.
+const IGNORE = ['api/**', '**/api/**'];
+
+/** True when a file is a content partial (underscore-prefixed), which is imported, not routed. */
+export function isPartial(absPath: string): boolean {
+  return path.basename(absPath).startsWith('_');
+}
+
+/**
+ * Load every doc file under `docs/` and resolve its site URL.
+ *
+ * @param repoRoot Absolute path to the repository root.
+ * @returns A fully populated {@link DocsIndex}.
+ */
+export async function buildDocsIndex(repoRoot: string): Promise<DocsIndex> {
+  const docsRoot = path.join(repoRoot, 'docs');
+  const relPaths = await glob(DOC_GLOB, { cwd: docsRoot, ignore: IGNORE, nodir: true });
+
+  const files: DocFile[] = [];
+  const fileToUrl = new Map<string, string>();
+  const urlToFile = new Map<string, string>();
+
+  for (const relFromDocs of relPaths) {
+    const abs = path.join(docsRoot, relFromDocs);
+    const content = await readFile(abs, 'utf8');
+    const partial = isPartial(abs);
+    let url: string | null = null;
+
+    if (!partial) {
+      const frontmatter = matter(content).data as Record<string, unknown>;
+      url = resolveDocUrl(path.join('docs', relFromDocs), frontmatter);
+      const existing = urlToFile.get(url);
+      if (existing && existing !== abs) {
+        console.warn(`warning: URL collision ${url}\n  ${existing}\n  ${abs}`);
+      }
+      fileToUrl.set(abs, url);
+      urlToFile.set(url, abs);
+    }
+
+    files.push({ abs, rel: path.join('docs', relFromDocs), content, isPartial: partial, url });
+  }
+
+  return { repoRoot, docsRoot, files, fileToUrl, urlToFile };
+}
+
+/** Split a raw URL into its path part and the trailing `#anchor`/`?query` suffix. */
+export function splitSuffix(rawUrl: string): { pathPart: string; suffix: string } {
+  const match = rawUrl.match(/[#?]/);
+  if (!match || match.index === undefined) return { pathPart: rawUrl, suffix: '' };
+  return { pathPart: rawUrl.slice(0, match.index), suffix: rawUrl.slice(match.index) };
+}
+
+/** The written form of a link, preserved across a rewrite. */
+export type LinkStyle = 'atSite' | 'fileAbs' | 'fileRel' | 'urlAbs' | 'urlRel';
+
+/** Classify how a link's path part is written, so a rewrite can reproduce the same form. */
+export function detectLinkStyle(pathPart: string): LinkStyle {
+  if (pathPart.startsWith('@site/')) return 'atSite';
+  if (/\.mdx?$/.test(pathPart)) return pathPart.startsWith('/') ? 'fileAbs' : 'fileRel';
+  return pathPart.startsWith('/') ? 'urlAbs' : 'urlRel';
+}
+
+function toPosix(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+
+/** Ensure a relative path is explicitly relative (`./x`, not `x`). */
+function dotSlash(rel: string): string {
+  return rel.startsWith('.') ? rel : './' + rel;
+}
+
+/**
+ * Render a link to `target` from `container`, in the given style.
+ *
+ * @param style The original link's written form.
+ * @param target Absolute path and site URL of the destination (`url` may be `null` for partials).
+ * @param container Absolute path and site URL of the file the link lives in.
+ * @param index The docs index (for repo/docs roots).
+ * @returns The rewritten path part, or `null` when the style cannot be rendered (e.g. a
+ *   URL-relative link whose container has no URL).
+ */
+export function renderRef(
+  style: LinkStyle,
+  target: { abs: string; url: string | null },
+  container: { abs: string; url: string | null },
+  index: DocsIndex,
+): string | null {
+  switch (style) {
+    case 'atSite':
+      return '@site/' + toPosix(path.relative(index.repoRoot, target.abs));
+    case 'fileAbs':
+      return '/' + toPosix(path.relative(index.docsRoot, target.abs));
+    case 'fileRel':
+      return dotSlash(toPosix(path.relative(path.dirname(container.abs), target.abs)));
+    case 'urlAbs':
+      return target.url;
+    case 'urlRel':
+      if (!container.url || !target.url) return null;
+      return dotSlash(path.posix.relative(path.posix.dirname(container.url), target.url));
+  }
+}
+
+/**
+ * Resolve a link's raw URL to the absolute doc file it points at.
+ *
+ * Handles every form the repo uses: `@site/docs/...` ESM specifiers, relative and absolute
+ * file-style links (`../foo.mdx`), and URL-style links (`/section/page`, `../page`) which are
+ * mapped back to a file via the URL index. Returns `null` for external links, fragments, and
+ * URLs that resolve to no indexed route.
+ *
+ * @param rawUrl The destination exactly as written.
+ * @param fromFileAbs Absolute path of the file the link lives in.
+ * @param index The docs index.
+ * @returns Absolute target file path, or `null`.
+ */
+export function resolveRefToFile(
+  rawUrl: string,
+  fromFileAbs: string,
+  index: DocsIndex,
+): string | null {
+  const { pathPart } = splitSuffix(rawUrl);
+  if (isExternalOrFragment(pathPart)) return null;
+
+  if (pathPart.startsWith('@site/')) {
+    return path.resolve(index.repoRoot, pathPart.slice('@site/'.length));
+  }
+
+  if (/\.mdx?$/.test(pathPart)) {
+    if (pathPart.startsWith('/')) return path.resolve(index.docsRoot, '.' + pathPart);
+    return path.resolve(path.dirname(fromFileAbs), pathPart);
+  }
+
+  // URL-style link (no extension): map back to a file via the URL index.
+  let urlPath: string;
+  if (pathPart.startsWith('/')) {
+    urlPath = normalizeUrl(pathPart);
+  } else {
+    const fromUrl = index.fileToUrl.get(fromFileAbs);
+    if (!fromUrl) return null; // partials have no stable URL to resolve relative links against
+    urlPath = normalizeUrl(path.posix.join(path.posix.dirname(fromUrl), pathPart));
+  }
+  return index.urlToFile.get(urlPath) ?? null;
+}
+
+/** 1-based line number of a byte offset within `content`. */
+function lineAt(content: string, offset: number): number {
+  let line = 1;
+  for (let i = 0; i < offset && i < content.length; i++) {
+    if (content[i] === '\n') line++;
+  }
+  return line;
+}
+
+/**
+ * Resolve every link in the tree to the file it targets.
+ *
+ * A file that fails to parse is recorded in `unparsed` rather than aborting the scan, so a
+ * single malformed file never silently drops the whole inventory. Callers must surface
+ * `unparsed` — those files may contain references the codemod could not see.
+ *
+ * @param index The docs index.
+ * @returns Resolved {@link LinkRecord}s and any {@link UnparsedFile}s.
+ */
+export function scanLinks(index: DocsIndex): ScanResult {
+  const records: LinkRecord[] = [];
+  const unparsed: UnparsedFile[] = [];
+  for (const file of index.files) {
+    let refs: LinkRef[];
+    try {
+      refs = extractLinkRefs(file.content);
+    } catch (error) {
+      unparsed.push({
+        file: file.abs,
+        reason: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+    for (const ref of refs) {
+      records.push({
+        fromFile: file.abs,
+        ref,
+        toFile: resolveRefToFile(ref.rawUrl, file.abs, index),
+        line: ref.range ? lineAt(file.content, ref.range[0]) : null,
+      });
+    }
+  }
+  return { records, unparsed };
+}

--- a/scripts/lib/mdx-link-codemod.ts
+++ b/scripts/lib/mdx-link-codemod.ts
@@ -62,6 +62,12 @@ export function normalizeUrl(url: string): string {
   return result === '' ? '/' : result;
 }
 
+/** A non-empty string `id:` frontmatter value, or null. Docusaurus disallows slashes in `id`. */
+function frontmatterId(frontmatter?: Record<string, unknown>): string | null {
+  const id = frontmatter?.id;
+  return typeof id === 'string' && id.length > 0 ? id : null;
+}
+
 /** Strip everything up to and including the `docs/` segment, yielding a docs-relative path. */
 function toDocsRelative(filePath: string): string {
   const normalized = filePath.replace(/\\/g, '/');
@@ -91,10 +97,12 @@ function normalizeDocSegments(filePath: string): string[] {
  * `docs/` is mounted at the site root (`routeBasePath: '/'`). Numeric directory prefixes
  * (`02-foo`) are stripped from every segment, `index`/`README` files resolve to their
  * folder root, and a `slug:` frontmatter value overrides the path-derived URL — absolute
- * (`/x`) replacing it entirely, relative (`x`) resolving against the doc's directory.
+ * (`/x`) replacing it entirely, relative (`x`) resolving against the doc's directory. With no
+ * `slug`, an `id:` frontmatter value replaces the final URL segment (Docusaurus derives the
+ * permalink from the doc id, so an id override moves the URL too).
  *
  * @param filePath Doc file path (absolute or repo-relative).
- * @param frontmatter Parsed frontmatter; only `slug` is consulted.
+ * @param frontmatter Parsed frontmatter; `slug` then `id` are consulted.
  * @returns The site URL path, with no trailing slash (matching `trailingSlash: false`).
  */
 export function resolveDocUrl(filePath: string, frontmatter?: Record<string, unknown>): string {
@@ -112,6 +120,9 @@ export function resolveDocUrl(filePath: string, frontmatter?: Record<string, unk
     return normalizeUrl(path.posix.join(directory, slug));
   }
 
+  const id = frontmatterId(frontmatter);
+  if (id !== null && segments.length > 0) segments[segments.length - 1] = id;
+
   return normalizeUrl('/' + segments.join('/'));
 }
 
@@ -119,15 +130,21 @@ export function resolveDocUrl(filePath: string, frontmatter?: Record<string, unk
  * Resolve the Docusaurus document id for a doc file.
  *
  * The id is the docs-relative path without extension and with numeric directory prefixes
- * stripped from every segment — the form referenced in `sidebars.js`. Unlike {@link resolveDocUrl},
- * it ignores `slug` frontmatter and does not collapse `index`/`README` to the folder root.
+ * stripped from every segment — the form referenced in `sidebars.js`. An `id:` frontmatter
+ * value replaces the final segment (e.g. `oracles/01-overview.mdx` with `id: overview-oracles`
+ * resolves to `oracles/overview-oracles`). Unlike {@link resolveDocUrl}, it ignores `slug`
+ * frontmatter and does not collapse `index`/`README` to the folder root.
  *
  * @param filePath Doc file path (absolute or repo-relative).
+ * @param frontmatter Parsed frontmatter; only `id` is consulted.
  * @returns The document id, e.g. `how-arbitrum-works/inside-arbitrum-nitro`.
  */
-export function resolveDocId(filePath: string): string {
+export function resolveDocId(filePath: string, frontmatter?: Record<string, unknown>): string {
   // Same segment transform as the URL, but no slug override and no index/README collapse.
-  return normalizeDocSegments(filePath).join('/');
+  const segments = normalizeDocSegments(filePath);
+  const id = frontmatterId(frontmatter);
+  if (id !== null && segments.length > 0) segments[segments.length - 1] = id;
+  return segments.join('/');
 }
 
 /** Locate the destination token of a markdown `[text](dest)` / `[text](dest "title")` link. */

--- a/scripts/lib/mdx-link-codemod.ts
+++ b/scripts/lib/mdx-link-codemod.ts
@@ -1,0 +1,336 @@
+/**
+ * MDX link codemod primitives.
+ *
+ * Shared building blocks for the doc-restructure tooling. Two responsibilities:
+ *
+ * 1. `resolveDocUrl` — map a doc file path to the site URL Docusaurus serves it at,
+ *    honoring numeric directory prefixes, `index`/`README` folder roots, and `slug:`
+ *    frontmatter overrides.
+ * 2. `extractLinkRefs` — parse an MDX source string and return the byte ranges of every
+ *    link URL across the four surfaces this repo uses (markdown links, `<Link to>` /
+ *    `<a href>` JSX attributes, and ESM partial imports).
+ *
+ * Rewrites are applied by `applyRewrites`, which splices only the URL byte ranges and
+ * leaves every other byte untouched. This keeps doc diffs surgical rather than reformatting
+ * whole files through a remark stringify round-trip.
+ */
+
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkMdx from 'remark-mdx';
+import remarkMath from 'remark-math';
+import { visit } from 'unist-util-visit';
+import path from 'node:path';
+
+const EXTENSION = /\.mdx?$/;
+const NUMERIC_PREFIX = /^\d+-/;
+const FRONTMATTER = /^---\r?\n[\s\S]*?\n---\r?\n?/;
+const EXTERNAL_OR_PROTOCOL = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
+const HTML_COMMENT = /<!--[\s\S]*?-->/g;
+// Docusaurus heading-id syntax (`## Title {#id}`). Strict MDX reads `{#id}` as an expression
+// and acorn rejects the leading `#`. It carries no link, so it is blanked before parsing.
+const HEADING_ID = /\{#[A-Za-z0-9_-]+\}/g;
+
+/** Which MDX surface a link was found on. */
+export type LinkSurface = 'markdown' | 'jsx-attr' | 'esm-import';
+
+/** A single link occurrence located in an MDX source string. */
+export interface LinkRef {
+  surface: LinkSurface;
+  /** The destination exactly as written, including any `#anchor` or `?query`. */
+  rawUrl: string;
+  /** Byte range `[start, end)` of the URL token in the source, or `null` when it cannot be safely spliced. */
+  range: [number, number] | null;
+  /** Set when the link cannot be auto-rewritten; describes why (for manual-review reporting). */
+  skipped?: string;
+  /** JSX element name, e.g. `Link` or `a` (only for `jsx-attr`). */
+  elementName?: string;
+  /** JSX attribute name, e.g. `to` or `href` (only for `jsx-attr`). */
+  attrName?: string;
+}
+
+/** A byte-range replacement to apply to a source string. */
+export interface Rewrite {
+  range: [number, number];
+  newText: string;
+}
+
+/** Collapse duplicate slashes and drop a trailing slash (except for the root `/`). */
+export function normalizeUrl(url: string): string {
+  let result = url.replace(/\/{2,}/g, '/');
+  if (result.length > 1) result = result.replace(/\/$/, '');
+  return result === '' ? '/' : result;
+}
+
+/** Strip everything up to and including the `docs/` segment, yielding a docs-relative path. */
+function toDocsRelative(filePath: string): string {
+  const normalized = filePath.replace(/\\/g, '/');
+  const match = normalized.match(/(?:^|\/)docs\/(.*)$/);
+  return match ? match[1] : normalized.replace(/^\//, '');
+}
+
+/**
+ * Resolve the site URL Docusaurus serves a doc file at.
+ *
+ * `docs/` is mounted at the site root (`routeBasePath: '/'`). Numeric directory prefixes
+ * (`02-foo`) are stripped from every segment, `index`/`README` files resolve to their
+ * folder root, and a `slug:` frontmatter value overrides the path-derived URL — absolute
+ * (`/x`) replacing it entirely, relative (`x`) resolving against the doc's directory.
+ *
+ * @param filePath Doc file path (absolute or repo-relative).
+ * @param frontmatter Parsed frontmatter; only `slug` is consulted.
+ * @returns The site URL path, with no trailing slash (matching `trailingSlash: false`).
+ */
+export function resolveDocUrl(filePath: string, frontmatter?: Record<string, unknown>): string {
+  const relative = toDocsRelative(filePath);
+  const segments = relative
+    .split('/')
+    .filter(Boolean)
+    .map((segment, index, all) =>
+      index === all.length - 1 ? segment.replace(EXTENSION, '') : segment,
+    )
+    .map((segment) => segment.replace(NUMERIC_PREFIX, ''));
+
+  if (segments.length > 0 && /^(?:index|readme)$/i.test(segments[segments.length - 1])) {
+    segments.pop();
+  }
+
+  const slug = frontmatter?.slug;
+  if (typeof slug === 'string' && slug.length > 0) {
+    if (slug.startsWith('/')) return normalizeUrl(slug);
+    const directory = '/' + segments.slice(0, -1).join('/');
+    return normalizeUrl(path.posix.join(directory, slug));
+  }
+
+  return normalizeUrl('/' + segments.join('/'));
+}
+
+/**
+ * Resolve the Docusaurus document id for a doc file.
+ *
+ * The id is the docs-relative path without extension and with numeric directory prefixes
+ * stripped from every segment — the form referenced in `sidebars.js`. Unlike {@link resolveDocUrl},
+ * it ignores `slug` frontmatter and does not collapse `index`/`README` to the folder root.
+ *
+ * @param filePath Doc file path (absolute or repo-relative).
+ * @returns The document id, e.g. `how-arbitrum-works/inside-arbitrum-nitro`.
+ */
+export function resolveDocId(filePath: string): string {
+  return toDocsRelative(filePath)
+    .split('/')
+    .filter(Boolean)
+    .map((segment, index, all) =>
+      index === all.length - 1 ? segment.replace(EXTENSION, '') : segment,
+    )
+    .map((segment) => segment.replace(NUMERIC_PREFIX, ''))
+    .join('/');
+}
+
+/** Locate the destination token of a markdown `[text](dest)` / `[text](dest "title")` link. */
+function locateMarkdownDestination(
+  source: string,
+  start: number,
+  end: number,
+): { url: string; start: number; end: number } | null {
+  const slice = source.slice(start, end);
+  const open = slice.indexOf('](');
+  if (open === -1) return null;
+
+  let cursor = open + 2;
+  while (cursor < slice.length && /\s/.test(slice[cursor])) cursor++;
+
+  const angled = slice[cursor] === '<';
+  if (angled) cursor++;
+  const destStart = cursor;
+
+  if (angled) {
+    while (cursor < slice.length && slice[cursor] !== '>') cursor++;
+  } else {
+    while (cursor < slice.length && !/[\s)]/.test(slice[cursor])) cursor++;
+  }
+
+  const url = slice.slice(destStart, cursor);
+  if (url.length === 0) return null;
+  return { url, start: start + destStart, end: start + cursor };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Locate the value token of a JSX string attribute (`name="value"` / `name='value'`). */
+function locateAttributeValue(
+  source: string,
+  start: number,
+  end: number,
+  name: string,
+  value: string,
+): { start: number; end: number } | null {
+  const slice = source.slice(start, end);
+  for (const quote of ['"', "'"]) {
+    const pattern = new RegExp(
+      escapeRegExp(name) + '\\s*=\\s*' + quote + escapeRegExp(value) + quote,
+    );
+    const match = pattern.exec(slice);
+    if (!match) continue;
+    const valueStart = match.index + match[0].length - value.length - 1;
+    return { start: start + valueStart, end: start + valueStart + value.length };
+  }
+  return null;
+}
+
+/** Locate every module specifier string inside an ESM import block. */
+function locateEsmSpecifiers(
+  base: number,
+  value: string,
+): Array<{ url: string; start: number; end: number }> {
+  const specifiers: Array<{ url: string; start: number; end: number }> = [];
+  const pattern = /(?:from|import)\s+(['"])([^'"]*)\1/g;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(value)) !== null) {
+    const quote = match[1];
+    const specifier = match[2];
+    const specifierStart = match.index + match[0].indexOf(quote) + 1;
+    specifiers.push({
+      url: specifier,
+      start: base + specifierStart,
+      end: base + specifierStart + specifier.length,
+    });
+  }
+  return specifiers;
+}
+
+/** Read the raw source text of an expression-valued JSX attribute, for manual-review reporting. */
+function expressionText(value: unknown): string {
+  if (value && typeof value === 'object' && 'value' in value) {
+    return String((value as { value: unknown }).value ?? '');
+  }
+  return String(value ?? '');
+}
+
+/**
+ * Extract every link reference from an MDX source string.
+ *
+ * Frontmatter is sliced off before parsing (MDX is strict and frontmatter may contain
+ * characters that look like JSX), and all returned byte ranges are offset back into the
+ * original source so they can be spliced directly.
+ *
+ * @param source Raw MDX file contents.
+ * @returns One `LinkRef` per link occurrence across all four surfaces.
+ */
+export function extractLinkRefs(source: string): LinkRef[] {
+  const frontmatter = source.match(FRONTMATTER);
+  const offset = frontmatter ? frontmatter[0].length : 0;
+  // Blank HTML comments (`<!-- -->`) to equal-length whitespace before parsing: strict MDX
+  // rejects them but this repo's `.mdx` files use them and Docusaurus tolerates them. Newlines
+  // are preserved so byte offsets stay aligned with the original source, and links commented
+  // out in the source are correctly ignored rather than rewritten.
+  const body = source
+    .slice(offset)
+    .replace(HTML_COMMENT, (match) => match.replace(/[^\n]/g, ' '))
+    .replace(HEADING_ID, (match) => ' '.repeat(match.length));
+
+  // `remark-parse`, `remark-math`, and `remark-mdx` resolve their own nested copies of `unified`
+  // in the Docusaurus dependency tree, so their plugin types reference a structurally-distinct
+  // `Processor`. The pipeline is correct at runtime; cast to sidestep the duplicate-types
+  // artifact rather than force a repo-wide `unified` resolution that could disturb the build.
+  // `remark-math` matches Docusaurus's own pipeline so `$…$` math is not misread as MDX.
+  const processor = unified()
+    .use(remarkParse as never)
+    .use(remarkMath as never)
+    .use(remarkMdx as never);
+  const tree = processor.parse(body);
+  const refs: LinkRef[] = [];
+
+  visit(tree, (node: any) => {
+    const position = node.position;
+    if (!position || position.start.offset == null || position.end.offset == null) return;
+    const start = position.start.offset + offset;
+    const end = position.end.offset + offset;
+
+    if (node.type === 'link') {
+      const located = locateMarkdownDestination(source, start, end);
+      if (located) {
+        refs.push({
+          surface: 'markdown',
+          rawUrl: located.url,
+          range: [located.start, located.end],
+        });
+      } else {
+        refs.push({
+          surface: 'markdown',
+          rawUrl: node.url ?? '',
+          range: null,
+          skipped: 'unparsed-destination',
+        });
+      }
+      return;
+    }
+
+    if (node.type === 'mdxJsxFlowElement' || node.type === 'mdxJsxTextElement') {
+      for (const attr of node.attributes ?? []) {
+        if (attr.type !== 'mdxJsxAttribute') continue;
+        if (attr.name !== 'to' && attr.name !== 'href') continue;
+
+        if (typeof attr.value !== 'string') {
+          refs.push({
+            surface: 'jsx-attr',
+            rawUrl: expressionText(attr.value),
+            range: null,
+            skipped: 'expression',
+            elementName: node.name ?? undefined,
+            attrName: attr.name,
+          });
+          continue;
+        }
+
+        const located = locateAttributeValue(source, start, end, attr.name, attr.value);
+        refs.push({
+          surface: 'jsx-attr',
+          rawUrl: attr.value,
+          range: located ? [located.start, located.end] : null,
+          skipped: located ? undefined : 'attr-not-located',
+          elementName: node.name ?? undefined,
+          attrName: attr.name,
+        });
+      }
+      return;
+    }
+
+    if (node.type === 'mdxjsEsm') {
+      for (const specifier of locateEsmSpecifiers(start, node.value ?? '')) {
+        refs.push({
+          surface: 'esm-import',
+          rawUrl: specifier.url,
+          range: [specifier.start, specifier.end],
+        });
+      }
+    }
+  });
+
+  return refs;
+}
+
+/** True when a raw URL points outside the docs tree (protocol, scheme-relative, or fragment-only). */
+export function isExternalOrFragment(rawUrl: string): boolean {
+  return rawUrl.length === 0 || rawUrl.startsWith('#') || EXTERNAL_OR_PROTOCOL.test(rawUrl);
+}
+
+/**
+ * Apply URL byte-range replacements to a source string.
+ *
+ * Rewrites are applied from the end of the file backward so earlier replacements never
+ * shift the offsets of later ones.
+ *
+ * @param source Original source string.
+ * @param rewrites Byte-range replacements; ranges must not overlap.
+ * @returns The rewritten source.
+ */
+export function applyRewrites(source: string, rewrites: Rewrite[]): string {
+  const ordered = [...rewrites].sort((a, b) => b.range[0] - a.range[0]);
+  let result = source;
+  for (const { range, newText } of ordered) {
+    result = result.slice(0, range[0]) + newText + result.slice(range[1]);
+  }
+  return result;
+}

--- a/scripts/lib/mdx-link-codemod.ts
+++ b/scripts/lib/mdx-link-codemod.ts
@@ -70,6 +70,22 @@ function toDocsRelative(filePath: string): string {
 }
 
 /**
+ * Split a docs-relative path into the segments shared by both the URL and the doc id: drop the
+ * file extension from the last segment and strip the numeric ordering prefix (`02-`) from every
+ * segment. {@link resolveDocUrl} and {@link resolveDocId} share this step, then diverge on
+ * slug/index handling — keep the segment transform here so the two can never drift apart.
+ */
+function normalizeDocSegments(filePath: string): string[] {
+  return toDocsRelative(filePath)
+    .split('/')
+    .filter(Boolean)
+    .map((segment, index, all) =>
+      index === all.length - 1 ? segment.replace(EXTENSION, '') : segment,
+    )
+    .map((segment) => segment.replace(NUMERIC_PREFIX, ''));
+}
+
+/**
  * Resolve the site URL Docusaurus serves a doc file at.
  *
  * `docs/` is mounted at the site root (`routeBasePath: '/'`). Numeric directory prefixes
@@ -82,15 +98,9 @@ function toDocsRelative(filePath: string): string {
  * @returns The site URL path, with no trailing slash (matching `trailingSlash: false`).
  */
 export function resolveDocUrl(filePath: string, frontmatter?: Record<string, unknown>): string {
-  const relative = toDocsRelative(filePath);
-  const segments = relative
-    .split('/')
-    .filter(Boolean)
-    .map((segment, index, all) =>
-      index === all.length - 1 ? segment.replace(EXTENSION, '') : segment,
-    )
-    .map((segment) => segment.replace(NUMERIC_PREFIX, ''));
+  const segments = normalizeDocSegments(filePath);
 
+  // `index`/`README` resolve to the folder root (drop the trailing segment).
   if (segments.length > 0 && /^(?:index|readme)$/i.test(segments[segments.length - 1])) {
     segments.pop();
   }
@@ -116,14 +126,8 @@ export function resolveDocUrl(filePath: string, frontmatter?: Record<string, unk
  * @returns The document id, e.g. `how-arbitrum-works/inside-arbitrum-nitro`.
  */
 export function resolveDocId(filePath: string): string {
-  return toDocsRelative(filePath)
-    .split('/')
-    .filter(Boolean)
-    .map((segment, index, all) =>
-      index === all.length - 1 ? segment.replace(EXTENSION, '') : segment,
-    )
-    .map((segment) => segment.replace(NUMERIC_PREFIX, ''))
-    .join('/');
+  // Same segment transform as the URL, but no slug override and no index/README collapse.
+  return normalizeDocSegments(filePath).join('/');
 }
 
 /** Locate the destination token of a markdown `[text](dest)` / `[text](dest "title")` link. */
@@ -242,6 +246,8 @@ export function extractLinkRefs(source: string): LinkRef[] {
   const tree = processor.parse(body);
   const refs: LinkRef[] = [];
 
+  // `node` is typed `any`: typing it precisely would mean importing and unioning every
+  // remark-mdx node type, which is noise for tooling that only branches on `node.type`.
   visit(tree, (node: any) => {
     const position = node.position;
     if (!position || position.start.offset == null || position.end.offset == null) return;
@@ -298,7 +304,10 @@ export function extractLinkRefs(source: string): LinkRef[] {
     }
 
     if (node.type === 'mdxjsEsm') {
-      for (const specifier of locateEsmSpecifiers(start, node.value ?? '')) {
+      // Scan the original source slice (not `node.value`): the parsed value comes from the
+      // comment/heading-id-blanked body, so searching the real source guarantees the specifier
+      // offsets line up with what `applyRewrites` will splice.
+      for (const specifier of locateEsmSpecifiers(start, source.slice(start, end))) {
         refs.push({
           surface: 'esm-import',
           rawUrl: specifier.url,

--- a/scripts/move-doc.ts
+++ b/scripts/move-doc.ts
@@ -320,8 +320,8 @@ async function main(): Promise<void> {
   const toRel = path.join('docs', path.relative(docsRoot, toAbs));
   const oldUrl = partial ? null : resolveDocUrl(fromFile.rel, frontmatter);
   const newUrl = partial ? null : resolveDocUrl(toRel, frontmatter);
-  const oldId = partial ? null : resolveDocId(fromFile.rel);
-  const newId = partial ? null : resolveDocId(toRel);
+  const oldId = partial ? null : resolveDocId(fromFile.rel, frontmatter);
+  const newId = partial ? null : resolveDocId(toRel, frontmatter);
 
   const { records, unparsed } = scanLinks(index);
   const {

--- a/scripts/move-doc.ts
+++ b/scripts/move-doc.ts
@@ -72,6 +72,42 @@ interface Change {
   next: string;
 }
 
+/** The disposition of one link under a move: rewrite it, flag it, or leave it. */
+type RewritePlan =
+  | { kind: 'rewrite'; rewrite: Rewrite; change: Change }
+  | { kind: 'unrenderable' }
+  | { kind: 'skip' };
+
+/**
+ * Render one link's rewrite, preserving its written form (`@site/…`, absolute URL, relative
+ * file/url, with any `#anchor`/`?query` suffix). Shared by both planners — the only thing that
+ * differs between inbound and outbound is which side moved, expressed via `target`/`container`.
+ *
+ * Returns `unrenderable` when the link has a byte range but its style can't be re-expressed in
+ * this context (e.g. a relative URL link inside a partial, which has no base URL) so the caller
+ * can surface it for manual review; `skip` when the rendered form is unchanged. Callers must
+ * handle a null `record.ref.range` themselves before calling.
+ */
+function planLinkRewrite(
+  record: LinkRecord,
+  target: { abs: string; url: string | null },
+  container: { abs: string; url: string | null },
+  index: DocsIndex,
+): RewritePlan {
+  const range = record.ref.range;
+  if (range === null) return { kind: 'skip' };
+  const { pathPart, suffix } = splitSuffix(record.ref.rawUrl);
+  const newPath = renderRef(detectLinkStyle(pathPart), target, container, index);
+  if (newPath === null) return { kind: 'unrenderable' };
+  const next = newPath + suffix;
+  if (next === record.ref.rawUrl) return { kind: 'skip' };
+  return {
+    kind: 'rewrite',
+    rewrite: { range, newText: next },
+    change: { file: container.abs, old: record.ref.rawUrl, next },
+  };
+}
+
 /** Build rewrites for links pointing AT the moved file (target moved, container unchanged). */
 function planInbound(
   records: LinkRecord[],
@@ -91,32 +127,24 @@ function planInbound(
   const edits: FileEdit[] = [];
   const unrenderable: LinkRecord[] = [];
   const changes: Change[] = [];
+  const target = { abs: toAbs, url: newUrl };
   for (const [abs, recs] of byFile) {
     const file = index.files.find((candidate) => candidate.abs === abs);
     if (!file) continue;
-    const containerUrl = index.fileToUrl.get(abs) ?? null;
+    const container = { abs, url: index.fileToUrl.get(abs) ?? null };
     const rewrites: Rewrite[] = [];
     for (const record of recs) {
+      // A range-less ref that resolves to the moved file (e.g. a markdown link whose destination
+      // could not be located) is known-broken-by-the-move but not auto-fixable — flag it.
       if (record.ref.range === null) {
         unrenderable.push(record);
         continue;
       }
-      const { pathPart, suffix } = splitSuffix(record.ref.rawUrl);
-      const style = detectLinkStyle(pathPart);
-      const newPath = renderRef(
-        style,
-        { abs: toAbs, url: newUrl },
-        { abs, url: containerUrl },
-        index,
-      );
-      if (newPath === null) {
-        unrenderable.push(record);
-        continue;
-      }
-      const next = newPath + suffix;
-      if (next !== record.ref.rawUrl) {
-        rewrites.push({ range: record.ref.range, newText: next });
-        changes.push({ file: abs, old: record.ref.rawUrl, next });
+      const plan = planLinkRewrite(record, target, container, index);
+      if (plan.kind === 'unrenderable') unrenderable.push(record);
+      else if (plan.kind === 'rewrite') {
+        rewrites.push(plan.rewrite);
+        changes.push(plan.change);
       }
     }
     if (rewrites.length > 0) edits.push({ abs, content: file.content, rewrites });
@@ -134,25 +162,23 @@ function planOutbound(
 ): { rewrites: Rewrite[]; changes: Change[] } {
   const rewrites: Rewrite[] = [];
   const changes: Change[] = [];
+  const container = { abs: toAbs, url: newUrl };
   for (const record of records) {
     if (record.fromFile !== fromAbs || record.ref.range === null || record.toFile === null)
       continue;
-    const { pathPart, suffix } = splitSuffix(record.ref.rawUrl);
-    const style = detectLinkStyle(pathPart);
+    const style = detectLinkStyle(splitSuffix(record.ref.rawUrl).pathPart);
     // Absolute forms (`/x`, `@site/…`) are location-independent; only relative forms move.
     if (style !== 'fileRel' && style !== 'urlRel') continue;
-    const targetUrl = index.fileToUrl.get(record.toFile) ?? null;
-    const newPath = renderRef(
-      style,
-      { abs: record.toFile, url: targetUrl },
-      { abs: toAbs, url: newUrl },
-      index,
-    );
-    if (newPath === null) continue;
-    const next = newPath + suffix;
-    if (next !== record.ref.rawUrl) {
-      rewrites.push({ range: record.ref.range, newText: next });
-      changes.push({ file: toAbs, old: record.ref.rawUrl, next });
+    // A self-link points back at the moved file, so its target is the NEW location — `index`
+    // still maps `fromAbs` to the pre-move URL, so don't look it up there.
+    const target =
+      record.toFile === fromAbs
+        ? { abs: toAbs, url: newUrl }
+        : { abs: record.toFile, url: index.fileToUrl.get(record.toFile) ?? null };
+    const plan = planLinkRewrite(record, target, container, index);
+    if (plan.kind === 'rewrite') {
+      rewrites.push(plan.rewrite);
+      changes.push(plan.change);
     }
   }
   return { rewrites, changes };
@@ -201,7 +227,9 @@ async function appendRedirect(
   const existed = existsSync(redirectsPath);
   const current = existed ? await readFile(redirectsPath, 'utf8') : redirectsTemplate();
 
-  if (current.includes(`from: '${from}'`)) return 'exists';
+  // Anchor the idempotency check to the entry's opening (`{ from: '…'`) so it matches a real
+  // redirect entry and never a substring of some other value.
+  if (current.includes(`{ from: '${from}'`)) return 'exists';
   if (!current.includes(REDIRECTS_END)) {
     throw new Error(
       `move-doc: ${path.basename(redirectsPath)} is missing the ${REDIRECTS_END} sentinel`,

--- a/scripts/move-doc.ts
+++ b/scripts/move-doc.ts
@@ -10,7 +10,7 @@
  *   2. moves the file, recomputing the file's *own* relative links so they stay valid from the
  *      new location;
  *   3. updates the doc id referenced in `sidebars.js`;
- *   4. records the old→new URL in `redirects.config.ts` (created if absent).
+ *   4. records the old→new URL in `redirects.config.js` (created if absent).
  *
  * `--dry-run` prints every change without touching the filesystem. After a real run, verify with
  * `yarn build` and propagate the redirect to the edge with `yarn sync-redirects`.
@@ -185,7 +185,7 @@ export const redirects = [
 `;
 }
 
-/** Append a redirect entry to redirects.config.ts (creating the file if needed). Idempotent on `from`. */
+/** Append a redirect entry to redirects.config.js (creating the file if needed). Idempotent on `from`. */
 async function appendRedirect(
   redirectsPath: string,
   from: string,

--- a/scripts/move-doc.ts
+++ b/scripts/move-doc.ts
@@ -21,7 +21,13 @@ import { readFile, writeFile, mkdir, rm } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import matter from 'gray-matter';
 
-import { resolveDocUrl, resolveDocId, applyRewrites, type Rewrite } from './lib/mdx-link-codemod';
+import {
+  resolveDocUrl,
+  resolveDocId,
+  applyRewrites,
+  isExternalOrFragment,
+  type Rewrite,
+} from './lib/mdx-link-codemod';
 import {
   buildDocsIndex,
   scanLinks,
@@ -284,6 +290,16 @@ async function main(): Promise<void> {
     'Glossary content was affected — run `yarn build-glossary` to refresh static/glossary.json ' +
     '(the quicklook tooltips). `yarn build` does not flag stale glossary links.';
 
+  // A relative link inside a partial cannot be resolved statically: a partial has no fixed URL,
+  // so `../x` depends on which page imports it. Such links are never auto-rewritten — flag them
+  // (like expression links) so a move never silently leaves one pointing at the old location.
+  const ambiguousPartialLinks = records.filter((record) => {
+    if (record.toFile !== null || !isPartial(record.fromFile)) return false;
+    const { pathPart } = splitSuffix(record.ref.rawUrl);
+    if (isExternalOrFragment(pathPart)) return false;
+    return pathPart.startsWith('.');
+  });
+
   const inboundRefCount = edits.reduce((sum, edit) => sum + edit.rewrites.length, 0);
   console.log(
     `${dryRun ? '[dry-run] ' : ''}move ${fromFile.rel} -> ${path.relative(repoRoot, toAbs)}`,
@@ -311,6 +327,15 @@ async function main(): Promise<void> {
       `  WARNING: ${unparsed.length} file(s) could not be parsed and were not scanned for references:`,
     );
     for (const { file } of unparsed) console.warn(`    ${path.relative(repoRoot, file)}`);
+  }
+  if (ambiguousPartialLinks.length > 0) {
+    console.warn(
+      `  WARNING: ${ambiguousPartialLinks.length} relative link(s) inside partials cannot be resolved ` +
+        `(a partial has no fixed URL); if this move affects their target, update them manually:`,
+    );
+    for (const record of ambiguousPartialLinks) {
+      console.warn(`    ${path.relative(repoRoot, record.fromFile)}: ${record.ref.rawUrl}`);
+    }
   }
 
   if (dryRun) {

--- a/scripts/move-doc.ts
+++ b/scripts/move-doc.ts
@@ -274,6 +274,16 @@ async function main(): Promise<void> {
       ? updateSidebars(sidebarsBefore, oldId, newId)
       : { content: sidebarsBefore, count: 0 };
 
+  // Glossary terms are rendered into runtime quicklook tooltips from the generated
+  // static/glossary.json, which `yarn build` does NOT validate. If a glossary source partial
+  // was rewritten (or moved), the generated JSON must be regenerated separately.
+  const isGlossary = (p: string) => p.replace(/\\/g, '/').includes('/partials/glossary/');
+  const touchedGlossary =
+    edits.some((edit) => isGlossary(edit.abs)) || isGlossary(fromAbs) || isGlossary(toAbs);
+  const glossaryReminder =
+    'Glossary content was affected — run `yarn build-glossary` to refresh static/glossary.json ' +
+    '(the quicklook tooltips). `yarn build` does not flag stale glossary links.';
+
   const inboundRefCount = edits.reduce((sum, edit) => sum + edit.rewrites.length, 0);
   console.log(
     `${dryRun ? '[dry-run] ' : ''}move ${fromFile.rel} -> ${path.relative(repoRoot, toAbs)}`,
@@ -315,6 +325,7 @@ async function main(): Promise<void> {
     }
     if (!partial && oldUrl !== newUrl)
       console.log(`  redirect: { from: '${oldUrl}', to: '${newUrl}' }`);
+    if (touchedGlossary) console.log(`\n  ${glossaryReminder}`);
     console.log('\n[dry-run] no files were changed.');
     return;
   }
@@ -334,12 +345,13 @@ async function main(): Promise<void> {
       newUrl,
       false,
     );
-    console.log(`  redirects.config.ts: ${status} { from: '${oldUrl}', to: '${newUrl}' }`);
+    console.log(`  redirects.config.js: ${status} { from: '${oldUrl}', to: '${newUrl}' }`);
   }
 
   console.log(
     '\nDone. Next: `yarn build` to verify links, then `yarn sync-redirects` to update vercel.json.',
   );
+  if (touchedGlossary) console.log(`Also: ${glossaryReminder}`);
 }
 
 main().catch((error) => {

--- a/scripts/move-doc.ts
+++ b/scripts/move-doc.ts
@@ -185,20 +185,25 @@ function planOutbound(
   return { rewrites, changes };
 }
 
-/** Replace a doc id everywhere it is referenced as a quoted string in `sidebars.js`. */
+/**
+ * Rewrite references to the moved doc in `sidebars.js`. A doc-item entry references it by id, while
+ * a `link`-type entry references it by URL (`href: '/x'`) — both must be updated or the URL ones
+ * 404, and the sidebar renders site-wide so one stale href breaks the build on every page. Each
+ * token is matched quote-delimited so a swap can't hit a substring of a longer id or path.
+ */
 function updateSidebars(
   content: string,
-  oldId: string,
-  newId: string,
+  swaps: ReadonlyArray<readonly [from: string, to: string]>,
 ): { content: string; count: number } {
   let count = 0;
   let updated = content;
-  for (const quote of ["'", '"']) {
-    const needle = `${quote}${oldId}${quote}`;
-    const replacement = `${quote}${newId}${quote}`;
-    const parts = updated.split(needle);
-    count += parts.length - 1;
-    updated = parts.join(replacement);
+  for (const [from, to] of swaps) {
+    if (from === to) continue;
+    for (const quote of ["'", '"']) {
+      const parts = updated.split(`${quote}${from}${quote}`);
+      count += parts.length - 1;
+      updated = parts.join(`${quote}${to}${quote}`);
+    }
   }
   return { content: updated, count };
 }
@@ -335,10 +340,10 @@ async function main(): Promise<void> {
 
   const sidebarsPath = path.join(repoRoot, 'sidebars.js');
   const sidebarsBefore = await readFile(sidebarsPath, 'utf8');
-  const sidebarsResult =
-    oldId && newId && oldId !== newId
-      ? updateSidebars(sidebarsBefore, oldId, newId)
-      : { content: sidebarsBefore, count: 0 };
+  const sidebarsSwaps: Array<readonly [string, string]> = [];
+  if (oldId && newId) sidebarsSwaps.push([oldId, newId]);
+  if (oldUrl && newUrl) sidebarsSwaps.push([oldUrl, newUrl]);
+  const sidebarsResult = updateSidebars(sidebarsBefore, sidebarsSwaps);
 
   // Glossary terms are rendered into runtime quicklook tooltips from the generated
   // static/glossary.json, which `yarn build` does NOT validate. If a glossary source partial
@@ -372,7 +377,7 @@ async function main(): Promise<void> {
   for (const edit of edits)
     console.log(`    ${path.relative(repoRoot, edit.abs)} (${edit.rewrites.length})`);
   console.log(`  moved-file relative links rewritten: ${outboundRewrites.length}`);
-  console.log(`  sidebars.js id replacements: ${sidebarsResult.count}`);
+  console.log(`  sidebars.js references updated (id + href): ${sidebarsResult.count}`);
 
   if (unrenderable.length > 0) {
     console.warn(

--- a/scripts/move-doc.ts
+++ b/scripts/move-doc.ts
@@ -1,0 +1,348 @@
+/**
+ * move-doc — move a doc file and rewrite everything that points at it.
+ *
+ * Usage:
+ *   yarn move-doc <from> <to> [--dry-run]
+ *
+ * In one command this:
+ *   1. rewrites every internal link in the tree that resolves to <from> so it points at <to>,
+ *      preserving each link's written form (absolute URL, relative file path, `@site/…`, anchor);
+ *   2. moves the file, recomputing the file's *own* relative links so they stay valid from the
+ *      new location;
+ *   3. updates the doc id referenced in `sidebars.js`;
+ *   4. records the old→new URL in `redirects.config.ts` (created if absent).
+ *
+ * `--dry-run` prints every change without touching the filesystem. After a real run, verify with
+ * `yarn build` and propagate the redirect to the edge with `yarn sync-redirects`.
+ */
+
+import path from 'node:path';
+import { readFile, writeFile, mkdir, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import matter from 'gray-matter';
+
+import { resolveDocUrl, resolveDocId, applyRewrites, type Rewrite } from './lib/mdx-link-codemod';
+import {
+  buildDocsIndex,
+  scanLinks,
+  splitSuffix,
+  detectLinkStyle,
+  renderRef,
+  isPartial,
+  type DocsIndex,
+  type LinkRecord,
+} from './lib/docs-link-index';
+
+const REDIRECTS_START = '// AUTO-GENERATED REDIRECTS START';
+const REDIRECTS_END = '// AUTO-GENERATED REDIRECTS END';
+
+interface Args {
+  from: string;
+  to: string;
+  dryRun: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const positional = argv.filter((arg) => !arg.startsWith('--'));
+  const dryRun = argv.includes('--dry-run');
+  if (positional.length !== 2) {
+    console.error('usage: yarn move-doc <from> <to> [--dry-run]');
+    process.exit(1);
+  }
+  return { from: positional[0], to: positional[1], dryRun };
+}
+
+/** A pending rewrite of a single file's contents. */
+interface FileEdit {
+  abs: string;
+  content: string;
+  rewrites: Rewrite[];
+}
+
+/** A human-readable description of one link rewrite, for `--dry-run` output. */
+interface Change {
+  file: string;
+  old: string;
+  next: string;
+}
+
+/** Build rewrites for links pointing AT the moved file (target moved, container unchanged). */
+function planInbound(
+  records: LinkRecord[],
+  index: DocsIndex,
+  fromAbs: string,
+  toAbs: string,
+  newUrl: string | null,
+): { edits: FileEdit[]; unrenderable: LinkRecord[]; changes: Change[] } {
+  const byFile = new Map<string, LinkRecord[]>();
+  for (const record of records) {
+    if (record.toFile !== fromAbs || record.fromFile === fromAbs) continue;
+    const bucket = byFile.get(record.fromFile);
+    if (bucket) bucket.push(record);
+    else byFile.set(record.fromFile, [record]);
+  }
+
+  const edits: FileEdit[] = [];
+  const unrenderable: LinkRecord[] = [];
+  const changes: Change[] = [];
+  for (const [abs, recs] of byFile) {
+    const file = index.files.find((candidate) => candidate.abs === abs);
+    if (!file) continue;
+    const containerUrl = index.fileToUrl.get(abs) ?? null;
+    const rewrites: Rewrite[] = [];
+    for (const record of recs) {
+      if (record.ref.range === null) {
+        unrenderable.push(record);
+        continue;
+      }
+      const { pathPart, suffix } = splitSuffix(record.ref.rawUrl);
+      const style = detectLinkStyle(pathPart);
+      const newPath = renderRef(
+        style,
+        { abs: toAbs, url: newUrl },
+        { abs, url: containerUrl },
+        index,
+      );
+      if (newPath === null) {
+        unrenderable.push(record);
+        continue;
+      }
+      const next = newPath + suffix;
+      if (next !== record.ref.rawUrl) {
+        rewrites.push({ range: record.ref.range, newText: next });
+        changes.push({ file: abs, old: record.ref.rawUrl, next });
+      }
+    }
+    if (rewrites.length > 0) edits.push({ abs, content: file.content, rewrites });
+  }
+  return { edits, unrenderable, changes };
+}
+
+/** Rewrite the moved file's own relative links so they remain valid from the new location. */
+function planOutbound(
+  records: LinkRecord[],
+  index: DocsIndex,
+  fromAbs: string,
+  toAbs: string,
+  newUrl: string | null,
+): { rewrites: Rewrite[]; changes: Change[] } {
+  const rewrites: Rewrite[] = [];
+  const changes: Change[] = [];
+  for (const record of records) {
+    if (record.fromFile !== fromAbs || record.ref.range === null || record.toFile === null)
+      continue;
+    const { pathPart, suffix } = splitSuffix(record.ref.rawUrl);
+    const style = detectLinkStyle(pathPart);
+    // Absolute forms (`/x`, `@site/…`) are location-independent; only relative forms move.
+    if (style !== 'fileRel' && style !== 'urlRel') continue;
+    const targetUrl = index.fileToUrl.get(record.toFile) ?? null;
+    const newPath = renderRef(
+      style,
+      { abs: record.toFile, url: targetUrl },
+      { abs: toAbs, url: newUrl },
+      index,
+    );
+    if (newPath === null) continue;
+    const next = newPath + suffix;
+    if (next !== record.ref.rawUrl) {
+      rewrites.push({ range: record.ref.range, newText: next });
+      changes.push({ file: toAbs, old: record.ref.rawUrl, next });
+    }
+  }
+  return { rewrites, changes };
+}
+
+/** Replace a doc id everywhere it is referenced as a quoted string in `sidebars.js`. */
+function updateSidebars(
+  content: string,
+  oldId: string,
+  newId: string,
+): { content: string; count: number } {
+  let count = 0;
+  let updated = content;
+  for (const quote of ["'", '"']) {
+    const needle = `${quote}${oldId}${quote}`;
+    const replacement = `${quote}${newId}${quote}`;
+    const parts = updated.split(needle);
+    count += parts.length - 1;
+    updated = parts.join(replacement);
+  }
+  return { content: updated, count };
+}
+
+function redirectsTemplate(): string {
+  return `/**
+ * Internal doc redirects: old URL -> new URL.
+ *
+ * Entries between the AUTO-GENERATED markers are maintained by \`yarn move-doc\`. Consumed by
+ * \`@docusaurus/plugin-client-redirects\` (in-app) and \`yarn sync-redirects\` (which mirrors them
+ * into vercel.json for the edge). Types live in redirects.config.d.ts.
+ */
+export const redirects = [
+  ${REDIRECTS_START}
+  ${REDIRECTS_END}
+];
+`;
+}
+
+/** Append a redirect entry to redirects.config.ts (creating the file if needed). Idempotent on `from`. */
+async function appendRedirect(
+  redirectsPath: string,
+  from: string,
+  to: string,
+  dryRun: boolean,
+): Promise<'created' | 'appended' | 'exists'> {
+  const existed = existsSync(redirectsPath);
+  const current = existed ? await readFile(redirectsPath, 'utf8') : redirectsTemplate();
+
+  if (current.includes(`from: '${from}'`)) return 'exists';
+  if (!current.includes(REDIRECTS_END)) {
+    throw new Error(
+      `move-doc: ${path.basename(redirectsPath)} is missing the ${REDIRECTS_END} sentinel`,
+    );
+  }
+
+  const entry = `  { from: '${from}', to: '${to}' },\n  ${REDIRECTS_END}`;
+  const next = current.replace(`  ${REDIRECTS_END}`, entry);
+  if (!dryRun) await writeFile(redirectsPath, next);
+  return existed ? 'appended' : 'created';
+}
+
+async function main(): Promise<void> {
+  const { from, to, dryRun } = parseArgs(process.argv.slice(2));
+  const repoRoot = process.cwd();
+  const fromAbs = path.resolve(repoRoot, from);
+  const toAbs = path.resolve(repoRoot, to);
+  const docsRoot = path.join(repoRoot, 'docs');
+
+  for (const [label, abs] of [
+    ['from', fromAbs],
+    ['to', toAbs],
+  ] as const) {
+    if (!abs.startsWith(docsRoot + path.sep) || !/\.mdx?$/.test(abs)) {
+      console.error(`move-doc: <${label}> must be a .md/.mdx file under docs/: ${abs}`);
+      process.exit(1);
+    }
+  }
+  if (fromAbs === toAbs) {
+    console.error('move-doc: <from> and <to> are the same path');
+    process.exit(1);
+  }
+  if (!existsSync(fromAbs)) {
+    console.error(`move-doc: <from> does not exist: ${fromAbs}`);
+    process.exit(1);
+  }
+  if (existsSync(toAbs)) {
+    console.error(`move-doc: <to> already exists: ${toAbs}`);
+    process.exit(1);
+  }
+
+  const index = await buildDocsIndex(repoRoot);
+  const fromFile = index.files.find((file) => file.abs === fromAbs);
+  if (!fromFile) {
+    console.error(`move-doc: <from> is not an indexed doc: ${fromAbs}`);
+    process.exit(1);
+  }
+
+  const partial = isPartial(fromAbs);
+  const frontmatter = matter(fromFile.content).data as Record<string, unknown>;
+  const toRel = path.join('docs', path.relative(docsRoot, toAbs));
+  const oldUrl = partial ? null : resolveDocUrl(fromFile.rel, frontmatter);
+  const newUrl = partial ? null : resolveDocUrl(toRel, frontmatter);
+  const oldId = partial ? null : resolveDocId(fromFile.rel);
+  const newId = partial ? null : resolveDocId(toRel);
+
+  const { records, unparsed } = scanLinks(index);
+  const {
+    edits,
+    unrenderable,
+    changes: inboundChanges,
+  } = planInbound(records, index, fromAbs, toAbs, newUrl);
+  const { rewrites: outboundRewrites, changes: outboundChanges } = planOutbound(
+    records,
+    index,
+    fromAbs,
+    toAbs,
+    newUrl,
+  );
+  const movedContent = applyRewrites(fromFile.content, outboundRewrites);
+
+  const sidebarsPath = path.join(repoRoot, 'sidebars.js');
+  const sidebarsBefore = await readFile(sidebarsPath, 'utf8');
+  const sidebarsResult =
+    oldId && newId && oldId !== newId
+      ? updateSidebars(sidebarsBefore, oldId, newId)
+      : { content: sidebarsBefore, count: 0 };
+
+  const inboundRefCount = edits.reduce((sum, edit) => sum + edit.rewrites.length, 0);
+  console.log(
+    `${dryRun ? '[dry-run] ' : ''}move ${fromFile.rel} -> ${path.relative(repoRoot, toAbs)}`,
+  );
+  if (!partial)
+    console.log(
+      `  url:  ${oldUrl}  ->  ${newUrl}${oldUrl === newUrl ? '  (unchanged: slug override)' : ''}`,
+    );
+  console.log(`  inbound link rewrites: ${inboundRefCount} across ${edits.length} file(s)`);
+  for (const edit of edits)
+    console.log(`    ${path.relative(repoRoot, edit.abs)} (${edit.rewrites.length})`);
+  console.log(`  moved-file relative links rewritten: ${outboundRewrites.length}`);
+  console.log(`  sidebars.js id replacements: ${sidebarsResult.count}`);
+
+  if (unrenderable.length > 0) {
+    console.warn(
+      `  WARNING: ${unrenderable.length} reference(s) could not be rewritten (review manually):`,
+    );
+    for (const record of unrenderable) {
+      console.warn(`    ${path.relative(repoRoot, record.fromFile)}: ${record.ref.rawUrl}`);
+    }
+  }
+  if (unparsed.length > 0) {
+    console.warn(
+      `  WARNING: ${unparsed.length} file(s) could not be parsed and were not scanned for references:`,
+    );
+    for (const { file } of unparsed) console.warn(`    ${path.relative(repoRoot, file)}`);
+  }
+
+  if (dryRun) {
+    const allChanges = [...inboundChanges, ...outboundChanges];
+    if (allChanges.length > 0) {
+      console.log('\n  rewrites:');
+      for (const change of allChanges) {
+        console.log(
+          `    ${path.relative(repoRoot, change.file)}: ${change.old}  ->  ${change.next}`,
+        );
+      }
+    }
+    if (!partial && oldUrl !== newUrl)
+      console.log(`  redirect: { from: '${oldUrl}', to: '${newUrl}' }`);
+    console.log('\n[dry-run] no files were changed.');
+    return;
+  }
+
+  for (const edit of edits) {
+    await writeFile(edit.abs, applyRewrites(edit.content, edit.rewrites));
+  }
+  await mkdir(path.dirname(toAbs), { recursive: true });
+  await writeFile(toAbs, movedContent);
+  await rm(fromAbs);
+  if (sidebarsResult.count > 0) await writeFile(sidebarsPath, sidebarsResult.content);
+
+  if (!partial && oldUrl && newUrl && oldUrl !== newUrl) {
+    const status = await appendRedirect(
+      path.join(repoRoot, 'redirects.config.js'),
+      oldUrl,
+      newUrl,
+      false,
+    );
+    console.log(`  redirects.config.ts: ${status} { from: '${oldUrl}', to: '${newUrl}' }`);
+  }
+
+  console.log(
+    '\nDone. Next: `yarn build` to verify links, then `yarn sync-redirects` to update vercel.json.',
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/move-doc.ts
+++ b/scripts/move-doc.ts
@@ -17,8 +17,9 @@
  */
 
 import path from 'node:path';
-import { readFile, writeFile, mkdir, rm } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, rename } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import matter from 'gray-matter';
 
 import {
@@ -242,6 +243,25 @@ async function appendRedirect(
   return existed ? 'appended' : 'created';
 }
 
+/**
+ * Move `fromAbs` to `toAbs`, preferring `git mv` so the rename is staged and git records it as a
+ * rename — preserving `git log --follow` history. The moved file's own links are rewritten right
+ * after, which would otherwise drop content similarity below git's rename-detection threshold and
+ * make the move read as delete+add. Falls back to a filesystem move when git can't do it (outside a
+ * work tree, or an untracked source); the move still happens, just unstaged. Returns true when the
+ * move was staged via git.
+ */
+async function moveFile(fromAbs: string, toAbs: string, repoRoot: string): Promise<boolean> {
+  await mkdir(path.dirname(toAbs), { recursive: true });
+  try {
+    execFileSync('git', ['mv', fromAbs, toAbs], { cwd: repoRoot, stdio: 'pipe' });
+    return true;
+  } catch {
+    await rename(fromAbs, toAbs);
+    return false;
+  }
+}
+
 async function main(): Promise<void> {
   const { from, to, dryRun } = parseArgs(process.argv.slice(2));
   const repoRoot = process.cwd();
@@ -386,9 +406,10 @@ async function main(): Promise<void> {
   for (const edit of edits) {
     await writeFile(edit.abs, applyRewrites(edit.content, edit.rewrites));
   }
-  await mkdir(path.dirname(toAbs), { recursive: true });
+  const staged = await moveFile(fromAbs, toAbs, repoRoot);
   await writeFile(toAbs, movedContent);
-  await rm(fromAbs);
+  if (!staged)
+    console.warn('  note: moved without git (untracked source or no work tree) — move is unstaged');
   if (sidebarsResult.count > 0) await writeFile(sidebarsPath, sidebarsResult.content);
 
   if (!partial && oldUrl && newUrl && oldUrl !== newUrl) {

--- a/scripts/move-doc.ts
+++ b/scripts/move-doc.ts
@@ -269,10 +269,22 @@ async function main(): Promise<void> {
   const toAbs = path.resolve(repoRoot, to);
   const docsRoot = path.join(repoRoot, 'docs');
 
-  for (const [label, abs] of [
-    ['from', fromAbs],
-    ['to', toAbs],
+  for (const [label, raw, abs] of [
+    ['from', from, fromAbs],
+    ['to', to, toAbs],
   ] as const) {
+    // A leading slash makes the arg an absolute path, so it resolves outside the repo. It usually
+    // means the caller passed a site URL ("/docs/…") instead of a repo-relative file path.
+    if (raw.startsWith('/')) {
+      console.error(
+        `move-doc: <${label}> starts with '/': ${raw}\n` +
+          `  Pass a repo-relative file path, not a site URL — drop the leading slash, e.g. '${raw.replace(
+            /^\/+/,
+            '',
+          )}'.`,
+      );
+      process.exit(1);
+    }
     if (!abs.startsWith(docsRoot + path.sep) || !/\.mdx?$/.test(abs)) {
       console.error(`move-doc: <${label}> must be a .md/.mdx file under docs/: ${abs}`);
       process.exit(1);

--- a/scripts/restructure.ts
+++ b/scripts/restructure.ts
@@ -1,0 +1,88 @@
+/**
+ * restructure — run a doc move end to end, in the order that keeps the edge consistent.
+ *
+ * Usage:
+ *   yarn restructure <from> <to> [--dry-run]
+ *
+ * Sequence:
+ *   1. `move-doc`        — move the file + rewrite links + sidebars.js + redirects.config.js
+ *   2. `yarn build`      — VERIFICATION GATE: fails on any broken link, and the client-redirects
+ *                          plugin rejects a redirect whose target route doesn't exist. If this
+ *                          fails the orchestrator aborts BEFORE touching the edge.
+ *   3. `build-glossary`  — only if the move changed a glossary source partial. Quicklook tooltips
+ *                          render from the generated static/glossary.json, which the build does
+ *                          not validate, so it must be regenerated explicitly.
+ *   4. `sync-redirects`  — mirror redirects.config.js into vercel.json, now that the move is verified.
+ *
+ * Keeping `yarn build` BETWEEN the move and the sync is the whole point: a redirect is never
+ * propagated to vercel.json for a move that doesn't build. `--dry-run` previews the move only —
+ * build, glossary, and sync are no-ops when nothing has changed, so they are skipped.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+/** Run a command, streaming its output; throws (non-zero exit) propagate to abort the sequence. */
+function run(command: string, args: string[]): void {
+  execFileSync(command, args, { stdio: 'inherit' });
+}
+
+/** True when the move left a glossary source partial dirty, so static/glossary.json is stale. */
+function glossaryChanged(): boolean {
+  try {
+    const out = execFileSync('git', ['status', '--porcelain', '--', 'docs/partials/glossary'], {
+      encoding: 'utf8',
+    });
+    return out.trim().length > 0;
+  } catch {
+    // Without git we can't tell; regenerate to be safe (build-glossary is idempotent).
+    console.warn(
+      '[restructure] could not check git for glossary changes — running build-glossary to be safe.',
+    );
+    return true;
+  }
+}
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  const positional = argv.filter((arg) => !arg.startsWith('--'));
+  const dryRun = argv.includes('--dry-run');
+  if (positional.length !== 2) {
+    console.error('usage: yarn restructure <from> <to> [--dry-run]');
+    process.exit(1);
+  }
+  const [from, to] = positional;
+
+  // 1. Move + rewrite. In dry-run this is the only step — nothing else has anything to act on.
+  run('yarn', ['move-doc', from, to, ...(dryRun ? ['--dry-run'] : [])]);
+  if (dryRun) {
+    console.log(
+      '\n[restructure] dry-run: build, glossary, and sync were skipped (nothing changed).',
+    );
+    return;
+  }
+
+  // 2. Verification gate. A failure here throws and aborts before step 4 touches the edge.
+  console.log('\n[restructure] verifying with `yarn build`…');
+  run('yarn', ['build']);
+
+  // 3. Regenerate quicklook data only when the move touched a glossary source.
+  if (glossaryChanged()) {
+    console.log('\n[restructure] glossary sources changed — running `yarn build-glossary`…');
+    run('yarn', ['build-glossary']);
+  }
+
+  // 4. Mirror redirects to the edge, now that the move is verified.
+  console.log('\n[restructure] syncing redirects to vercel.json…');
+  run('yarn', ['sync-redirects']);
+
+  console.log('\n[restructure] done.');
+}
+
+try {
+  main();
+} catch (error) {
+  // execFileSync throws on a non-zero child exit; surface a concise abort rather than a stack.
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`\n[restructure] aborted: ${message}`);
+  process.exit(1);
+}

--- a/scripts/sync-vercel-redirects.ts
+++ b/scripts/sync-vercel-redirects.ts
@@ -27,6 +27,12 @@ function entryLine(source: string, destination: string): string {
   return INDENT + JSON.stringify({ source, destination, permanent: false }) + ',';
 }
 
+// Every block line (including the END sentinel) carries a trailing comma. That is correct
+// because the block is inserted at the FRONT of the `redirects` array, ahead of the existing
+// hand-maintained entries — so a comma always separates it from what follows. This assumes the
+// array is non-empty (always true for this repo's vercel.json); inserting into a completely
+// empty `redirects: []` would leave a trailing comma before `]`, which the JSON.parse guard
+// below would reject (fail-safe: it refuses to write rather than emit invalid JSON).
 function buildBlock(): string[] {
   const lines = [entryLine(START_SOURCE, '/')];
   for (const redirect of redirects) lines.push(entryLine(redirect.from, redirect.to));

--- a/scripts/sync-vercel-redirects.ts
+++ b/scripts/sync-vercel-redirects.ts
@@ -1,0 +1,81 @@
+/**
+ * sync-vercel-redirects — mirror `redirects.config.ts` into `vercel.json`'s edge redirects.
+ *
+ * Usage:
+ *   yarn sync-redirects
+ *
+ * The generated redirects are written as a contiguous block at the front of `vercel.json`'s
+ * `redirects` array, bounded by two sentinel entries. The block is regenerated in full on every
+ * run (idempotent); every hand-maintained redirect after it is left byte-for-byte unchanged.
+ * The edit is a line splice, not a JSON re-serialization, so the file's existing formatting is
+ * preserved. The script refuses to write if the result is not valid JSON, or if exactly one
+ * sentinel is present (a corrupted block).
+ */
+
+import path from 'node:path';
+import { readFile, writeFile } from 'node:fs/promises';
+
+import { redirects } from '../redirects.config';
+
+// Sentinel entries: valid, non-looping redirects that mark the auto-generated region. Their
+// source paths are namespaced so they never match real traffic.
+const START_SOURCE = '/__redirects-autogen-start__';
+const END_SOURCE = '/__redirects-autogen-end__';
+const INDENT = '    ';
+
+function entryLine(source: string, destination: string): string {
+  return INDENT + JSON.stringify({ source, destination, permanent: false }) + ',';
+}
+
+function buildBlock(): string[] {
+  const lines = [entryLine(START_SOURCE, '/')];
+  for (const redirect of redirects) lines.push(entryLine(redirect.from, redirect.to));
+  lines.push(entryLine(END_SOURCE, '/'));
+  return lines;
+}
+
+async function main(): Promise<void> {
+  const vercelPath = path.join(process.cwd(), 'vercel.json');
+  const text = await readFile(vercelPath, 'utf8');
+  const lines = text.split('\n');
+
+  const startIdx = lines.findIndex((line) => line.includes(START_SOURCE));
+  const endIdx = lines.findIndex((line) => line.includes(END_SOURCE));
+
+  if ((startIdx === -1) !== (endIdx === -1)) {
+    throw new Error(
+      'sync-redirects: exactly one autogen sentinel found in vercel.json — refusing to edit a corrupted block.',
+    );
+  }
+
+  const block = buildBlock();
+  let next: string;
+  if (startIdx === -1) {
+    const arrayIdx = lines.findIndex((line) => /"redirects"\s*:\s*\[/.test(line));
+    if (arrayIdx === -1)
+      throw new Error('sync-redirects: could not find the "redirects": [ array in vercel.json');
+    next = [...lines.slice(0, arrayIdx + 1), ...block, ...lines.slice(arrayIdx + 1)].join('\n');
+  } else {
+    if (startIdx > endIdx)
+      throw new Error('sync-redirects: autogen sentinels are out of order in vercel.json');
+    next = [...lines.slice(0, startIdx), ...block, ...lines.slice(endIdx + 1)].join('\n');
+  }
+
+  try {
+    JSON.parse(next);
+  } catch (error) {
+    throw new Error(`sync-redirects: refusing to write — result is not valid JSON: ${error}`);
+  }
+
+  if (next === text) {
+    console.log('sync-redirects: vercel.json already up to date.');
+    return;
+  }
+  await writeFile(vercelPath, next);
+  console.log(`sync-redirects: wrote ${redirects.length} generated redirect(s) into vercel.json.`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2831,6 +2831,21 @@
     react-helmet-async "npm:@slorber/react-helmet-async@1.3.0"
     react-loadable "npm:@docusaurus/react-loadable@6.0.0"
 
+"@docusaurus/plugin-client-redirects@^3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.10.1.tgz#e22ed20e5837b7c3a28258e3d1816c4239c82b36"
+  integrity sha512-LHgd+YDvkhfOHMAE6XtUng3DQNzVM765RqVRrMJgHtzAvfopQhY6ieprqjxDVBdv21cLma6I0jHr+YCZH8fL9A==
+  dependencies:
+    "@docusaurus/core" "3.10.1"
+    "@docusaurus/logger" "3.10.1"
+    "@docusaurus/utils" "3.10.1"
+    "@docusaurus/utils-common" "3.10.1"
+    "@docusaurus/utils-validation" "3.10.1"
+    eta "^2.2.0"
+    fs-extra "^11.1.1"
+    lodash "^4.17.21"
+    tslib "^2.6.0"
+
 "@docusaurus/plugin-content-blog@3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.10.1.tgz#0bd8de700ccbd8e95d920df2613304ef59abe72b"
@@ -13734,6 +13749,14 @@ remark-mdx@^3.0.0:
     mdast-util-mdx "^3.0.0"
     micromark-extension-mdxjs "^3.0.0"
 
+remark-mdx@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/remark-mdx/-/remark-mdx-3.1.1.tgz#047f97038bc7ec387aebb4b0a4fe23779999d845"
+  integrity sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==
+  dependencies:
+    mdast-util-mdx "^3.0.0"
+    micromark-extension-mdxjs "^3.0.0"
+
 remark-parse@^11.0.0:
   version "11.0.0"
   resolved "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz"
@@ -14652,6 +14675,13 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+to-vfile@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/to-vfile/-/to-vfile-8.0.0.tgz#4e1282bf251ce2beacae8e23a1752b3b3986bd29"
+  integrity sha512-IcmH1xB5576MJc9qcfEC/m/nQCFt3fzMHz45sSlgJyTWjRbKW1HAkJpuf3DgE57YzIlZcwcBZA5ENQbBo4aLkg==
+  dependencies:
+    vfile "^6.0.0"
+
 toidentifier@~1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz"
@@ -14850,7 +14880,7 @@ unicode-property-aliases-ecmascript@^2.0.0:
   resolved "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz"
   integrity sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==
 
-unified@^11:
+unified@^11, unified@^11.0.5:
   version "11.0.5"
   resolved "https://registry.yarnpkg.com/unified/-/unified-11.0.5.tgz#f66677610a5c0a9ee90cab2b8d4d66037026d9e1"
   integrity sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==
@@ -14935,7 +14965,7 @@ unist-util-visit-parents@^6.0.0:
     "@types/unist" "^3.0.0"
     unist-util-is "^6.0.0"
 
-unist-util-visit@^5:
+unist-util-visit@^5, unist-util-visit@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-5.1.0.tgz#9a2a28b0aa76a15e0da70a08a5863a2f060e2468"
   integrity sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==
@@ -15145,6 +15175,14 @@ vfile@^6.0.0, vfile@^6.0.1:
   dependencies:
     "@types/unist" "^3.0.0"
     unist-util-stringify-position "^4.0.0"
+    vfile-message "^4.0.0"
+
+vfile@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-6.0.3.tgz#3652ab1c496531852bf55a6bac57af981ebc38ab"
+  integrity sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==
+  dependencies:
+    "@types/unist" "^3.0.0"
     vfile-message "^4.0.0"
 
 vscode-jsonrpc@8.2.0:


### PR DESCRIPTION
## Description

Adds codemod tooling that turns moving a doc into a single command — rewriting internal links (and the moved file's own relative links), updating `sidebars.js` entries, and recording redirects — plus registers `@docusaurus/plugin-client-redirects` with `redirects.config.js` as the single source of truth (mirrored into `vercel.json` via `yarn sync-redirects`).

> **Codemod, in this PR:** a script that edits source files by parsing their structure (the MDX syntax tree) rather than doing blind find-and-replace. It locates the actual link nodes — markdown links, `<Link>`/`<a>` attributes, and partial imports — and rewrites only those byte ranges, so links update reliably without touching prose, code blocks, or formatting.

Tooling only; no documentation content is moved in this PR. New README section "Restructuring docs" documents the workflow.

## Document type

- [x] Codebase changes

## Checklist

- [x] I have used sentence-case for titles and headers
- [x] I have used descriptive link text (not "here" or "this")
- [x] I have tested my changes locally with `yarn start` or `yarn build`
- [x] My code follows the existing code style and conventions
- [x] I have checked for broken links
- [x] I have verified that my changes don't break the build

## Additional Notes

Opened to surface the Vercel preview (sitemap output + client redirects). `redirects.config.js` is intentionally committed empty — entries are appended by `yarn move-doc`.

**The codemod unit tests must stay in the codebase to prevent future regressions.** They validate the tooling itself (URL/id resolution, link extraction, byte-range splicing, link rewriting), not individual restructures, and are run via `yarn test:codemod`. They are wired into the `Tests` CI workflow (`.github/workflows/test.yml`) so they run on every PR and push to `master`. Per-restructure correctness is enforced separately by `yarn build` (`onBrokenLinks: 'throw'`).