### PR TITLE
Widen development browserslist to restore the webpack cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,9 +131,9 @@
       "not op_mini all"
     ],
     "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
+      "last 3 chrome version",
+      "last 3 firefox version",
+      "last 5 safari version"
     ]
   },
   "engines": {


### PR DESCRIPTION
## Description

Widens the `development` browserslist.

The previous targets resolve to browsers that need no prefixes, so autoprefixer warned on every CSS module. Webpack has no serializer for those warnings, so it skipped caching every CSS module and `yarn start` recompiled everything on every run.

## Document type

- [x] Codebase changes

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have tested my changes locally with `yarn start` or `yarn build`
- [x] I have verified that my changes don't break the build

## Additional Notes

Cold `yarn start`: cache-serializer warnings hundreds → 0, client compiles in 15.45s. `yarn build` was never affected — the `production` targets do need prefixes.
