### PR TITLE
fix: hastscript v9 named-export break in llms-txt rehype plugin

### DIFF
--- a/src/plugins/rehype-llms-cleanup.js
+++ b/src/plugins/rehype-llms-cleanup.js
@@ -1,5 +1,5 @@
 const { buildMarkerValue } = require('./llms-markers');
-const h = require('hastscript');
+const { h } = require('hastscript');
 // hast-util-select is ESM; Node 22.x supports require() of ESM modules that
 // don't use top-level await, which this package doesn't. Loads synchronously.
 const { matches, select, selectAll } = require('hast-util-select');


### PR DESCRIPTION
## Description

Fixes a regression in the llms-txt build caused by the `hastscript` 6.0.0 → 9.0.1 bump. hastscript v7+ is ESM-only and replaced its default export with named exports (`{ h, s }`), so `const h = require('hastscript')` returned the module namespace object instead of the `h` function. Every `h(...)` call in the `rehype-llms-cleanup` plugin then threw "h is not a function", and `docusaurus-plugin-llms-txt` skipped affected routes (for example `/stylus/reference/stylus-toml-reference`) with "Failed to convert HTML to Markdown".

The fix destructures the named export:

```diff
-const h = require('hastscript');
+const { h } = require('hastscript');
```

Extracted from #3349 so it can merge to master independently of the Inside Arbitrum Nitro docs rewrite. master currently ships `hastscript@^9` with the old import, so this fixes a live build warning on master.

## Document type

- [x] Codebase changes

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have tested my changes locally with `yarn build`
- [x] I have verified that my changes don't break the build

## Additional Notes

Verified with a full `yarn build`: `docusaurus-plugin-llms-txt` reports "Plugin completed successfully — processed 285 documents", and the "h is not a function" / "Failed to convert HTML to Markdown" warnings are gone.
