### PR TITLE
Silence TS5101 baseUrl deprecation in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@tsconfig/docusaurus/tsconfig.json",
   "compilerOptions": {
+    // Silence TS5101 for the deprecated `baseUrl` (still used by the @/ and @site/ path aliases below).
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "moduleResolution": "bundler",
     "allowJs": false,


### PR DESCRIPTION
## Description

Adds `"ignoreDeprecations": "6.0"` to `tsconfig.json` to silence **TS5101**, which TypeScript 6.0 raises for the deprecated `baseUrl` option. `baseUrl` is still required here for the `@/*` and `@site/*` path aliases, so it can't simply be removed.

TS5101 is a *fatal* config error — it halts `tsc` entirely, which breaks `yarn typecheck` and the `.ts`/`.tsx` pre-commit hook for every contributor. This restores `tsc` to a runnable state. (`tsconfig.json` is not used in the Docusaurus build itself — only editor tooling, `yarn typecheck`, and the pre-commit hook — so site builds are unaffected.)

Split out of #3353 (SME review gate) so that repo-wide fix lands independently of the feature.

## Document type

- [x] Codebase changes

## SME review

- [x] No content here needs SME review (editorial only)

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have verified that my changes don't break the build

## Additional Notes

Config-only change; doc-specific checklist items (frontmatter, sentence-case titles, link text) don't apply. Note: ~80 pre-existing repo-wide `tsc` type errors remain after this fix — those are separate tech debt and out of scope here; this PR only clears the fatal TS5101 abort.
