### PR TITLE
docs(custom-genesis): CLI-flag genesis init note + bump generator ima…

### DIFF
--- a/docs/launch-arbitrum-chain/deploy/custom-genesis-state.mdx
+++ b/docs/launch-arbitrum-chain/deploy/custom-genesis-state.mdx
@@ -121,6 +121,12 @@ This step is only required if you choose to deploy the rollup to the parent chai
      - `--init.empty=false`: **(Required)** Forces the node to load the provided genesis file instead of initializing a blank state.
 5. Start your chain, with the correct preloaded state.
 
+<VanillaAdmonition type="info" title="Loading your custom genesis at start-up">
+
+Your custom genesis is loaded via the `--init.genesis-json-file` and `--init.empty=false` flags when you start the node—it is **not** read from `node-config.json`. If you generate your node configuration with the Chain SDK's `prepare-node-config`, it won't include these, so make sure to pass them on the command line.
+
+</VanillaAdmonition>
+
 ### Use the `genesis-file-generator` tool
 
 #### Environment variables reference (.env)
@@ -153,7 +159,7 @@ These parameters define the identify of your chain
    docker run --rm \
    --env-file .env \
    -v "$(pwd)/genesis":/app/genesis \
-   offchainlabs/genesis-file-generator:v0.0.2-4c37f62
+   offchainlabs/genesis-file-generator:v0.0.3-rc-deffec7
    ```
 
    - You can also generate your own `genesis.json` file, but carefully read [this notice about the chain configuration property](https://github.com/OffchainLabs/genesis-file-generator#exclamation-important-note-about-the-chain-config-property) before proceeding with the next steps.
@@ -165,7 +171,7 @@ These parameters define the identify of your chain
    --env-file .env \
    -v "$(pwd)/genesis":/app/genesis \
    -v "$(pwd)/custom-alloc.json":/app/custom-alloc.json:ro \
-   offchainlabs/genesis-file-generator:v0.0.2-4c37f62
+   offchainlabs/genesis-file-generator:v0.0.3-rc-deffec7
    ```
 
    Example `custom-alloc.json` (preallocates 1 ETH—review the solvency warning above before setting non-zero balances):


### PR DESCRIPTION
…ge to v0.0.3-rc-deffec7

- Note that custom genesis loads via --init.genesis-json-file / --init.empty=false at start-up, not from node-config.json (NIT-5134 / Gap 3)

- Bump genesis-file-generator image v0.0.2-4c37f62 -> v0.0.3-rc-deffec7 in both docker commands (NIT-5124)

Thank you for contributing to our docs!

Please fill out the form below to ensure your doc gets quickly approved and merged.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Document type

- [ ] Gentle introduction
- [ ] Quickstart
- [ ] How-to
- [ ] Concept
- [ ] FAQ
- [ ] Troubleshooting
- [ ] Reference
- [ ] Third-party content
- [ ] Codebase changes
- [ ] Not applicable

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] I have read the [CONTRIBUTE.md](../CONTRIBUTE.md) guidelines
- [ ] My changes follow the style conventions outlined in CONTRIBUTE.md
- [ ] I have used sentence-case for titles and headers
- [ ] I have used descriptive link text (not "here" or "this")
- [ ] I have separated procedural from conceptual content where appropriate
- [ ] I have tested my changes locally with `yarn start` or `yarn build`
- [ ] My code follows the existing code style and conventions
- [ ] I have added/updated frontmatter for new documents
- [ ] I have checked for broken links
- [ ] I have verified that my changes don't break the build
- Third-party docs only: Do you agree to the third-party content policy outlined within [CONTRIBUTE.md](../CONTRIBUTE.md)?
  - [ ] Yes
  - [ ] Not applicable

## Additional Notes

<!-- Add any additional notes or context for reviewers -->
