### PR TITLE
Update Stylus prerequisites versions

### DIFF
--- a/docs/stylus/fundamentals/prerequisites.mdx
+++ b/docs/stylus/fundamentals/prerequisites.mdx
@@ -60,7 +60,7 @@ Expected output:
 
 ```
 rustc 1.91.0 (or higher)
-cargo-stylus 0.10.0 (or higher)
+cargo-stylus 0.10.7 (or higher)
 Docker version 24.0.0 (or higher)
 cast 1.0.0 (or higher)
 ```


### PR DESCRIPTION
## Description

Part of a section-wide **Stylus documentation update** that brings `docs/stylus/` back in line with the current stack (stylus-sdk **0.10.7** / cargo-stylus **0.10.7** / Nitro **v3.11.0**). The update is split into ~25 small, independently reviewable PRs (all tagged `stylus`).

**This PR:** updates the cargo-stylus and Rust toolchain version references.

Code examples were verified against the live toolchain — compiled, and deployed on a local Nitro dev node where applicable — and conceptual claims were checked against the Nitro source. The branch builds clean with `yarn build` (strict `onBrokenLinks`).

## Document type

- [x] Reference

## Checklist

- [x] My changes follow the style conventions outlined in CONTRIBUTE.md
- [x] I have used sentence-case for titles and headers
- [x] I have used descriptive link text
- [x] I have checked for broken links
- [x] I have verified that my changes don't break the build (`yarn build`)

## Additional Notes

Version strings appear here as literals; they are centralized into `src/resources/globalVars.js` in a final follow-up PR. Companion PRs share the `stylus` tag.
