### PR TITLE
Update Stylus trait-based composition guide

### DIFF
--- a/docs/stylus/how-tos/trait-based-composition.mdx
+++ b/docs/stylus/how-tos/trait-based-composition.mdx
@@ -63,6 +63,7 @@ use stylus_sdk::{
 };
 
 // Define traits for different functionality
+#[public]
 trait IErc20 {
     fn name(&self) -> String;
     fn symbol(&self) -> String;
@@ -72,6 +73,7 @@ trait IErc20 {
     fn transfer(&mut self, to: Address, value: U256) -> bool;
 }
 
+#[public]
 trait IOwnable {
     fn owner(&self) -> Address;
     fn transfer_ownership(&mut self, new_owner: Address) -> bool;
@@ -181,44 +183,41 @@ When using trait-based composition, you need to be careful about function select
 </VanillaAdmonition>
 
 <CustomDetails summary="Selector issue example: ERC-721">
+
 ```rust
-// In Solidity, both these functions would have different selectors:
-// function safeTransferFrom(address from, address to, uint256 tokenId)
-// function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
+// In Solidity, these two functions share the name `safeTransferFrom` but have
+// different selectors because their parameter lists differ:
+//   function safeTransferFrom(address from, address to, uint256 tokenId)
+//   function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 
-// In Rust, we need to use different method names, but want the same selectors: #[public]
-impl<T: Erc721Params> Erc721<T> {
-// Use the #[selector] attribute to specify the correct Solidity-compatible name #[selector(name = "safeTransferFrom")]
-pub fn safe_transfer_from_with_data<S: TopLevelStorage + BorrowMut<Self>>(
-storage: &mut S,
-from: Address,
-to: Address,
-token_id: U256,
-data: Bytes,
-) -> Result<(), Erc721Error> {
-// Implementation
-}
-
-    // This method also needs the same selector name
+// Rust has no method overloading, so each variant needs a distinct Rust name.
+// Use the #[selector(name = "...")] attribute to export a Solidity-compatible
+// selector. Because the two variants take different parameters, both can keep
+// the `safeTransferFrom` name on the ABI side without colliding.
+#[public]
+impl Erc721 {
     #[selector(name = "safeTransferFrom")]
-    pub fn safe_transfer_from<S: TopLevelStorage + BorrowMut<Self>>(
-        storage: &mut S,
+    pub fn safe_transfer_from(&mut self, from: Address, to: Address, token_id: U256) {
+        // Implementation here
+    }
+
+    #[selector(name = "safeTransferFrom")]
+    pub fn safe_transfer_from_with_data(
+        &mut self,
         from: Address,
         to: Address,
         token_id: U256,
-    ) -> Result<(), Erc721Error> {
-        // Implementation
+        data: Bytes,
+    ) {
+        // Implementation here
     }
-
 }
-
 ```
+
 </CustomDetails>
 
 <VanillaAdmonition type="info" title="ABI generation and inheritance">
-  The Stylus SDK generates ABIs based on the methods that are available at the entrypoint contract.
-  When using trait-based composition, make sure that all methods you want exposed in the ABI are
-  properly included through the #[implements] attribute.
+  The Stylus SDK generates ABIs based on the methods that are available at the entrypoint contract. When using trait-based composition, make sure that all methods you want exposed in the ABI are properly included through the #[implements] attribute.
 </VanillaAdmonition>
 
 ## Methods search order
@@ -235,4 +234,3 @@ In a typical composition chain:
 - If not found there, it looks in the first trait specified in the inheritance list
 - If still not found, it searches in the next trait in the list
 - This continues until the method is found or all possibilities are exhausted
-```


### PR DESCRIPTION
## Description

Part of a section-wide **Stylus documentation update** that brings `docs/stylus/` back in line with the current stack (stylus-sdk **0.10.7** / cargo-stylus **0.10.7** / Nitro **v3.11.0**). The update is split into ~25 small, independently reviewable PRs (all tagged `stylus`).

**This PR:** adds the required `#[public]` on interface traits and modernizes the selector example.

Code examples were verified against the live toolchain — compiled, and deployed on a local Nitro dev node where applicable — and conceptual claims were checked against the Nitro source. The branch builds clean with `yarn build` (strict `onBrokenLinks`).

## Document type

- [x] How-to

## Checklist

- [x] My changes follow the style conventions outlined in CONTRIBUTE.md
- [x] I have used sentence-case for titles and headers
- [x] I have used descriptive link text
- [x] I have checked for broken links
- [x] I have verified that my changes don't break the build (`yarn build`)

## Additional Notes

Version strings appear here as literals; they are centralized into `src/resources/globalVars.js` in a final follow-up PR. Companion PRs share the `stylus` tag.
