### PR TITLE
Update Stylus check-and-deploy guide

### DIFF
--- a/docs/stylus/cli-tools/check-and-deploy.mdx
+++ b/docs/stylus/cli-tools/check-and-deploy.mdx
@@ -47,7 +47,7 @@ The `cargo stylus check` command validates that your contract can be deployed an
    - Required exports (`user_entrypoint`)
    - Allowed imports (only `vm_hooks`)
    - Memory constraints
-   - Size limits (24KB compressed)
+   - Size limits (decompressed WASM within `MaxWasmSize`)
 4. **Simulates activation** using `eth_call` to verify onchain compatibility
 5. **Estimates the data fee** required for activation
 
@@ -106,7 +106,7 @@ Common validation errors include:
 
 - **Missing entrypoint**: Contract lacks `#[entrypoint]` attribute
 - **Invalid exports**: Contract exports reserved symbols
-- **Size limit exceeded**: Compressed WASM exceeds 24KB
+- **Size limit exceeded**: Decompressed WASM exceeds `MaxWasmSize` (the chain-configurable limit, 128 KB by default and 256 KB at ArbOS 60+)
 - **Invalid imports**: Contract imports functions outside `vm_hooks`
 - **Memory violations**: Incorrect memory handling or growth
 
@@ -263,7 +263,7 @@ cargo stylus deploy \
 # Specify cargo-stylus version
 cargo stylus deploy \
   --private-key-path=./key.txt \
-  --cargo-stylus-version=0.5.0
+  --cargo-stylus-version=0.10.7
 ```
 
 Skip Docker for local development (non-reproducible):
@@ -401,7 +401,7 @@ cargo stylus deploy \
 cargo stylus deploy \
   --endpoint="https://arb1.arbitrum.io/rpc" \
   --private-key-path=./key.txt \
-  --cargo-stylus-version=0.5.0
+  --cargo-stylus-version=0.10.7
 
 # 4. Verify the deployed contract
 cargo stylus verify \
@@ -522,7 +522,7 @@ cargo stylus deploy \
 cargo stylus deploy \
   --endpoint="https://arb1.arbitrum.io/rpc" \
   --private-key-path=./key.txt \
-  --cargo-stylus-version=0.5.0
+  --cargo-stylus-version=0.10.7
 
 # Then verify on Arbiscan
 cargo stylus verify \
@@ -542,7 +542,7 @@ cargo stylus deploy \
 # Check compressed size
 cargo stylus check
 
-# If size is close to 24KB limit:
+# If the decompressed WASM is close to the MaxWasmSize limit:
 # - Use #[no_std]
 # - Remove unused dependencies
 # - Enable aggressive optimizations
@@ -568,7 +568,7 @@ cargo stylus deploy --private-key-path=./key.txt --estimate-gas
 
 ### Size limit errors
 
-**Error**: Compressed WASM exceeds 24KB
+**Error**: Decompressed WASM exceeds the size limit (`MaxWasmSize`)
 
 **Solutions**:
 
@@ -583,7 +583,7 @@ cargo stylus deploy --private-key-path=./key.txt --estimate-gas
 
    ```toml
    [dependencies]
-   stylus-sdk = "0.5"
+   stylus-sdk = "0.10.7"
    # Remove unnecessary crates
    ```
 
@@ -690,7 +690,7 @@ cargo stylus deploy --private-key-path=./key.txt --estimate-gas
 4. Check SDK version compatibility:
    ```toml
    [dependencies]
-   stylus-sdk = "0.5"  # Use latest stable version
+   stylus-sdk = "0.10.7"  # Use latest stable version
    ```
 
 ## Non-Rust WASM Deployment


### PR DESCRIPTION
## Description

Part of a section-wide **Stylus documentation update** that brings `docs/stylus/` back in line with the current stack (stylus-sdk **0.10.7** / cargo-stylus **0.10.7** / Nitro **v3.11.0**). The update is split into ~25 small, independently reviewable PRs (all tagged `stylus`).

**This PR:** corrects the WASM size-limit references and version strings.

Code examples were verified against the live toolchain — compiled, and deployed on a local Nitro dev node where applicable — and conceptual claims were checked against the Nitro source. The branch builds clean with `yarn build` (strict `onBrokenLinks`).

## Document type

- [x] How-to

## Checklist

- [x] My changes follow the style conventions outlined in CONTRIBUTE.md
- [x] I have used sentence-case for titles and headers
- [x] I have used descriptive link text
- [x] I have checked for broken links
- [x] I have verified that my changes don't break the build (`yarn build`)

## Additional Notes

Version strings appear here as literals; they are centralized into `src/resources/globalVars.js` in a final follow-up PR. Companion PRs share the `stylus` tag.
