### PR TITLE
docs: tw-1035

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -1005,6 +1005,11 @@ const sidebars = {
             },
             {
               type: 'doc',
+              label: 'Token bridging',
+              id: 'how-arbitrum-works/deep-dives/token-bridging',
+            },
+            {
+              type: 'doc',
               label: 'Gas and fees',
               id: 'how-arbitrum-works/deep-dives/gas-and-fees',
             },


### PR DESCRIPTION
- Somewhere Token Bridging was dropped from sidebar; adding it back under HAW