### PR TITLE
Update Stylus WebAssembly size limits

### DIFF
--- a/docs/stylus/concepts/webassembly.mdx
+++ b/docs/stylus/concepts/webassembly.mdx
@@ -232,13 +232,13 @@ impl Counter {
 
 ### 2. Compile to WASM
 
-```bash
+```shell
 cargo stylus build
 ```
 
 This runs:
 
-```bash
+```shell
 cargo build \
   --lib \
   --locked \
@@ -249,7 +249,7 @@ cargo build \
 
 ### 3. Optimize (optional)
 
-```bash
+```shell
 wasm-opt target/wasm32-unknown-unknown/release/my_contract.wasm \
   -O3 \
   --strip-debug \
@@ -260,7 +260,7 @@ Optimization can reduce the size by an additional 10-30%.
 
 ### 4. Deploy and activate
 
-```bash
+```shell
 # Deploy compressed WASM
 cargo stylus deploy --private-key=$PRIVATE_KEY
 
@@ -269,17 +269,20 @@ cargo stylus deploy --private-key=$PRIVATE_KEY
 
 ## Size limitations
 
-Nitro imposes limits on WASM contract size:
+Nitro bounds the **decompressed** size of an activated Stylus program through the `MaxWasmSize` ArbOS parameter. This is the WASM size after Brotli decompression, not the compressed on-chain bytecode, and it is not the EVM contract-size limit (the 24 KB EIP-170 ceiling applies to Solidity contracts, not Stylus programs).
 
-| Limit                 | Value                  | Reason                            |
-| --------------------- | ---------------------- | --------------------------------- |
-| **Uncompressed size** | ~3-4 MB                | Memory and processing constraints |
-| **Compressed size**   | 24 KB (initial)        | Ethereum transaction size limit   |
-| **Compressed size**   | 128 KB (with EIP-4844) | Larger blob transactions          |
+`MaxWasmSize` is chain-configurable by the chain owner via `ArbOwner.SetWasmMaxSize`. The values below are the protocol defaults:
 
-To stay within limits:
+| ArbOS version   | Default `MaxWasmSize` (decompressed) |
+| --------------- | ------------------------------------ |
+| Before ArbOS 60 | 128 KB                               |
+| ArbOS 60+       | 256 KB                               |
 
-- Use `#[no_std]` to avoid standard library bloat
+From ArbOS 60 onward, large programs can also be stored as a root plus fragments (default `MaxFragmentCount` of 4): the compressed payload is split across multiple code accounts, reassembled, and decompressed at activation, with the decompressed total still bounded by `MaxWasmSize`.
+
+To stay within these limits:
+
+- Use `#![no_std]` to avoid standard library bloat
 - Strip debug symbols with `--strip-debug`
 - Enable aggressive optimization (`-O3`)
 - Minimize dependencies
@@ -355,7 +358,7 @@ Stylus uses WASM MVP (Minimum Viable Product) instructions plus bulk-memory oper
 ### 1. Minimize binary size
 
 ```rust
-// Use #[no_std] when possible
+// Use #![no_std] when possible
 #![no_std]
 extern crate alloc;
 
@@ -376,7 +379,7 @@ let large_buffer = vec![0u8; 1024];
 
 ### 3. Profile before optimizing
 
-```bash
+```shell
 # Check binary size
 ls -lh target/wasm32-unknown-unknown/release/*.wasm
 
@@ -387,7 +390,7 @@ twiggy top target/wasm32-unknown-unknown/release/my_contract.wasm
 
 ### 4. Test locally
 
-```bash
+```shell
 # Use cargo-stylus for local testing
 cargo stylus check
 cargo stylus export-abi


### PR DESCRIPTION
## Description

Part of a section-wide **Stylus documentation update** that brings `docs/stylus/` back in line with the current stack (stylus-sdk **0.10.7** / cargo-stylus **0.10.7** / Nitro **v3.11.0**). The update is split into ~25 small, independently reviewable PRs (all tagged `stylus`).

**This PR:** corrects the WASM size-limit model to the chain-configurable `MaxWasmSize` (128 KB / 256 KB at ArbOS 60+).

Code examples were verified against the live toolchain — compiled, and deployed on a local Nitro dev node where applicable — and conceptual claims were checked against the Nitro source. The branch builds clean with `yarn build` (strict `onBrokenLinks`).

## Document type

- [x] Concept

## Checklist

- [x] My changes follow the style conventions outlined in CONTRIBUTE.md
- [x] I have used sentence-case for titles and headers
- [x] I have used descriptive link text
- [x] I have checked for broken links
- [x] I have verified that my changes don't break the build (`yarn build`)

## Additional Notes

Version strings appear here as literals; they are centralized into `src/resources/globalVars.js` in a final follow-up PR. Companion PRs share the `stylus` tag.
