### PR TITLE
Update Stylus activation concept

### DIFF
--- a/docs/stylus/concepts/activation.mdx
+++ b/docs/stylus/concepts/activation.mdx
@@ -58,7 +58,7 @@ pub enum ContractStatus {
 
 Before deployment, your Rust contract is compiled and processed:
 
-```bash
+```shell
 cargo stylus check
 ```
 
@@ -71,7 +71,7 @@ This performs:
    - Strip unnecessary custom sections
 3. **Brotli compression**: Maximum compression (level 11)
 4. **Add EOF prefix**: `EFF00000` (identifies Stylus programs)
-5. **Size validation**: Compressed code must be ≤ 24KB
+5. **Size validation**: The _decompressed_ WASM must fit within the chain's `MaxWasmSize` parameter (default 128 KB, raised to 256 KB at ArbOS 60+). This is a chain-configurable ArbOS parameter, not the 24 KB EVM contract-code limit that applies to Solidity. At ArbOS 60+, programs larger than the limit can be split into a root plus fragments.
 
 **WASM Processing Pipeline**:
 
@@ -83,7 +83,7 @@ _Figure 1: WASM binary processing pipeline showing transformation from raw binar
 
 Deployment creates a transaction that stores your processed WASM onchain:
 
-```bash
+```shell
 cargo stylus deploy \
   --private-key-path=key.txt \
   --endpoint="https://sepolia-rollup.arbitrum.io/rpc"
@@ -116,7 +116,7 @@ EVM Initcode Prelude (43 bytes):
 
 ### Step 3: Calculate activation fee
 
-Before activating, the data fee must be calculated:
+Before activating, the data fee must be calculated. Conceptually (illustrative pseudocode, not a runnable API):
 
 ```rust
 // Simulated via state overrides (no transaction sent)
@@ -137,7 +137,7 @@ let final_fee = data_fee * (1 + bump_percent / 100);
 
 Activation registers your contract with the ArbWasm precompile:
 
-```bash
+```shell
 # Automatic activation (default)
 cargo stylus deploy --private-key-path=key.txt
 
@@ -166,72 +166,14 @@ cargo stylus activate \
 
 ## Using `cargo-stylus`
 
-The `cargo-stylus` CLI tool simplifies the deployment and activation workflow.
+The `cargo-stylus` CLI maps directly onto the two steps above:
 
-### Basic deployment (automatic activation)
+- `cargo stylus deploy` handles both deployment and activation in one command (the default).
+- `cargo stylus deploy --no-activate` deploys without activating, so the program can be inspected or activated later.
+- `cargo stylus activate --address=<ADDRESS>` activates a previously deployed contract.
+- `cargo stylus check` validates the contract and reports whether matching code is already activated, the estimated data fee, or any validation errors.
 
-By default, `cargo stylus deploy` handles both steps:
-
-```bash
-cargo stylus deploy \
-  --private-key-path=wallet.txt \
-  --endpoint="https://sepolia-rollup.arbitrum.io/rpc"
-```
-
-**Output**:
-
-```
-Building contract...
-Compressing WASM...
-Deploying contract to 0x1234567890abcdef...
-Deployment transaction: 0xabcd...
-Contract deployed at: 0x1234567890abcdef
-Activating contract...
-Activation transaction: 0xef12...
-Contract activated successfully!
-```
-
-### Deploy without activation
-
-To deploy but skip activation:
-
-```bash
-cargo stylus deploy \
-  --private-key-path=wallet.txt \
-  --no-activate
-```
-
-This is useful when:
-
-- You want to inspect the contract before activating
-- Someone else will handle the activation
-- You're testing deployment workflows
-
-### Manual activation
-
-Activate a previously deployed contract:
-
-```bash
-cargo stylus activate \
-  --address=0x1234567890abcdef \
-  --private-key-path=wallet.txt \
-  --endpoint="https://sepolia-rollup.arbitrum.io/rpc"
-```
-
-### Check contract status
-
-Before deploying, check if a contract with the same code is already activated:
-
-```bash
-cargo stylus check \
-  --endpoint="https://sepolia-rollup.arbitrum.io/rpc"
-```
-
-**Possible outcomes**:
-
-1. **Code already activated**: You can reuse the existing deployment
-2. **Ready to activate**: Shows estimated data fee
-3. **Validation errors**: Displays issues that must be fixed
+For the full command syntax and options, see the [check and deploy guide](/stylus/cli-tools/check-and-deploy) and the [`cargo-stylus` command reference](/stylus/cli-tools/commands-reference).
 
 ## Deployment with constructors
 
@@ -250,7 +192,7 @@ impl MyContract {
 
 **Deploy with constructor arguments**:
 
-```bash
+```shell
 cargo stylus deploy \
   --private-key-path=wallet.txt \
   --constructor-args 42 0x1234567890abcdef1234567890abcdef12345678
@@ -267,7 +209,7 @@ pub fn constructor(&mut self) {
 }
 ```
 
-```bash
+```shell
 cargo stylus deploy \
   --private-key-path=wallet.txt \
   --constructor-value=1000000000000000000  # 1 ETH in wei
@@ -304,7 +246,7 @@ function activateProgram(
 
 **Example (via cast)**:
 
-```bash
+```shell
 cast send 0x0000000000000000000000000000000000000071 \
   "activateProgram(address)" \
   0x1234567890abcdef \
@@ -341,10 +283,10 @@ Returns the number of seconds until expiration (default: ~1 year from activation
 Extend a program's expiration time:
 
 ```solidity
-function codehashKeepalive(bytes32 codehash) external payable returns (uint64 expirySeconds);
+function codehashKeepalive(bytes32 codehash) external payable;
 ```
 
-Resets the expiration timer to prevent program deactivation.
+Resets the expiration timer to prevent program deactivation. The call pays the activation data fee in `value` and returns no value. To read the time remaining before expiry, use the separate `programTimeLeft` getter (above), which returns the seconds left.
 
 ### `ArbWasm` errors
 
@@ -371,21 +313,13 @@ error ProgramInsufficientValue(uint256 have, uint256 want);
 
 ### Estimating costs
 
-Get cost estimates before deploying:
-
-```bash
-# Estimate deployment gas
-cargo stylus deploy --estimate-gas
-
-# Check activation fee
-cargo stylus check  # Shows estimated data fee
-```
+Before deploying, `cargo stylus deploy --estimate-gas` reports the deployment gas and `cargo stylus check` reports the estimated activation data fee. See the [check and deploy guide](/stylus/cli-tools/check-and-deploy) for details.
 
 ### Fee bump configuration
 
 Protect against fee variance with configurable bump percentage:
 
-```bash
+```shell
 # Default: 20% bump
 cargo stylus deploy --private-key-path=wallet.txt
 
@@ -393,11 +327,10 @@ cargo stylus deploy --private-key-path=wallet.txt
 # (Note: Use programmatically via stylus-tools library)
 ```
 
-**In code** (using stylus-tools):
+**In code** (illustrative, using the `stylus-tools` library):
 
 ```rust
-use stylus_tools::core::activation::ActivationConfig;
-
+// Illustrative — types and field names are not a stable public API.
 let config = ActivationConfig {
     data_fee_bump_percent: 25,  // 25% safety margin
 };
@@ -407,7 +340,7 @@ let config = ActivationConfig {
 
 If your contract's codehash matches an already-activated contract:
 
-```bash
+```shell
 cargo stylus check
 ```
 
@@ -443,7 +376,7 @@ function cacheProgram(address program) external payable returns (uint256);
 
 When deploying multiple instances of the same contract:
 
-```bash
+```shell
 # First deployment: full deploy + activate
 cargo stylus deploy --private-key-path=wallet.txt
 # Contract 1: 0xaaaa... (activated)
@@ -460,7 +393,7 @@ All three contracts share the same codehash and activation, saving on data fees.
 
 ### Programmatic deployment
 
-Using the `stylus-tools` library directly:
+Using the `stylus-tools` library directly. The following is illustrative pseudocode that sketches the deploy/activate flow — it is not a compilable example, and the exact types and signatures vary by `stylus-tools` version:
 
 ```rust
 use stylus_tools::core::{
@@ -505,7 +438,7 @@ async fn deploy_and_activate(
 
 Use a custom deployer contract instead of the default:
 
-```bash
+```shell
 cargo stylus deploy \
   --private-key-path=wallet.txt \
   --deployer-address=0x... \
@@ -531,13 +464,13 @@ Deployed → Activated → [Active] → [Keepalive] → [Expired]
 
 ### Expiration and `Keepalive`
 
-Programs automatically expire after ~1 year (configurable by chain):
+Programs expire after the chain's `ExpiryDays` parameter (default 365 days). Both the expiry period and the minimum age before a program can be kept alive (`KeepaliveDays`, default 31 days) are configurable ArbOS parameters:
 
 ```solidity
 // Check time remaining
 uint64 timeLeft = ArbWasm.programTimeLeft(contractAddress);
 
-// Extend expiration
+// Extend expiration (pays the data fee in value; the program must be at least KeepaliveDays old)
 ArbWasm.codehashKeepalive{value: keepaliveFee}(codehash);
 ```
 
@@ -557,7 +490,7 @@ ArbWasm.codehashKeepalive{value: keepaliveFee}(codehash);
 
 If a program expires:
 
-```bash
+```shell
 # Reactivate the existing deployment
 cargo stylus activate --address=0x...
 ```
@@ -574,7 +507,7 @@ The contract code remains onchain; only the activation state is cleared.
 
 **Solution**:
 
-```bash
+```shell
 cargo stylus activate --address=0x...
 ```
 
@@ -612,153 +545,29 @@ cargo stylus activate --address=0x...
 
 **Solution**:
 
-```bash
+```shell
 # Reactivate the contract
 cargo stylus activate --address=0x...
 ```
 
-### Debugging activation
+### Debugging and verifying activation
 
-Enable verbose output:
-
-```bash
-# Check detailed status
-cargo stylus check --verbose
-
-# Deploy with verbose logging
-RUST_LOG=debug cargo stylus deploy --private-key-path=wallet.txt
-```
-
-### Verifying activation status
-
-Check if a contract is activated:
-
-```bash
-# Via cargo-stylus
-cargo stylus check --address=0x...
-
-# Via cast (calling ArbWasm)
-cast call 0x0000000000000000000000000000000000000071 \
-  "codehashVersion(bytes32)" \
-  $(cast keccak $(cast code 0x...))
-```
+To inspect status or debug a failed activation, `cargo stylus check` validates a contract (add `--verbose` for detail), and `cargo stylus check --address=0x...` reports whether an existing deployment is activated. For verbose deploy logging and `cast`-based status checks against the ArbWasm precompile, see the [debugging transactions guide](/stylus/cli-tools/debugging-tx) and the [check and deploy guide](/stylus/cli-tools/check-and-deploy).
 
 ## Best practices
 
-### 1. Always check before deploying
+- **Check before deploying.** `cargo stylus check` catches validation errors and reports whether matching code is already activated, avoiding duplicate activations and wasted gas.
+- **Use automatic activation.** Unless you have a reason to split the steps, `cargo stylus deploy` deploys and activates in one command.
+- **Test on Arbitrum Sepolia first**, then deploy to mainnet.
+- **Monitor expiration** of production contracts with `programTimeLeft` and call `codehashKeepalive` before the program expires.
+- **Keep the SDK updated** — older versions may become incompatible with chain upgrades:
 
-```bash
-cargo stylus check
-```
+  ```toml
+  [dependencies]
+  stylus-sdk = "0.10.7"
+  ```
 
-This prevents deploying duplicate code and wasting gas.
-
-### 2. Use automatic activation
-
-Unless you have specific reasons to split deployment and activation, use the default behavior:
-
-```bash
-cargo stylus deploy  # Deploys AND activates
-```
-
-### 3. Test on testnet first
-
-Deploy to Arbitrum Sepolia before mainnet:
-
-```bash
-cargo stylus deploy \
-  --endpoint="https://sepolia-rollup.arbitrum.io/rpc" \
-  --private-key-path=testnet-key.txt
-```
-
-### 4. Monitor contract expiration
-
-Set up monitoring for production contracts:
-
-```solidity
-uint64 timeLeft = ArbWasm.programTimeLeft(contractAddress);
-if (timeLeft < 30 days) {
-    // Send alert or trigger keepalive
-}
-```
-
-### 5. Document activation details
-
-Track activation information:
-
-- Contract address
-- Activation transaction hash
-- Stylus version
-- Data fee paid
-- Activation timestamp
-
-### 6. Keep SDK updated
-
-Use the latest Stylus SDK version:
-
-```toml
-[dependencies]
-stylus-sdk = "0.10.0-beta.1"
-```
-
-Older versions may become incompatible with chain upgrades.
-
-### 7. Handle constructor arguments carefully
-
-Type-check constructor arguments:
-
-```bash
-# Incorrect (will fail)
-cargo stylus deploy --constructor-args "hello" 123
-
-# Correct (matches constructor signature)
-cargo stylus deploy --constructor-args 0x1234... 42
-```
-
-## Complete example
-
-Here's a full deployment workflow:
-
-```bash
-# 1. Create new Stylus project
-cargo stylus new my-token
-cd my-token
-
-# 2. Build and verify locally
-cargo build --release --target wasm32-unknown-unknown
-cargo stylus check
-
-# 3. Test on Arbitrum Sepolia
-export SEPOLIA_ENDPOINT="https://sepolia-rollup.arbitrum.io/rpc"
-export PRIVATE_KEY_PATH="./sepolia-key.txt"
-
-cargo stylus deploy \
-  --endpoint=$SEPOLIA_ENDPOINT \
-  --private-key-path=$PRIVATE_KEY_PATH \
-  --constructor-args "MyToken" "MTK" 18
-
-# 4. Verify deployment
-cargo stylus check \
-  --endpoint=$SEPOLIA_ENDPOINT \
-  --address=0x...  # Address from step 3
-
-# 5. Deploy to mainnet
-export MAINNET_ENDPOINT="https://arb1.arbitrum.io/rpc"
-export MAINNET_KEY_PATH="./mainnet-key.txt"
-
-cargo stylus deploy \
-  --endpoint=$MAINNET_ENDPOINT \
-  --private-key-path=$MAINNET_KEY_PATH \
-  --constructor-args "MyToken" "MTK" 18
-
-# 6. Cache the contract (optional, for gas optimization)
-cast send 0x0000000000000000000000000000000000000072 \
-  "cacheProgram(address)" \
-  0x...  # Your contract address \
-  --value 10000000000000000 \
-  --rpc-url=$MAINNET_ENDPOINT \
-  --private-key=$MAINNET_PRIVATE_KEY
-```
+For the full deployment walkthrough — project setup, gas estimation, reproducible builds, and verification — see the [check and deploy guide](/stylus/cli-tools/check-and-deploy).
 
 ## Summary
 
@@ -766,7 +575,7 @@ cast send 0x0000000000000000000000000000000000000072 \
 - **cargo-stylus handles both**: Use `deploy` for automatic activation
 - **Data fee required**: Activation costs **ETH** (separate from deployment gas)
 - **Code reuse**: Identical contracts share activation, saving costs
-- **Expiration**: Programs expire after ~1 year without a `keepalive`
+- **Expiration**: Programs expire after the chain's `ExpiryDays` parameter (default 365 days) unless kept alive
 - **ArbWasm precompile**: All activation goes through address `0x71`
 - **Check first**: Use the `cargo stylus check` to avoid duplicate activations
 
@@ -774,5 +583,5 @@ cast send 0x0000000000000000000000000000000000000072 \
 
 - [Contracts](../fundamentals/contracts.mdx): Writing Stylus contracts
 - [Global Variables and Functions](../fundamentals/global-variables-and-functions.mdx): VM interface methods
-  <!-- - [cargo-stylus CLI Reference](../reference/cargo-stylus-reference.mdx) - Complete CLI documentation -->
-  <!-- - [ArbWasm Precompile](../reference/precompiles.mdx#arbwasm) - Detailed precompile reference -->
+- [Check and deploy](/stylus/cli-tools/check-and-deploy): Full `cargo stylus` deployment walkthrough
+- [`cargo-stylus` command reference](/stylus/cli-tools/commands-reference): Complete CLI option reference


### PR DESCRIPTION
## Description

Part of a section-wide **Stylus documentation update** that brings `docs/stylus/` back in line with the current stack (stylus-sdk **0.10.7** / cargo-stylus **0.10.7** / Nitro **v3.11.0**). The update is split into ~25 small, independently reviewable PRs (all tagged `stylus`).

**This PR:** corrects the `codehashKeepalive` signature, fixes the WASM size limit, and trims duplicated CLI walkthroughs to links.

Code examples were verified against the live toolchain — compiled, and deployed on a local Nitro dev node where applicable — and conceptual claims were checked against the Nitro source. The branch builds clean with `yarn build` (strict `onBrokenLinks`).

## Document type

- [x] Concept

## Checklist

- [x] My changes follow the style conventions outlined in CONTRIBUTE.md
- [x] I have used sentence-case for titles and headers
- [x] I have used descriptive link text
- [x] I have checked for broken links
- [x] I have verified that my changes don't break the build (`yarn build`)

## Additional Notes

Version strings appear here as literals; they are centralized into `src/resources/globalVars.js` in a final follow-up PR. Companion PRs share the `stylus` tag.
