### PR TITLE
Update Stylus verify-contracts guide

### DIFF
--- a/docs/stylus/cli-tools/verify-contracts.mdx
+++ b/docs/stylus/cli-tools/verify-contracts.mdx
@@ -13,9 +13,11 @@ displayed_sidebar: buildStylusSidebar
 
 You can verify a Stylus contract in two ways: locally with `cargo stylus` or on [Arbiscan](https://arbiscan.io/), Arbitrum’s block explorer. This guide covers both methods.
 
-:::info
+<VanillaAdmonition type="info">
+
 Stylus contract verification on Arbiscan is only supported for contracts deployed using `cargo-stylus` 0.5.0 or higher.
-:::
+
+</VanillaAdmonition>
 
 ## Overview: Why verify contracts?
 
@@ -166,15 +168,14 @@ If your contract is a single `.rs` file:
 For multi-file projects:
 
 1. Click **"Standard JSON Input"**
-2. Generate the JSON using:
+2. Prepare a Standard JSON Input file containing all of your contract's source files and metadata, following the fields requested by the Arbiscan form.
+3. Upload the Standard JSON Input file
 
-```shell
-cargo stylus verify --json
-```
+<VanillaAdmonition type="info">
 
-This generates a `project.json` file containing all sources and metadata.
+The `cargo stylus` CLI does not currently emit this Standard JSON Input bundle. For CLI-based reproducible verification, use the local `cargo stylus verify` flow shown above; the Arbiscan Standard JSON Input is prepared through the explorer's verification form.
 
-3. Upload the `project.json` file
+</VanillaAdmonition>
 
 <ImageZoom src="/img/stylus/standard-json-input.webp" alt="Standard JSON input option" />
 


### PR DESCRIPTION
## Description

Part of a section-wide **Stylus documentation update** that brings `docs/stylus/` back in line with the current stack (stylus-sdk **0.10.7** / cargo-stylus **0.10.7** / Nitro **v3.11.0**). The update is split into ~25 small, independently reviewable PRs (all tagged `stylus`).

**This PR:** removes the non-existent `cargo stylus verify --json` command and notes the Arbiscan Standard-JSON flow honestly.

Code examples were verified against the live toolchain — compiled, and deployed on a local Nitro dev node where applicable — and conceptual claims were checked against the Nitro source. The branch builds clean with `yarn build` (strict `onBrokenLinks`).

## Document type

- [x] How-to

## Checklist

- [x] My changes follow the style conventions outlined in CONTRIBUTE.md
- [x] I have used sentence-case for titles and headers
- [x] I have used descriptive link text
- [x] I have checked for broken links
- [x] I have verified that my changes don't break the build (`yarn build`)

## Additional Notes

Version strings appear here as literals; they are centralized into `src/resources/globalVars.js` in a final follow-up PR. Companion PRs share the `stylus` tag.
