### PR TITLE
Add placeholder /solutions/payments landing page and Enterprise solutions nav

### DIFF
--- a/docs/solutions/payments.mdx
+++ b/docs/solutions/payments.mdx
@@ -1,0 +1,60 @@
+---
+title: 'Payments on Arbitrum'
+sidebar_label: 'Payments'
+description: 'Implementation entry point for building payments on Arbitrum. Restates the three deployment paths — settle on Arbitrum One, build a payments application, or launch a dedicated chain — and routes each into the technical documentation needed to implement it.'
+user_story: 'As a lead or senior developer who has chosen a payments deployment path during evaluation, I want a single page that restates that path and routes me into the implementation docs I need.'
+content_type: concept
+author: gblanchemain
+sme: gblanchemain
+---
+
+This page is the implementation entry point for teams building payments on Arbitrum. During evaluation you chose a deployment path, a settlement currency, and a set of provider categories. This page restates the three deployment paths in the same order you saw them, then routes each one into the technical documentation you need to implement it. It assumes the decision is already made — this is orientation, not a decision aid.
+
+The three deployment paths, in order:
+
+1. **Settle on Arbitrum One** — send stablecoin transfers with no custom contracts.
+2. **Build a payments application on Arbitrum One** — enforce payout logic onchain.
+3. **Launch a dedicated Arbitrum chain** — operate payments with chain-level control.
+
+Each path routes into existing documentation. Where a path needs material that does not yet exist, that is marked explicitly below.
+
+## Settle on Arbitrum One
+
+For teams sending stablecoin transfers with no custom contracts. This path is mostly a matter of pointing existing tools at the right network.
+
+- **Network setup** (chain IDs, RPC endpoints, faucets) → [Chain info](/for-devs/dev-tools-and-resources/chain-info) and [Chains and testnets](/arbitrum-essentials/public-chains)
+- **First stablecoin transfer** → [USDC quick start guide](/for-devs/third-party-docs/Circle/usdc-quickstart-guide)
+- **USDC on Arbitrum One** (native vs. bridged) → [USDC on Arbitrum One](/arbitrum-bridge/usdc-arbitrum-one)
+- **Wallet experience** → [ZeroDev](/for-devs/third-party-docs/ZeroDev/zero-dev)
+
+If you want to confirm the full flow end to end before integrating, follow the [testnet settlement walkthrough](/solutions/payments/prove-your-first-settlement), which strings the steps above into a single payment-shaped recipe.
+
+## Build a payments application on Arbitrum One
+
+For teams enforcing payout logic onchain. This path routes into the application-layer documentation.
+
+- **Contract deployment basics** → [Solidity quickstart](/build-decentralized-apps/quickstart-solidity-remix)
+- **FX rates and external data** → [Oracles overview](/arbitrum-essentials/oracles/overview-oracles)
+- **Cross-chain coordination** → [Cross-chain messaging](/arbitrum-essentials/bridging/cross-chain-messaging)
+
+<VanillaAdmonition type="info">A reviewed batch-payout and treasury reference contract is in progress and not yet available. Until it ships, build payout logic on the application-layer references above. This page will link the reference contract here once it is published and audited.</VanillaAdmonition>
+
+## Launch a dedicated Arbitrum chain
+
+For teams that need chain-level control. This path has the deepest existing coverage; route directly into it.
+
+- **Overview** → [A gentle introduction to Arbitrum chains](/launch-arbitrum-chain/overview/introduction)
+- **Deploy** → [Chain SDK overview](/launch-arbitrum-chain/quickstart/sdk-introduction)
+- **Custom gas token** (stablecoin-denominated fees) → [Custom gas token (Rollup)](/launch-arbitrum-chain/chain-config/costs/custom-gas-token-rollup) and [Custom gas token (AnyTrust)](/launch-arbitrum-chain/chain-config/costs/custom-gas-token-anytrust)
+- **Bridged USDC** → [Adopt the bridged USDC standard](/launch-arbitrum-chain/integrations/bridged-usdc)
+- **Access control** → [Ownership and access](/launch-arbitrum-chain/operate/ownership-and-access)
+
+Chain-level compliance tooling and private chain configurations are not yet available. This page does not document them until they ship.
+
+## Shared reference
+
+Relevant to all three paths:
+
+- **Transaction lifecycle and finality** → [Transaction lifecycle](/how-arbitrum-works/deep-dives/transaction-lifecycle)
+- **Gas and fees** → [Gas and fees](/how-arbitrum-works/deep-dives/gas-and-fees)
+- **Reconciliation and data tooling** → indexing and data providers such as [The Graph](/for-devs/third-party-docs/TheGraph) and [Covalent](/for-devs/third-party-docs/Covalent)

--- a/docs/solutions/payments.mdx
+++ b/docs/solutions/payments.mdx
@@ -8,9 +8,19 @@ author: gblanchemain
 sme: gblanchemain
 ---
 
-This page is the implementation entry point for teams building payments on Arbitrum. During evaluation you chose a deployment path, a settlement currency, and a set of provider categories. This page restates the three deployment paths in the same order you saw them, then routes each one into the technical documentation you need to implement it. It assumes the decision is already made — this is orientation, not a decision aid.
+This page is the implementation entry point for teams building payments on Arbitrum. Payments settle as stablecoin transfers on Arbitrum One: fund in fiat or stablecoins, define your payout logic, execute transfers, and reconcile against an onchain audit trail. Arbitrum One supports USD-denominated stablecoins (USDC, USDT, PYUSD) and non-USD options with onchain volume (EURe, MXNB, MYRC), with sub-cent transaction costs and 24/7 settlement, which reduces the need to pre-fund nostro accounts across weekends and holidays.
 
-The three deployment paths, in order:
+## Overview
+
+We will dive into the deployment paths, which route into the technical documentation needed to implement the solution, and list the stablecoins, service providers, and a pilot checklist commonly used in production payment stacks. It assumes the deployment decision is already made—this is an orientation, not a decision aid.
+
+<VanillaAdmonition type="info" title="Start on Arbitrum One">
+  For most payment pilots, start on Arbitrum One before launching a [dedicated Arbitrum chain](#launch-a-dedicated-arbitrum-chain). You get access to existing stablecoin liquidity with less infrastructure overhead.
+</VanillaAdmonition>
+
+## Choose your deployment path
+
+Three paths cover most payment builds:
 
 1. **Settle on Arbitrum One** — send stablecoin transfers with no custom contracts.
 2. **Build a payments application on Arbitrum One** — enforce payout logic onchain.
@@ -18,43 +28,189 @@ The three deployment paths, in order:
 
 Each path routes into existing documentation. Where a path needs material that does not yet exist, that is marked explicitly below.
 
-## Settle on Arbitrum One
+## Settle on Arbitrum One (recommended for pilots)
 
-For teams sending stablecoin transfers with no custom contracts. This path is mostly a matter of pointing existing tools at the right network.
+Use Arbitrum One as your settlement rail. Your product submits stablecoin transfers (e.g., USDC) over standard RPC. No custom smart contracts are required on day one. This path is mostly a matter of pointing existing tools at the right network.
 
-- **Network setup** (chain IDs, RPC endpoints, faucets) → [Chain info](/for-devs/dev-tools-and-resources/chain-info) and [Chains and testnets](/arbitrum-essentials/public-chains)
-- **First stablecoin transfer** → [USDC quick start guide](/for-devs/third-party-docs/Circle/usdc-quickstart-guide)
-- **USDC on Arbitrum One** (native vs. bridged) → [USDC on Arbitrum One](/arbitrum-bridge/usdc-arbitrum-one)
-- **Wallet experience** → [ZeroDev](/for-devs/third-party-docs/ZeroDev/zero-dev)
+#### Choose this when
 
-If you want to confirm the full flow end to end before integrating, follow the [testnet settlement walkthrough](/solutions/payments/prove-your-first-settlement), which strings the steps above into a single payment-shaped recipe.
+- You want a fast path to production
+- Compliance screening lives offchain with vendors such as Chainalysis—see [Compliance and analytics](#compliance-and-analytics) in the payments ecosystem below
+- You need access to existing stablecoin liquidity and off-ramps
+
+<VanillaAdmonition type="tip" title="Wallet UX for pilots — ZeroDev">
+  If payers or payees hold funds onchain, [ZeroDev](https://docs.zerodev.app/) smart accounts (built by Offchain) provide passkey or social login, sponsored gas (or gas paid in your settlement ERC-20), and batched transfers on Arbitrum One without building wallet infrastructure from scratch. It works with whichever stablecoin you settle in, not USDC alone. See [ZeroDev on Arbitrum](/for-devs/third-party-docs/ZeroDev/zero-dev).
+</VanillaAdmonition>
+
+#### Core documentation
+
+- [USDC on Arbitrum One](/arbitrum-bridge/usdc-arbitrum-one): native USDC vs. bridged USDC (USDC.e)
+- [USDC quick start guide](/for-devs/third-party-docs/Circle/usdc-quickstart-guide.mdx): validate your first programmatic transfer on Arbitrum Sepolia, then mainnet
+- [ZeroDev on Arbitrum](/for-devs/third-party-docs/ZeroDev/zero-dev.mdx): embedded smart accounts and gasless UserOps
+- [Chain info](/for-devs/dev-tools-and-resources/chain-info.mdx) and [Chains and testnets](/arbitrum-essentials/public-chains.mdx): chain IDs and network parameters
+- [RPC endpoints and providers](/arbitrum-essentials/reference/node-providers.mdx)
+- [Gas and fees](/how-arbitrum-works/deep-dives/gas-and-fees) and [How to estimate gas](/arbitrum-essentials/how-to-estimate-gas.mdx)
+
+If you want to confirm the full flow end to end before integrating, follow the [testnet settlement walkthrough](/solutions/payments/prove-your-first-settlement.mdx), which strings the steps above into a single payment-shaped recipe.
 
 ## Build a payments application on Arbitrum One
 
-For teams enforcing payout logic onchain. This path routes into the application-layer documentation.
+Deploy Solidity smart contracts for treasury logic, routing, FX policy, or payout automation directly on Arbitrum One. Combine onchain execution with offchain compliance and fiat rails. If you later need chain-level control (custom gas, compliance engine, private execution), you can [launch a dedicated Arbitrum chain](#launch-a-dedicated-arbitrum-chain) and deploy the same style of contracts there.
 
-- **Contract deployment basics** → [Solidity quickstart](/build-decentralized-apps/quickstart-solidity-remix)
-- **FX rates and external data** → [Oracles overview](/arbitrum-essentials/oracles/overview-oracles)
-- **Cross-chain coordination** → [Cross-chain messaging](/arbitrum-essentials/bridging/cross-chain-messaging)
+#### Choose this when
 
-<VanillaAdmonition type="info">A reviewed batch-payout and treasury reference contract is in progress and not yet available. Until it ships, build payout logic on the application-layer references above. This page will link the reference contract here once it is published and audited.</VanillaAdmonition>
+- Payout rules, limits, or multi-party approvals must be enforced onchain
+- You want composability with DeFi liquidity and existing Arbitrum integrations
+- You are building a proprietary orchestration layer (e.g., [Rise](https://blog.arbitrum.io/rise-global-payments/) programmable payroll)
+
+#### Core documentation
+
+- [Solidity quickstart](/build-decentralized-apps/01-quickstart-solidity-remix.mdx): deploy your first contract
+- [ZeroDev on Arbitrum](/for-devs/third-party-docs/ZeroDev/zero-dev.mdx) and [ZeroDev documentation](https://docs.zerodev.app/): smart accounts for payers and payees (gasless flows, session keys, batching)
+- [Cross-chain messaging](/arbitrum-essentials/bridging/cross-chain-messaging.mdx): coordinate logic across chains
+- [Oracles overview](/arbitrum-essentials/oracles/overview-oracles.mdx): FX rates and external data
+- [Circle Paymaster quickstart](/for-devs/third-party-docs/Circle/usdc-paymaster-quickstart.mdx): let users pay gas in USDC
+- [LayerZero on Arbitrum](/for-devs/third-party-docs/LayerZero/layerzero.mdx): omnichain messaging and tokens
+- [Allium on Arbitrum](https://docs.allium.so/historical-data/supported-blockchains/evm/arbitrum) _(external)_: query transfers and balances for reconciliation
+- [Arbitrum SDK](https://github.com/OffchainLabs/arbitrum-sdk) _(external)_: bridging and messaging utilities
+
+#### Private payments
+
+Confidential amounts and counterparties can be implemented at the smart contract layer on Arbitrum One or at chain level on a dedicated Arbitrum chain. On Arbitrum One, see [Fhenix CoFHE](https://cofhe-docs.fhenix.zone/) (encrypted contract logic on Arbitrum Sepolia today) and [Railgun](https://railgun.org/) (private transfers). Chain-level private execution is on the [dedicated chain](#launch-a-dedicated-arbitrum-chain) roadmap. For architecture scoping, [contact Offchain Enterprise Services](https://www.offchain.io/contact).
+
+<VanillaAdmonition type="caution" title="Sample payment contracts">
+  Arbitrum docs do not yet include reference contracts for treasury, batch payout, or remittance flows. A reviewed batch-payout and treasury reference contract is in progress. Until it ships, use the [USDC quick start guide](/for-devs/third-party-docs/Circle/usdc-quickstart-guide.mdx) to validate settlement and build payout logic on the application-layer references above, or [contact Offchain Enterprise Services](https://www.offchain.io/contact) to design contract architecture. This page will link the reference contract here once it is published and audited.
+</VanillaAdmonition>
 
 ## Launch a dedicated Arbitrum chain
 
-For teams that need chain-level control. This path has the deepest existing coverage; route directly into it.
+Deploy your own Arbitrum chain when you need control over network economics, fee denomination, permissions, and data visibility. This path fits teams scaling proprietary payment infrastructure. You can deploy your own payment smart contracts on the chain (the same programmability as a payments application on Arbitrum One) while adding chain-level controls that Arbitrum One alone cannot offer.
 
-- **Overview** → [A gentle introduction to Arbitrum chains](/launch-arbitrum-chain/overview/introduction)
-- **Deploy** → [Chain SDK overview](/launch-arbitrum-chain/quickstart/sdk-introduction)
-- **Custom gas token** (stablecoin-denominated fees) → [Custom gas token (Rollup)](/launch-arbitrum-chain/chain-config/costs/custom-gas-token-rollup) and [Custom gas token (AnyTrust)](/launch-arbitrum-chain/chain-config/costs/custom-gas-token-anytrust)
-- **Bridged USDC** → [Adopt the bridged USDC standard](/launch-arbitrum-chain/integrations/bridged-usdc)
-- **Access control** → [Ownership and access](/launch-arbitrum-chain/operate/ownership-and-access)
+Many pilots settle in existing stablecoins. Teams can also issue a custom settlement token—for tokenized deposits, bank-branded assets, or a custom gas token on your chain. See [Issuing your own stablecoin](#issuing-your-own-stablecoin) or [contact Offchain Enterprise Services](https://www.offchain.io/contact) for issuance design.
 
-Chain-level compliance tooling and private chain configurations are not yet available. This page does not document them until they ship.
+#### Choose this when
 
-## Shared reference
+- You require stablecoin-denominated network fees (e.g., USDC, USDT as gas)
+- You need protocol-level compliance controls or restricted participation beyond application-layer screening on Arbitrum One
+- Proprietary routing, FX, or counterparty data must not appear on a public ledger
 
-Relevant to all three paths:
+Ethereum L1 anchors security and finality; your chain settles stablecoins and payment contracts; offchain service providers handle fiat. A dedicated chain adds chain-level control—it does not replace [third-party service providers](#references-and-sources).
 
-- **Transaction lifecycle and finality** → [Transaction lifecycle](/how-arbitrum-works/deep-dives/transaction-lifecycle)
-- **Gas and fees** → [Gas and fees](/how-arbitrum-works/deep-dives/gas-and-fees)
-- **Reconciliation and data tooling** → indexing and data providers such as [The Graph](/for-devs/third-party-docs/TheGraph) and [Covalent](/for-devs/third-party-docs/Covalent)
+#### Core documentation
+
+- [A gentle introduction to Arbitrum chains](/launch-arbitrum-chain/overview/introduction.mdx)
+- [Chain SDK overview](/launch-arbitrum-chain/quickstart/sdk-introduction.mdx): deploy a production chain
+- [Custom gas token (Rollup)](/launch-arbitrum-chain/chain-config/costs/custom-gas-token-rollup.mdx) and [Custom gas token (AnyTrust)](/launch-arbitrum-chain/chain-config/costs/custom-gas-token-anytrust.mdx): stablecoin-denominated fees
+- [Native mint/burn gas token](/launch-arbitrum-chain/chain-config/costs/configure-native-mint-burn.mdx)
+- [Adopt the bridged USDC standard](/launch-arbitrum-chain/integrations/bridged-usdc.mdx)
+- [Ownership and access](/launch-arbitrum-chain/operate/ownership-and-access.mdx)
+- [Third-party infrastructure providers](/launch-arbitrum-chain/integrations/infrastructure-providers.mdx)
+
+<VanillaAdmonition type="warning" title="Some features unavailable">
+  Chain-level compliance tooling and private chain configurations are not yet available. This page does not document them.
+</VanillaAdmonition>
+
+## Choose stablecoins by corridor
+
+Map settlement assets to destination market, liquidity, and issuer requirements. Verify token addresses on [Arbiscan](https://arbiscan.io/) before production.
+
+### USD-denominated (Arbitrum One)
+
+| Stablecoin                | Issuer                       | Description                                                                                            | Documentation                                                                                                                                |
+| ------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Native USDC**           | Circle                       | Default for most dollar pilots; native issuance on Arbitrum One with CEX support and direct redemption | [USDC on Arbitrum One](/arbitrum-bridge/usdc-arbitrum-one) · [USDC quick start](/for-devs/third-party-docs/Circle/usdc-quickstart-guide.mdx) |
+| **Bridged USDC (USDC.e)** | Circle (via Arbitrum bridge) | Legacy bridged USDC from Ethereum; prefer native USDC for new production flows                         | [USDC on Arbitrum One](/arbitrum-bridge/02-usdc-arbitrum-one.mdx)                                                                            |
+| **USDT**                  | Tether                       | Widely used in LATAM, Africa, and parts of APAC                                                        | [Tether documentation](https://tether.to/en/developers) _(external)_                                                                         |
+| **PYUSD**                 | Paxos                        | PayPal USD on Arbitrum One; suited to PayPal ecosystem payouts                                         | [Paxos blockchains](https://docs.paxos.com/guides/developer/blockchains) _(external)_                                                        |
+| **USDL**                  | Paxos International          | Yield-bearing USD stablecoin on Arbitrum One for treasury yield use cases                              | [USDL on Arbitrum](https://www.paxos.com/newsroom/yield-bearing-stablecoin-lift-dollar-usdl-launches-on-arbitrum) _(external)_               |
+
+More USD-denominated tokens are listed on the [Arbitrum Portal](https://portal.arbitrum.io/).
+
+### Non-USD-denominated (Arbitrum One)
+
+Non-USD stablecoins with meaningful volume on Arbitrum today for corridor-specific pilots. Verify contract addresses on [Arbiscan](https://arbiscan.io/) before production.
+
+| Stablecoin | Issuer   | Description                                                                                          | Documentation                                    |
+| ---------- | -------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| **EURe**   | Monerium | Euro e-money token, 1:1 with EUR; available on Arbitrum for SEPA-corridor and euro-native settlement | [EURe](https://monerium.com/eure/) _(external)_  |
+| **MXNB**   | Juno     | Mexican peso stablecoin, 1:1 with MXN; fiat-backed for LATAM corridor access on Arbitrum             | [MXNB](https://mxnb.mx/en-US) _(external)_       |
+| **MYRC**   | BLOX     | Malaysian ringgit stablecoin, 1:1 with MYR; issued on Arbitrum for APAC fiat and crypto rails        | [BLOX / MYRC](https://www.blox.my/) _(external)_ |
+
+More non-USD-denominated tokens are listed on the [Arbitrum Portal](https://portal.arbitrum.io/).
+
+### Issuing your own stablecoin
+
+Deploy a custom ERC-20 on Arbitrum One with the [Create a token quickstart](/build-decentralized-apps/quickstart-create-a-token.mdx). For bank-branded or corridor-specific settlement assets, work with issuance providers in the [payments ecosystem](#references-and-sources) below (for example, Circle [bridged USDC](/launch-arbitrum-chain/integrations/bridged-usdc.mdx) on dedicated chains, or fiat-backed issuers such as Monerium, Paxos, and BLOX). [Contact Offchain Enterprise Services](https://www.offchain.io/contact) for issuance architecture.
+
+## References and sources
+
+The following service providers are commonly used in production payment stacks on Arbitrum. Links point to Arbitrum docs where available; external links go to provider documentation. Listing a provider does not imply an official commercial partnership with Offchain.
+
+### Fiat on- and off-ramps
+
+| Provider    | Description                  | Documentation                                                   |
+| ----------- | ---------------------------- | --------------------------------------------------------------- |
+| Yellow Card | Africa-focused fiat ↔ crypto | [Yellow Card](https://yellowcard.io/) _(external)_              |
+| MoonPay     | Global fiat on-ramp          | [MoonPay documentation](https://dev.moonpay.com/) _(external)_  |
+| Banxa       | Fiat gateway                 | [Banxa documentation](https://docs.banxa.com/) _(external)_     |
+| Transak     | Fiat on- and off-ramp API    | [Transak documentation](https://docs.transak.com/) _(external)_ |
+
+### Custody
+
+| Provider               | Description                                                | Documentation                                                                 |
+| ---------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Fireblocks             | Wallet and treasury infrastructure for institutional teams | [Fireblocks documentation](https://developers.fireblocks.com/) _(external)_   |
+| BitGo                  | Qualified custody and wallet API                           | [BitGo documentation](https://developers.bitgo.com/) _(external)_             |
+| Coinbase Institutional | Custody and trading (Coinbase product)                     | [Coinbase Institutional](https://www.coinbase.com/institutional) _(external)_ |
+
+### Compliance and analytics
+
+| Provider    | Description                        | Documentation                                            |
+| ----------- | ---------------------------------- | -------------------------------------------------------- |
+| TRM Labs    | Blockchain intelligence and AML    | [TRM Labs](https://www.trmlabs.com/) _(external)_        |
+| Chainalysis | Compliance and investigation tools | [Chainalysis](https://www.chainalysis.com/) _(external)_ |
+| Elliptic    | Crypto compliance and screening    | [Elliptic](https://www.elliptic.co/) _(external)_        |
+
+### Oracles and market data
+
+| Provider     | Description                     | Documentation                                                      |
+| ------------ | ------------------------------- | ------------------------------------------------------------------ |
+| Chainlink    | Price feeds and automation      | [Chainlink on Arbitrum](/for-devs/oracles/chainlink/chainlink.mdx) |
+| Pyth Network | Real-time financial market data | [Pyth documentation](https://docs.pyth.network/) _(external)_      |
+
+### Wallets and smart accounts (recommended)
+
+| Provider    | Description                                                                                                               | Documentation                                                                                                      |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| **ZeroDev** | Offchain smart account stack: gasless or ERC-20 gas, passkey/social login, batching, session keys for payouts on Arbitrum | [ZeroDev on Arbitrum](/for-devs/third-party-docs/ZeroDev/zero-dev.mdx) · [ZeroDev docs](https://docs.zerodev.app/) |
+
+### Payment orchestration
+
+| Provider        | Description                                | Documentation                                                               |
+| --------------- | ------------------------------------------ | --------------------------------------------------------------------------- |
+| Stripe (Bridge) | Fiat and stablecoin payment infrastructure | [Bridge documentation](https://apidocs.bridge.xyz/) _(external)_            |
+| LayerZero       | Omnichain messaging and tokens             | [LayerZero on Arbitrum](/for-devs/third-party-docs/LayerZero/layerzero.mdx) |
+
+### Data and reconciliation
+
+| Provider  | Description                                                                     | Documentation                                                                                                |
+| --------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Allium    | Arbitrum transfers, balances, and SQL/API analytics for treasury reconciliation | [Allium on Arbitrum](https://docs.allium.so/historical-data/supported-blockchains/evm/arbitrum) _(external)_ |
+| The Graph | Indexing and querying onchain payment data                                      | [The Graph](/for-devs/third-party-docs/TheGraph/thegraph.mdx)                                                |
+| Covalent  | Unified API for historical balances and transfers                               | [Covalent](/for-devs/third-party-docs/Covalent/covalent.mdx)                                                 |
+
+Explore more projects on the [Arbitrum Portal](https://portal.arbitrum.io/).
+
+## Recommended pilot checklist
+
+A minimal path from zero to a verified settlement on Arbitrum One. Skip steps that do not apply to your [deployment path](#choose-your-deployment-path).
+
+1. **Pick a deployment path.** Most pilots start by settling on Arbitrum One without custom contracts. Add onchain treasury contracts if you need them; launch a dedicated chain only if you need chain-level control.
+2. **Pick a stablecoin for your corridor.** Dollar pilots: [native USDC on Arbitrum One](/arbitrum-bridge/usdc-arbitrum-one). See [Choose stablecoins by corridor](#choose-stablecoins-by-corridor) for USDT, PYUSD, or non-USD-denominated options (EURe, MXNB, MYRC).
+3. **Prove settlement on testnet.** Configure RPC via [Chain info](/for-devs/dev-tools-and-resources/chain-info.mdx) (chain ID `421614`), fund Sepolia ETH and USDC ([Circle faucet](https://faucet.circle.com/)), and complete a transfer with the [USDC quick start guide](/for-devs/third-party-docs/Circle/usdc-quickstart-guide.mdx). Confirm on [Arbitrum Sepolia Arbiscan](https://sepolia.arbiscan.io/). For a guided version, follow the [testnet settlement walkthrough](/solutions/payments/prove-your-first-settlement.mdx).
+4. **Add ZeroDev if end users touch funds onchain.** Integrate [ZeroDev on Arbitrum](/for-devs/third-party-docs/ZeroDev/zero-dev.mdx) for passkey login and gasless payouts. Skip this step if only your treasury wallet sends transfers.
+5. **Wire production service providers before mainnet volume.** Choose on-ramps, custody, and compliance screening from the [payments ecosystem](#references-and-sources). Track payouts with [Allium on Arbitrum](https://docs.allium.so/historical-data/supported-blockchains/evm/arbitrum) when you need reconciliation at scale.
+
+## Get help
+
+- Work with the [Offchain Enterprise Services team](https://www.offchain.io/contact) for solution design, pilot scoping, and payment infrastructure support.

--- a/docs/solutions/payments/prove-your-first-settlement.mdx
+++ b/docs/solutions/payments/prove-your-first-settlement.mdx
@@ -1,0 +1,61 @@
+---
+title: 'Prove your first settlement on testnet'
+sidebar_label: 'Testnet settlement walkthrough'
+description: 'A payment-shaped walkthrough that strings network setup, testnet funding, a USDC transfer, and settlement confirmation into one followable recipe on Arbitrum Sepolia.'
+user_story: 'As a developer settling stablecoin payments on Arbitrum One, I want to prove the full transfer-and-settle flow on testnet before integrating it into my application.'
+content_type: tutorial
+author: gblanchemain
+sme: gblanchemain
+---
+
+<VanillaAdmonition type="caution">This walkthrough is pending subject-matter-expert review. The steps stitch together existing, individually maintained guides; the end-to-end sequence has not yet been verified by an engineering SME. Treat contract addresses and faucet sources as authoritative only at their linked sources.</VanillaAdmonition>
+
+This walkthrough is for the [Settle on Arbitrum One](/solutions/payments) path. It does not introduce new tooling. It connects the network setup, funding, transfer, and confirmation steps you already have into one payment-shaped flow, so you can prove a stablecoin settles end to end on testnet before you integrate it.
+
+You run the whole flow on **Arbitrum Sepolia**, the public testnet, so no real funds are involved.
+
+## What you will prove
+
+By the end you will have sent a **USDC** transfer on Arbitrum Sepolia and confirmed that it settled. That is the smallest complete unit of a payment: value moved from one address to another and verified as final.
+
+## Prerequisites
+
+- A wallet (such as MetaMask) you can point at a custom network.
+- Node.js and npm, if you follow the application-based transfer in step 3.
+
+## Step 1 — Point your wallet at Arbitrum Sepolia
+
+Add the Arbitrum Sepolia network to your wallet using the chain ID and RPC endpoint from the network reference. Do not copy these values from elsewhere — use the maintained reference:
+
+- [Chain info](/for-devs/dev-tools-and-resources/chain-info) — chain IDs, RPC endpoints, and block explorers
+- [Chains and testnets](/arbitrum-essentials/public-chains) — the full list of public Arbitrum networks
+
+## Step 2 — Fund the account
+
+You need two things in the sending account:
+
+1. **Testnet ETH** to pay gas. Use a faucet for Arbitrum Sepolia listed in [Chain info](/for-devs/dev-tools-and-resources/chain-info).
+2. **Testnet USDC** to transfer. Get it from [Circle's faucet](https://faucet.circle.com/).
+
+Confirm both balances appear in your wallet on Arbitrum Sepolia before continuing.
+
+## Step 3 — Send a USDC transfer
+
+Send the transfer one of two ways:
+
+- **From a wallet:** send a small **USDC** amount to a second address you control. This is enough to prove settlement.
+- **From an application:** follow the [USDC quick start guide](/for-devs/third-party-docs/Circle/usdc-quickstart-guide), which builds a small app that connects a wallet and sends a **USDC** transaction. Point it at Arbitrum Sepolia rather than mainnet.
+
+Use the **USDC** contract address for Arbitrum Sepolia from Circle's official documentation. Do not hardcode an address taken from this page.
+
+## Step 4 — Confirm settlement
+
+Look up the transaction hash in the Arbitrum Sepolia block explorer (linked from [Chain info](/for-devs/dev-tools-and-resources/chain-info)) and confirm the recipient balance changed.
+
+To understand when a transaction is final — and what finality means relative to the parent chain — read [Transaction lifecycle](/how-arbitrum-works/deep-dives/transaction-lifecycle). This is the difference between "the transfer was accepted" and "the transfer has settled," which matters once you reconcile payments in production.
+
+## Next steps
+
+- Move from testnet to mainnet with [USDC on Arbitrum One](/arbitrum-bridge/usdc-arbitrum-one), which covers native versus bridged **USDC**.
+- Review [Gas and fees](/how-arbitrum-works/deep-dives/gas-and-fees) so your cost model reflects mainnet conditions.
+- Return to the [Payments](/solutions/payments) page for the application and dedicated-chain paths.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -224,6 +224,17 @@ const config = {
             ],
           },
           {
+            type: 'dropdown',
+            label: 'Enterprise solutions',
+            position: 'right',
+            items: [
+              {
+                label: 'Payments',
+                to: '/solutions/payments',
+              },
+            ],
+          },
+          {
             type: 'docSidebar',
             sidebarId: 'runArbitrumChainSidebar',
             position: 'right',

--- a/sidebars.js
+++ b/sidebars.js
@@ -1714,6 +1714,33 @@ const sidebars = {
     },
   ],
 
+  // Enterprise solutions sidebar
+  enterpriseSolutionsSidebar: [
+    {
+      type: 'category',
+      label: 'Enterprise solutions',
+      collapsed: false,
+      items: [
+        {
+          type: 'category',
+          label: 'Payments',
+          collapsed: false,
+          link: {
+            type: 'doc',
+            id: 'solutions/payments',
+          },
+          items: [
+            {
+              type: 'doc',
+              id: 'solutions/payments/prove-your-first-settlement',
+              label: 'Testnet settlement walkthrough',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+
   // Notices sidebar
   noticeSidebar: [
     {


### PR DESCRIPTION
## Description

**This is placeholder content.** It executes `payment-content-plan.md`: a developer-facing `/solutions/payments` page that acts as the handoff target from the `offchain.io/solutions` evaluation page. The page is mostly a routing layer into existing docs, plus one small new artifact (a testnet walkthrough) and explicit markers where content is not yet available.

What's in the diff:

- **`docs/solutions/payments.mdx`** — landing/routing page. Restates the three canonical deployment paths (in the locked order/names that match the evaluation page) and routes each into existing documentation, plus a shared-reference section.
  1. Settle on Arbitrum One
  2. Build a payments application on Arbitrum One
  3. Launch a dedicated Arbitrum chain
- **`docs/solutions/payments/prove-your-first-settlement.mdx`** — Path 1 testnet settlement walkthrough. **Drafted, not yet verified** — it carries a `caution` admonition flagging that the end-to-end sequence is pending SME review, and it deliberately hardcodes no contract addresses (it routes to Circle's docs and the maintained chain-info reference).
- **`docusaurus.config.js`** — new **Enterprise solutions** navbar dropdown with a **Payments** child.
- **`sidebars.js`** — new `enterpriseSolutionsSidebar` (Enterprise solutions › Payments › Testnet settlement walkthrough).

Placeholder / not-yet-shipped items, called out on the page rather than written:

- **Path 2 batch-payout / treasury reference contract** is scoped, not written — it needs an engineering owner and an audit. The page shows a "not yet available" marker. Tracked in **TW-898**.
- **Compliance Engine** and **Private Chains** are roadmap items; no pages were created for them (one neutral "not yet available" line only).

Tracking: **TW-898** (batch-payout contract) · **TW-899** (walkthrough SME review).

## Document type

- [ ] Gentle introduction
- [x] Quickstart
- [ ] How-to
- [x] Concept
- [ ] FAQ
- [ ] Troubleshooting
- [ ] Reference
- [ ] Third-party content
- [ ] Codebase changes
- [ ] Not applicable

## Checklist

- [x] I have read the [CONTRIBUTE.md](../CONTRIBUTE.md) guidelines
- [x] My changes follow the style conventions outlined in CONTRIBUTE.md
- [x] I have used sentence-case for titles and headers
- [x] I have used descriptive link text (not "here" or "this")
- [x] I have separated procedural from conceptual content where appropriate
- [x] I have tested my changes locally with `yarn start` or `yarn build`
- [x] My code follows the existing code style and conventions
- [x] I have added/updated frontmatter for new documents
- [x] I have checked for broken links
- [x] I have verified that my changes don't break the build
- Third-party docs only: Do you agree to the third-party content policy outlined within [CONTRIBUTE.md](../CONTRIBUTE.md)?
  - [ ] Yes
  - [x] Not applicable

## Additional Notes

This PR is opened as a **draft** because the content is a placeholder:

- The Path 1 walkthrough needs an SME to run it end to end on Arbitrum Sepolia before the pending-review admonition is removed (TW-899).
- The Path 2 reference contract (the highest-value artifact) is not in this PR; it's scoped to engineering with an audit note (TW-898). The page links it via a "not yet available" marker until then.

Author/SME frontmatter is set to `gblanchemain` as a placeholder; SME assignment is pending.

`yarn build` passes with `onBrokenLinks: 'throw'` — all routed links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
