### PR TITLE
Update Stylus gentle introduction

### DIFF
--- a/docs/stylus/gentle-introduction.mdx
+++ b/docs/stylus/gentle-introduction.mdx
@@ -24,7 +24,7 @@ Stylus is an upgrade to Arbitrum Nitro [(ArbOS 32)](/run-arbitrum-node/arbos-rel
 
 This second virtual machine executes WebAssembly (WASM) rather than EVM bytecode. WASM is a binary format used in web standards and browsers for efficient computation. Its design is to be portable and human-readable, with sandboxed execution environments for security. Working with WASM is nothing new for Arbitrum chains. Ever since the [Nitro upgrade](https://medium.com/offchainlabs/arbitrum-nitro-one-small-step-for-l2-one-giant-leap-for-ethereum-bc9108047450), WASM has been a fundamental component of Arbitrum's fraud proofs.
 
-With a WASM VM, any programming language compilable to WASM is within Stylus's scope. While many popular programming languages can compile to WASM, some compilers are better suited to smart contract development than others, such as Rust, C, and C++. Other languages like Go, Sway, Move, and Cairo are also supported. Languages that include their own runtimes, like Python and JavaScript, are more complex for Stylus to support, although not impossible. WASM programs tend to be more efficient than EVM bytecode for memory-intensive applications. This efficiency comes from mature compiler toolchains for languages like Rust and C, which have benefited from decades of optimization work. The WASM runtime also executes faster than the EVM interpreter. Third-party contributions in the form of libraries for new and existing languages are welcome.
+With a WASM VM, any programming language compilable to WASM is within Stylus's scope. In practice, some compilers are better suited to smart contract development than others. Rust has the first-class, fully supported SDK, and C and C++ are also supported. Any other language that compiles to WASM is theoretically possible, but support for those is experimental rather than officially maintained. Languages that include their own runtimes, like Python and JavaScript, are more complex for Stylus to support, although not impossible. WASM programs tend to be more efficient than EVM bytecode for memory-intensive applications. This efficiency comes from mature compiler toolchains for languages like Rust and C, which have benefited from decades of optimization work. The WASM runtime also executes faster than the EVM interpreter. Third-party contributions in the form of libraries for new and existing languages are welcome.
 
 ## How Stylus works
 
@@ -44,9 +44,11 @@ To make your contract callable, it must undergo an [activation process](/stylus/
 
 Stylus measures computational costs using ink instead of gas. Ink works like gas but is thousands of times smaller. WASM executes faster than the EVM, so a single EVM operation takes as long as thousands of WASM operations. A finer-grained unit makes pricing more precise.
 
-:::note
-Stylus contracts need to be reactivated once per year (365 days) or after any Stylus upgrade. You can do this using [`cargo-stylus`](/stylus/cli-tools/commands-reference) or the [ArbWasm precompile](/arbitrum-essentials/precompiles/reference#common-precompiles). If a contract isn't reactivated, it becomes uncallable.
-:::
+<VanillaAdmonition type="note">
+
+Stylus contracts need to be reactivated once per year (365 days) or after any Stylus upgrade. You can do this using [`cargo-stylus`](/stylus/cli-tools/commands-reference) or the [ArbWasm precompile](/arbitrum-essentials/precompiles/reference#common-precompiles). If a contract isn't reactivated, it becomes uncallable. The 365-day expiry and a minimum age of about 31 days before a contract can be kept alive are both configurable chain parameters; these are the current defaults.
+
+</VanillaAdmonition>
 
 ### Execution
 


### PR DESCRIPTION
## Description

Part of a section-wide **Stylus documentation update** that brings `docs/stylus/` back in line with the current stack (stylus-sdk **0.10.7** / cargo-stylus **0.10.7** / Nitro **v3.11.0**). The update is split into ~25 small, independently reviewable PRs (all tagged `stylus`).

**This PR:** confirms the reactivation period (365 days + 31-day keepalive) and softens the language-support overstatement.

Code examples were verified against the live toolchain — compiled, and deployed on a local Nitro dev node where applicable — and conceptual claims were checked against the Nitro source. The branch builds clean with `yarn build` (strict `onBrokenLinks`).

## Document type

- [x] Gentle introduction

## Checklist

- [x] My changes follow the style conventions outlined in CONTRIBUTE.md
- [x] I have used sentence-case for titles and headers
- [x] I have used descriptive link text
- [x] I have checked for broken links
- [x] I have verified that my changes don't break the build (`yarn build`)

## Additional Notes

Version strings appear here as literals; they are centralized into `src/resources/globalVars.js` in a final follow-up PR. Companion PRs share the `stylus` tag.
