### PR TITLE
docs(stylus-by-example): use #[public] instead of deprecated #[external]

### DIFF
--- a/docs/stylus-by-example/applications/multi_call.mdx
+++ b/docs/stylus-by-example/applications/multi_call.mdx
@@ -63,7 +63,7 @@ pub enum MultiCallErrors {
     CallFailed(CallFailed),
 }
 
-#[external]
+#[public]
 impl MultiCall {
     pub fn multicall(
         &self,

--- a/docs/stylus-by-example/basic_examples/function.mdx
+++ b/docs/stylus-by-example/basic_examples/function.mdx
@@ -115,9 +115,9 @@ Previously, all public methods were required to return a `Result` type with `Vec
 In the following example, `owner` is a public function that returns the contract owner's address. Since this function is infallible (i.e., it cannot produce an error), it does not need to return a `Result` type.
 
 ```rust
-#[external]
+#[public]
 impl Contract {
-    // Define an external function to get the owner of the contract
+    // Define a public function to get the owner of the contract
     pub fn owner(&self) -> Address {
         self.owner.get()
     }


### PR DESCRIPTION
## Description

The "Public Functions" section of the functions guide instructs readers to use the `#[public]` macro, but the code sample immediately below it used `#[external]`:

```rust
#[external]
impl Contract {
    // Define an external function to get the owner of the contract
    pub fn owner(&self) -> Address {
        self.owner.get()
    }
}
```

`#[external]` was renamed to `#[public]` in `stylus-sdk` and no longer compiles against current versions, so this snippet contradicts both the surrounding prose and the full `src/lib.rs` example further down the same page (which already uses `#[public]`).

`docs/stylus-by-example/applications/multi_call.mdx` had the same stale macro on its `impl MultiCall` block.

This PR changes both occurrences to `#[public]` (and updates the inline comment to say "public function"). No other changes.

Fixes #1748

## Document type

- [x] Reference

## Checklist

- [x] I have read the CONTRIBUTE.md guidelines
- [x] My changes follow the style conventions outlined in CONTRIBUTE.md
- [x] My code follows the existing code style and conventions
- [x] I have verified that my changes don't break the build (content-only change inside ```rust fences)

## Additional Notes

Scope is intentionally limited to the deprecated macro named in #1748. `multi_call.mdx` still carries other dated APIs (`#[solidity_storage]`, `stylus-sdk = "0.5.0"`) that are out of scope here.
