### PR TITLE
Update Stylus opcode/hostio pricing reference

### DIFF
--- a/docs/stylus/reference/opcode-hostio-pricing.mdx
+++ b/docs/stylus/reference/opcode-hostio-pricing.mdx
@@ -9,6 +9,8 @@ sidebar_position: 3
 
 This reference provides the latest gas and ink costs for specific WASM opcodes and host I/Os when using Stylus. For a conceptual introduction to Stylus gas and ink, see [Gas and ink (Stylus)](/stylus/concepts/gas-metering).
 
+<VanillaAdmonition type="info">The per-opcode and per-host-I/O ink costs in the tables below are subject to change as Stylus matures. They are defined in the upstream Stylus/Arbitrator source rather than in the precompiles, so confirm the current values against that source before relying on exact figures. The ink-to-gas relationship is fixed: 10,000 ink = 1 gas.</VanillaAdmonition>
+
 ## Opcode costs
 
 The Stylus VM charges for WASM opcodes according to the following table, which was determined via a conservative statistical analysis and is expected to change as Stylus matures. Prices may fluctuate across upgrades as our analysis evolves and optimizations are made.
@@ -99,7 +101,7 @@ The Stylus VM charges for WASM opcodes according to the following table, which w
 | 0x77   | I32Rotl       | 70           | 0.007          |                               |
 | 0x78   | I32Rotr       | 70           | 0.007          |                               |
 | 0x79   | I64Clz        | 210          | 0.021          |                               |
-| 0x7a   | I64Ctz        | 210          | 0.012          |                               |
+| 0x7a   | I64Ctz        | 210          | 0.021          |                               |
 | 0x7b   | I64Popcnt     | 6000         | 0.6            |                               |
 | 0x7c   | I64Add        | 100          | 0.01           |                               |
 | 0x7d   | I64Sub        | 100          | 0.01           |                               |
@@ -142,7 +144,7 @@ Note that the values in this table were determined via a conservative statistica
 | block_coinbase   | 13440           | 1.344          |                            |
 | block_gas_limit  | 8400            | 0.84           |                            |
 | block_number     | 8400            | 0.84           |                            |
-| block_timestmap  | 8400            | 0.84           |                            |
+| block_timestamp  | 8400            | 0.84           |                            |
 | chain_id         | 8400            | 0.84           |                            |
 | contract_address | 13440           | 1.344          |                            |
 | evm_gas_left     | 8400            | 0.84           |                            |


### PR DESCRIPTION
## Description

Part of a section-wide **Stylus documentation update** that brings `docs/stylus/` back in line with the current stack (stylus-sdk **0.10.7** / cargo-stylus **0.10.7** / Nitro **v3.11.0**). The update is split into ~25 small, independently reviewable PRs (all tagged `stylus`).

**This PR:** fixes typos and adds an SME-validation note for the per-hostio ink table (those constants could not be verified from the Nitro checkout).

Code examples were verified against the live toolchain — compiled, and deployed on a local Nitro dev node where applicable — and conceptual claims were checked against the Nitro source. The branch builds clean with `yarn build` (strict `onBrokenLinks`).

## Document type

- [x] Reference

## Checklist

- [x] My changes follow the style conventions outlined in CONTRIBUTE.md
- [x] I have used sentence-case for titles and headers
- [x] I have used descriptive link text
- [x] I have checked for broken links
- [x] I have verified that my changes don't break the build (`yarn build`)

## Additional Notes

Version strings appear here as literals; they are centralized into `src/resources/globalVars.js` in a final follow-up PR. Companion PRs share the `stylus` tag.
