### PR TITLE
Update Stylus gas-metering concept

### DIFF
--- a/docs/stylus/concepts/gas-metering.mdx
+++ b/docs/stylus/concepts/gas-metering.mdx
@@ -31,10 +31,10 @@ Stylus introduces new pricing models for WASM programs. Intended for high-comput
 
 There are, however, minor overheads to using Stylus that may matter to your application:
 
-- The first time a WASM is deployed, it must be _activated_. This is generally a few million gas, though to avoid testnet DoS, we've set it to a fixed 14 million. Note that you do not have to activate future copies of the same program. For example, the same NFT template can be deployed many times without paying this cost more than once. We will soon make the fees paid depend on the program, so that the gas used is based on the complexity of the WASM instead of this very conservative, worst-case estimate.
-- Calling a Stylus contract costs 128-2048 gas. We're working with Wasmer to improve setup costs, but there will likely always be some amount of gas one pays to jump into WASM execution. This means that if a contract does next to nothing, it may be cheaper in Solidity. However if a contract starts doing interesting work, the dynamic fees will quickly make up for this fixed-cost overhead.
+- The first time a WASM is deployed, it must be _activated_. Activation charges a configurable `ActivationGas` amount (`0` by default), plus a fixed computation charge of `1,659,168` gas, plus a dynamic data fee that scales with the size of the compiled program. Note that you do not have to activate future copies of the same program. For example, the same NFT template can be deployed many times without paying the activation cost more than once.
+- Calling a Stylus contract incurs a minimum init cost of `8,832` gas when the program is not cached, or `352` gas when it is cached, plus a dynamic init term proportional to the program's complexity. There will likely always be some amount of gas one pays to jump into WASM execution. This means that if a contract does next to nothing, it may be cheaper in Solidity. However if a contract starts doing interesting work, the dynamic fees will quickly make up for this fixed-cost overhead.
 
-Though conservative bounds have been chosen for testnet, all of this is subject to change as pricing models mature and further optimizations are made. Since gas numbers will vary across updates, it may make more sense to clock the time it takes to perform an operation rather than going solely by the numbers reported in receipts.
+All of these parameters are configurable by the chain owner and subject to change as pricing models mature and further optimizations are made. Since gas numbers will vary across updates, it may make more sense to clock the time it takes to perform an operation rather than going solely by the numbers reported in receipts.
 
 ## Ink and gas
 
@@ -72,7 +72,7 @@ For example, if the Stylus VM becomes 2x faster, instead of cutting the nominal 
 
 It is important to note that users never need to worry about this notion of ink. Receipts will always be measured in gas, with the exchange rate applied automatically under the hood as the VMs pass execution back and forth.
 
-However, developers optimizing contracts may choose to measure performance in ink to pin down the exact cost of executing various routines. The <a href="https://docs.rs/stylus-sdk/0.3.0/stylus_sdk/evm/fn.ink_left.html"><code>ink_left</code></a> function exposes this value, and various methods throughout the Rust SDK optionally accept ink amounts too.
+However, developers optimizing contracts may choose to measure performance in ink to pin down the exact cost of executing various routines. The `evm_ink_left()` host method exposes this value, and various methods throughout the Rust SDK optionally accept ink amounts too.
 
 ### See also
 


### PR DESCRIPTION
## Description

Part of a section-wide **Stylus documentation update** that brings `docs/stylus/` back in line with the current stack (stylus-sdk **0.10.7** / cargo-stylus **0.10.7** / Nitro **v3.11.0**). The update is split into ~25 small, independently reviewable PRs (all tagged `stylus`).

**This PR:** replaces invented activation/init-gas numbers with the verified Nitro model and fixes a dead docs.rs link.

Code examples were verified against the live toolchain — compiled, and deployed on a local Nitro dev node where applicable — and conceptual claims were checked against the Nitro source. The branch builds clean with `yarn build` (strict `onBrokenLinks`).

## Document type

- [x] Concept

## Checklist

- [x] My changes follow the style conventions outlined in CONTRIBUTE.md
- [x] I have used sentence-case for titles and headers
- [x] I have used descriptive link text
- [x] I have checked for broken links
- [x] I have verified that my changes don't break the build (`yarn build`)

## Additional Notes

Version strings appear here as literals; they are centralized into `src/resources/globalVars.js` in a final follow-up PR. Companion PRs share the `stylus` tag.
